### PR TITLE
feat: include shift times in handover responses

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/ContentHandover/ContentHandoverRequestModel.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/ContentHandover/ContentHandoverRequestModel.cs
@@ -41,6 +41,8 @@ public class ContentHandoverRequestModel
     public string? RequestComment { get; set; }
     public string? DecisionComment { get; set; }
     public int? ShiftIndex { get; set; }
+    public int? ShiftStartTime { get; set; }
+    public int? ShiftEndTime { get; set; }
     public string? FromWorkerName { get; set; }
     public string? ToWorkerName { get; set; }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/content_handover.proto
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/content_handover.proto
@@ -45,6 +45,8 @@ message ContentHandoverRequestModel {
   string request_comment = 10;
   string decision_comment = 11;
   int32 shift_index = 12;
+  int32 shift_start_time = 13;
+  int32 shift_end_time = 14;
 }
 
 message ContentHandoverResponse {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
@@ -286,7 +286,7 @@ public class ContentHandoverService : IContentHandoverService
                 FireCreatePush(model.ToSdkSitId, new List<int> { request.Id }, 1, fromPR.Date);
 
                 return new OperationDataResult<List<ContentHandoverRequestModel>>(
-                    true, new List<ContentHandoverRequestModel> { MapToModel(request) });
+                    true, new List<ContentHandoverRequestModel> { MapToModel(request, fromPR) });
             }
 
             // Partial (per-shift) create. Transactional all-or-nothing.
@@ -369,7 +369,7 @@ public class ContentHandoverService : IContentHandoverService
             FireCreatePush(model.ToSdkSitId, created.Select(r => r.Id).ToList(), created.Count, fromPR.Date);
 
             return new OperationDataResult<List<ContentHandoverRequestModel>>(
-                true, created.Select(MapToModel).ToList());
+                true, created.Select(r => MapToModel(r, fromPR)).ToList());
         }
         catch (Exception ex)
         {
@@ -423,6 +423,19 @@ public class ContentHandoverService : IContentHandoverService
             3 => pr.PlannedEndOfShift3,
             4 => pr.PlannedEndOfShift4,
             5 => pr.PlannedEndOfShift5,
+            _ => 0
+        };
+    }
+
+    private static int GetPlannedStartOfShift(PlanRegistration pr, int n)
+    {
+        return n switch
+        {
+            1 => pr.PlannedStartOfShift1,
+            2 => pr.PlannedStartOfShift2,
+            3 => pr.PlannedStartOfShift3,
+            4 => pr.PlannedStartOfShift4,
+            5 => pr.PlannedStartOfShift5,
             _ => 0
         };
     }
@@ -765,7 +778,16 @@ public class ContentHandoverService : IContentHandoverService
                 .OrderByDescending(r => r.RequestedAtUtc)
                 .ToListAsync();
 
-            var models = requests.Select(MapToModel).ToList();
+            var prIds = requests.Select(r => r.FromPlanRegistrationId).Distinct().ToList();
+            var planRegistrations = await _dbContext.PlanRegistrations
+                .Where(p => prIds.Contains(p.Id))
+                .ToDictionaryAsync(p => p.Id);
+
+            var models = requests.Select(r =>
+            {
+                planRegistrations.TryGetValue(r.FromPlanRegistrationId, out var fromPR);
+                return MapToModel(r, fromPR);
+            }).ToList();
             return new OperationDataResult<List<ContentHandoverRequestModel>>(true, models);
         }
         catch (Exception ex)
@@ -811,7 +833,16 @@ public class ContentHandoverService : IContentHandoverService
                 .OrderByDescending(r => r.RequestedAtUtc)
                 .ToListAsync();
 
-            var models = requests.Select(MapToModel).ToList();
+            var prIds = requests.Select(r => r.FromPlanRegistrationId).Distinct().ToList();
+            var planRegistrations = await _dbContext.PlanRegistrations
+                .Where(p => prIds.Contains(p.Id))
+                .ToDictionaryAsync(p => p.Id);
+
+            var models = requests.Select(r =>
+            {
+                planRegistrations.TryGetValue(r.FromPlanRegistrationId, out var fromPR);
+                return MapToModel(r, fromPR);
+            }).ToList();
             return new OperationDataResult<List<ContentHandoverRequestModel>>(true, models);
         }
         catch (Exception ex)
