### PR TITLE
fix(playwright): drop obsolete useGoogleSheetAsDefault toggle in (c)

### DIFF
--- a/eform-client/playwright/e2e/plugins/time-planning-pn/c/dashboard-edit-a.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/c/dashboard-edit-a.spec.ts
@@ -276,10 +276,9 @@ test.describe('Dashboard edit values', () => {
 
     await page.locator('#firstColumn0').click();
 
-    const useGoogleSheetClass = await page.locator('#useGoogleSheetAsDefault > div > div > input').getAttribute('class');
-    if (useGoogleSheetClass !== 'mdc-checkbox__native-control mdc-checkbox--selected') {
-      await page.locator('#useGoogleSheetAsDefault').click();
-    }
+    // useGoogleSheetAsDefault is seeded true by default (commit e86d3a1b) and
+    // its toggle is now first-user-only (commit c7732b40), so the prior
+    // ensure-on block was unreachable for the admin CI user and timed out.
 
     const autoBreakClass = await page.locator('#autoBreakCalculationActive > div > div > input').getAttribute('class');
     if (autoBreakClass !== 'mdc-checkbox__native-control mdc-checkbox--selected') {


### PR DESCRIPTION
## Summary
- Remove the ensure-on block for `#useGoogleSheetAsDefault` in `c/dashboard-edit-a.spec.ts` — it hung the suite for 120s because the checkbox is now (a) seeded true by default (e86d3a1b) and (b) gated behind `selectCurrentUserIsFirstUser$` (c7732b40), so it never renders for the admin CI user.
- The subsequent `autoBreakCalculationActive` block is preserved — that's the assertion the test actually cares about.

## Test plan
- [ ] `pn-playwright-test (c)` goes green on this PR
- [ ] `(a)`, `(b)`, and the other groups remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)