### PR TITLE
feat: grant "eForm users" full planning view when no manager exists

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -89,6 +89,29 @@ public class TimePlanningPlanningService(
                 var eFormAdminsGroup = userSecurityGroups
                     .Any(x => x.SecurityGroup.Name == "eForm admins");
                 isAdmin = eFormAdminsGroup;
+                if (!isAdmin)
+                {
+                    var isEformUsersGroup = userSecurityGroups
+                        .Any(x => x.SecurityGroup.Name == "eForm users");
+                    var isKunTidGroup = userSecurityGroups
+                        .Any(x => x.SecurityGroup.Name == "Kun tid");
+                    if (isEformUsersGroup && !isKunTidGroup)
+                    {
+                        // Fallback: when no user in the system is configured as a manager,
+                        // grant "eForm users" members the admin-for-visibility view on this
+                        // endpoint so the planning dashboard isn't empty in that degenerate
+                        // state. Users also in "Kun tid" (time-registration device users with
+                        // WebAccess) are explicitly excluded and stay restricted to own site.
+                        var anyManagerExists = await dbContext.AssignedSites
+                            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                            .AnyAsync(x => x.IsManager)
+                            .ConfigureAwait(false);
+                        if (!anyManagerExists)
+                        {
+                            isAdmin = true;
+                        }
+                    }
+                }
             }
 
             if (!isAdmin)


### PR DESCRIPTION
## Summary

- Adds a narrow fallback to `TimePlanningPlanningService.Index`: when no `AssignedSite` has `IsManager=true` system-wide, users in the **"eForm users"** security group are promoted to the admin-for-visibility path so the planning dashboard isn't empty in that degenerate state.
- Composite "Kun tid + WebAccess" users (auto-added to both groups by `BackendConfigurationAssignmentWorkerServiceHelper`) are explicitly excluded and stay restricted to their own site — honoring the rule that "kun tid" users must only see their own time.
- The 2026-04-10 filter (`isAdmin = eFormAdminsGroup`) is preserved; the fallback only fires when that gate fails.
- Scope is strictly `TimePlanningPlanningService.Index`. `TimeSettingService.GetAvailableSites` and `AbsenceRequestService.GetInboxAsync` are untouched.

## Test plan

- [ ] In a tenant with zero `AssignedSite.IsManager=true` rows, log in as a non-admin user in "eForm users" → **Time Planning > Plannings** shows all workers.
- [ ] Flip one `AssignedSite.IsManager=true` (via property-worker UI) → same user now sees only their own site.
- [ ] Log in as a "Kun tid" user (property worker with `timeRegistrationEnabled=true`) in the same zero-manager tenant → still restricted to own site.
- [ ] Log in as a composite "Kun tid + WebAccess" user in the zero-manager tenant → still restricted to own site.
- [ ] Existing admin ("eForm admins" / `admin` role) flow unchanged — sees all workers regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)