@@ -881,9 +912,15 @@ public class ContentHandoverService : IContentHandoverService
                     .ToDictionaryAsync(s => s.MicrotingUid, s => s.Name ?? string.Empty);
             }
 
+            var prIds = requests.Select(r => r.FromPlanRegistrationId).Distinct().ToList();
+            var planRegistrations = await _dbContext.PlanRegistrations
+                .Where(p => prIds.Contains(p.Id))
+                .ToDictionaryAsync(p => p.Id);
+
             var models = requests.Select(r =>
             {
-                var model = MapToModel(r);
+                planRegistrations.TryGetValue(r.FromPlanRegistrationId, out var fromPR);
+                var model = MapToModel(r, fromPR);
                 model.FromWorkerName = siteNameLookup.GetValueOrDefault(r.FromSdkSitId);
                 model.ToWorkerName = siteNameLookup.GetValueOrDefault(r.ToSdkSitId);
                 return model;
@@ -1064,8 +1101,19 @@ public class ContentHandoverService : IContentHandoverService
         // will be recomputed by PlanRegistrationHelper on BOTH rows in the caller.
     }
 
-    private ContentHandoverRequestModel MapToModel(PlanRegistrationContentHandoverRequest request)
+    private ContentHandoverRequestModel MapToModel(
+        PlanRegistrationContentHandoverRequest request,
+        PlanRegistration? fromPlanRegistration = null)
     {
+        int? shiftStartTime = null;
+        int? shiftEndTime = null;
+
+        if (fromPlanRegistration != null && request.ShiftIndex is > 0)
+        {
+            shiftStartTime = GetPlannedStartOfShift(fromPlanRegistration, request.ShiftIndex.Value);
+            shiftEndTime = GetPlannedEndOfShift(fromPlanRegistration, request.ShiftIndex.Value);
+        }
+
         return new ContentHandoverRequestModel
         {
             Id = request.Id,
@@ -1079,7 +1127,9 @@ public class ContentHandoverService : IContentHandoverService
             RespondedAtUtc = request.RespondedAtUtc,
             RequestComment = null, // Entity doesn't have RequestComment
             DecisionComment = request.DecisionComment,
-            ShiftIndex = request.ShiftIndex
+            ShiftIndex = request.ShiftIndex,
+            ShiftStartTime = shiftStartTime,
+            ShiftEndTime = shiftEndTime
         };
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningContentHandoverGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningContentHandoverGrpcService.cs
@@ -284,7 +284,9 @@ public class TimePlanningContentHandoverGrpcService
             RespondedAtUtc = m.RespondedAtUtc?.ToString("yyyy-MM-ddTHH:mm:ss") ?? "",
             RequestComment = m.RequestComment ?? "",
             DecisionComment = m.DecisionComment ?? "",
-            ShiftIndex = m.ShiftIndex ?? 0
+            ShiftIndex = m.ShiftIndex ?? 0,
+            ShiftStartTime = m.ShiftStartTime ?? 0,
+            ShiftEndTime = m.ShiftEndTime ?? 0
         };
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ShiftStartTime` and `ShiftEndTime` (minutes from midnight) to handover request responses
- Server now looks up the source PlanRegistration and extracts planned shift times based on ShiftIndex
- Flutter app will display these as "Shift 1 (08:00 – 16:00)" in sent/inbox cards

## Files changed
- Proto: `content_handover.proto` — new fields 13, 14
- DTO: `ContentHandoverRequestModel.cs` — new nullable int properties
- Service: `ContentHandoverService.cs` — `MapToModel` now accepts PlanRegistration, added `GetPlannedStartOfShift` helper
- gRPC: `TimePlanningContentHandoverGrpcService.cs` — maps new fields

## Test plan
- [ ] Create a handover request for a specific shift — response should include start/end times
- [ ] Create a full-day handover — shift times should be null/0
- [ ] Verify inbox and sent lists include the times
- [ ] Flutter app displays time range in subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)