### PR TITLE
fix: request-history page stalling

### DIFF
--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p]
+        test: [a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/q/activate-plugin.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/q/activate-plugin.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { PluginPage } from '../../../Page objects/Plugin.page';
+
+test.describe('Enable Backend Config plugin', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await new PluginPage(page).Navbar.goToPluginsPage();
+  });
+
+  test('should enabled Time registration plugin', async ({ page }) => {
+    test.setTimeout(180000);
+    const pluginName = 'Microting Time Planning Plugin';
+
+    // Open action menu for the plugin
+    await page.locator('.mat-mdc-row').filter({ hasText: pluginName }).first()
+      .locator('#actionMenu').click();
+    await page.waitForTimeout(500);
+
+    // Click the status button inside the menu to enable the plugin
+    await page.locator('#plugin-status-button0').scrollIntoViewIfNeeded();
+    await expect(page.locator('#plugin-status-button0')).toBeVisible();
+    await page.locator('#plugin-status-button0').click();
+    await page.waitForTimeout(500);
+
+    // Confirm activation in the modal if present
+    if (await page.locator('#pluginOKBtn').count() > 0) {
+      await page.locator('#pluginOKBtn').click();
+      await page.waitForTimeout(100000); // Wait for plugin activation
+    }
+
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await new PluginPage(page).Navbar.goToPluginsPage();
+
+    // Verify the plugin is enabled by checking the status
+    // Re-open the action menu to check the status
+    await page.locator('.mat-mdc-row').filter({ hasText: pluginName }).first()
+      .locator('#actionMenu').click();
+    await page.waitForTimeout(500);
+
+    await expect(
+      page.locator('#plugin-status-button0').locator('mat-icon')
+    ).toContainText('toggle_on'); // plugin is enabled
+  });
+});

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/q/assert-true.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/q/assert-true.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+// create canary in a coal mine test asserting true
+test('asserts true', () => {
+  expect(true).toBe(true); // this will pass
+});

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/q/time-planning-request-history.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/q/time-planning-request-history.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+
+test.describe('Time Planning - Request History', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    // Navigate directly to the request history page
+    await page.goto('http://localhost:4200/plugins/time-planning-pn/request-history');
+    // Wait for any spinner to disappear
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+  });
+
+  test('should load the request history page without stalling', async ({ page }) => {
+    // Verify the filter bar is visible
+    await page.locator('#time-planning-pn-request-history-filters').scrollIntoViewIfNeeded();
+    await expect(page.locator('#time-planning-pn-request-history-filters')).toBeVisible();
+
+    // Verify the grid is visible
+    await page.locator('#time-planning-pn-request-history-grid').scrollIntoViewIfNeeded();
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+  });
+
+  test('should display all filter controls', async ({ page }) => {
+    // Type filter dropdown
+    await expect(page.locator('#requestHistoryTypeFilter')).toBeVisible();
+
+    // Status filter dropdown
+    await expect(page.locator('#requestHistoryStatusFilter')).toBeVisible();
+
+    // Date from input
+    await expect(page.locator('#requestHistoryFromDate')).toBeVisible();
+
+    // Date to input
+    await expect(page.locator('#requestHistoryToDate')).toBeVisible();
+
+    // Apply button
+    await expect(page.locator('#applyFiltersBtn')).toBeVisible();
+  });
+
+  test('should filter by type when selecting Handover', async ({ page }) => {
+    // Select "Handover" in the type filter
+    await page.locator('#requestHistoryTypeFilter').selectOption('Handover');
+    await page.locator('#applyFiltersBtn').click();
+
+    // Wait for loading to complete
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+
+    // Verify the grid is still visible after filtering
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+
+    // If there are rows, all should be of type Handover
+    const typeHandoverBadges = page.locator('.type-handover');
+    const typeAbsenceBadges = page.locator('.type-absence');
+    if (await typeHandoverBadges.count() > 0) {
+      // There should be no Absence rows when filtering by Handover
+      expect(await typeAbsenceBadges.count()).toBe(0);
+    }
+  });
+
+  test('should filter by type when selecting Absence', async ({ page }) => {
+    // Select "Absence" in the type filter
+    await page.locator('#requestHistoryTypeFilter').selectOption('Absence');
+    await page.locator('#applyFiltersBtn').click();
+
+    // Wait for loading to complete
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+
+    // Verify the grid is still visible after filtering
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+
+    // If there are rows, all should be of type Absence
+    const typeAbsenceBadges = page.locator('.type-absence');
+    const typeHandoverBadges = page.locator('.type-handover');
+    if (await typeAbsenceBadges.count() > 0) {
+      // There should be no Handover rows when filtering by Absence
+      expect(await typeHandoverBadges.count()).toBe(0);
+    }
+  });
+
+  test('should filter by status when selecting Pending', async ({ page }) => {
+    // Select "Pending" in the status filter
+    await page.locator('#requestHistoryStatusFilter').selectOption('Pending');
+    await page.locator('#applyFiltersBtn').click();
+
+    // Wait for loading to complete
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+
+    // Verify the grid is still visible after filtering
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+
+    // If there are rows, verify only Pending status rows are shown
+    const pendingBadges = page.locator('.status-pending');
+    const approvedBadges = page.locator('.status-approved');
+    const rejectedBadges = page.locator('.status-rejected');
+    if (await pendingBadges.count() > 0) {
+      expect(await approvedBadges.count()).toBe(0);
+      expect(await rejectedBadges.count()).toBe(0);
+    }
+  });
+
+  test('should handle empty state gracefully', async ({ page }) => {
+    // The grid should be visible even with no data
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+
+    // If no rows, the noResultText should be present or the grid should simply be empty
+    // (mtx-grid shows noResultText when data is empty)
+  });
+
+  test('should reset filters when selecting All for type', async ({ page }) => {
+    // First set a filter
+    await page.locator('#requestHistoryTypeFilter').selectOption('Handover');
+    await page.locator('#applyFiltersBtn').click();
+
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+
+    // Then reset to All
+    await page.locator('#requestHistoryTypeFilter').selectOption('');
+    await page.locator('#applyFiltersBtn').click();
+
+    if (await page.locator('.overlay-spinner').count() > 0) {
+      await page.locator('.overlay-spinner').waitFor({ state: 'hidden', timeout: 30000 });
+    }
+
+    // Grid should still be visible
+    await expect(page.locator('#time-planning-pn-request-history-grid')).toBeVisible();
+  });
+});

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
@@ -41,15 +41,12 @@
 </div>
 
 <mtx-grid
-  [data]="pagedRows"
+  [data]="filteredRows"
   [cellTemplate]="{ type: typeTpl, status: statusTpl }"
   [showPaginator]="true"
   [pageOnFront]="true"
-  [length]="totalItems"
-  [pageIndex]="pageIndex"
-  [pageSize]="pageSize"
+  [pageSize]="25"
   [pageSizeOptions]="[10, 25, 50, 100]"
-  (page)="onPageChange($event)"
   [rowStriped]="false"
   [showToolbar]="false"
   [showColumnMenuButton]="false"

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
@@ -4,10 +4,10 @@
   </div>
 </eform-new-subheader>
 
-<div class="filter-bar">
+<div class="filter-bar" id="time-planning-pn-request-history-filters">
   <mat-form-field>
     <mat-label>{{ 'Type' | translate }}</mat-label>
-    <select matNativeControl [(ngModel)]="filterType">
+    <select matNativeControl [(ngModel)]="filterType" id="requestHistoryTypeFilter">
       <option value="">{{ 'All' | translate }}</option>
       <option value="Handover">{{ 'Handover' | translate }}</option>
       <option value="Absence">{{ 'Absence' | translate }}</option>
@@ -16,7 +16,7 @@
 
   <mat-form-field>
     <mat-label>{{ 'Status' | translate }}</mat-label>
-    <select matNativeControl [(ngModel)]="filterStatus">
+    <select matNativeControl [(ngModel)]="filterStatus" id="requestHistoryStatusFilter">
       <option value="">{{ 'All' | translate }}</option>
       <option value="Pending">{{ 'Pending' | translate }}</option>
       <option value="Approved">{{ 'Approved' | translate }}</option>
@@ -27,12 +27,12 @@
 
   <mat-form-field>
     <mat-label>{{ 'Date From' | translate }}</mat-label>
-    <input matInput type="date" [(ngModel)]="filterFromDate" />
+    <input matInput type="date" [(ngModel)]="filterFromDate" id="requestHistoryFromDate" />
   </mat-form-field>
 
   <mat-form-field>
     <mat-label>{{ 'Date To' | translate }}</mat-label>
-    <input matInput type="date" [(ngModel)]="filterToDate" />
+    <input matInput type="date" [(ngModel)]="filterToDate" id="requestHistoryToDate" />
   </mat-form-field>
 
   <button mat-raised-button color="primary" (click)="applyFilters()" id="applyFiltersBtn">

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { TimePlanningPnRequestHistoryService, RequestHistoryQueryParams } from '../../../../services';
-import { Subscription, forkJoin } from 'rxjs';
+import { Subscription, forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 import { MtxGridColumn } from '@ng-matero/extensions/grid';
 import { AutoUnsubscribe } from 'ngx-auto-unsubscribe';
@@ -41,22 +42,12 @@ export class RequestHistoryPageComponent implements OnInit, OnDestroy {
   filterFromDate = '';
   filterToDate = '';
 
-  // Pagination
-  pageIndex = 0;
-  pageSize = 25;
-  totalItems = 0;
-
   loadSub$: Subscription;
 
   private _tableHeaders: MtxGridColumn[];
 
   get tableHeaders(): MtxGridColumn[] {
     return this._tableHeaders;
-  }
-
-  get pagedRows(): RequestHistoryRow[] {
-    const start = this.pageIndex * this.pageSize;
-    return this.filteredRows.slice(start, start + this.pageSize);
   }
 
   ngOnInit(): void {
@@ -76,7 +67,6 @@ export class RequestHistoryPageComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {}
 
   applyFilters(): void {
-    this.pageIndex = 0;
     this.loadData();
   }
 
@@ -95,8 +85,22 @@ export class RequestHistoryPageComponent implements OnInit, OnDestroy {
     }
 
     this.loadSub$ = forkJoin({
-      handovers: this.requestHistoryService.getAllHandoverRequests(params),
-      absences: this.requestHistoryService.getAllAbsenceRequests(params),
+      handovers: this.requestHistoryService.getAllHandoverRequests(params).pipe(
+        catchError(() => {
+          this.toastrService.error(
+            this.translateService.instant('Error loading handover requests')
+          );
+          return of({ success: false, model: [] });
+        })
+      ),
+      absences: this.requestHistoryService.getAllAbsenceRequests(params).pipe(
+        catchError(() => {
+          this.toastrService.error(
+            this.translateService.instant('Error loading absence requests')
+          );
+          return of({ success: false, model: [] });
+        })
+      ),
     }).subscribe({
       next: ({ handovers, absences }) => {
         const merged: RequestHistoryRow[] = [];
@@ -164,11 +168,5 @@ export class RequestHistoryPageComponent implements OnInit, OnDestroy {
     }
 
     this.filteredRows = result;
-    this.totalItems = result.length;
-  }
-
-  onPageChange(event: any): void {
-    this.pageIndex = event.pageIndex;
-    this.pageSize = event.pageSize;
   }
 }


### PR DESCRIPTION
## Summary

- Fixed request-history page stalling caused by `pagedRows` getter creating a new array reference on every change detection cycle, triggering an infinite re-render loop in mtx-grid
- Removed manual pagination conflict — the component was slicing data AND telling mtx-grid to paginate, causing double-pagination. Now mtx-grid handles pagination internally with `pageOnFront=true` on the stable `filteredRows` array
- Added `catchError` on individual `forkJoin` observables so one failing HTTP request (handovers or absences) does not block the other from loading

## Test plan

- [ ] Navigate to /plugins/time-planning-pn/request-history — page loads without stalling
- [ ] Filters work (type, status, date range)
- [ ] Table shows data correctly
- [ ] Pagination works (change page size, navigate pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)