### PR TITLE
fix: handle personal mode in gRPC UpdateWorkingHours

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningWorkingHoursGrpcServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningWorkingHoursGrpcServiceTests.cs
@@ -196,4 +196,243 @@ public class TimePlanningWorkingHoursGrpcServiceTests
         Assert.That(response.Model.Stop1StoppedAt, Is.EqualTo(""));
         Assert.That(response.Model.Pause10StartedAt, Is.EqualTo(""));
     }
+
+    [Test]
+    public async Task UpdateWorkingHours_PersonalMode_PassesNullSdkSiteIdAndNullToken()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 0,
+            Token = "",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+                Comment = "Personal update",
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            null,
+            Arg.Any<TimePlanningWorkingHoursUpdateModel>(),
+            null);
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_KioskMode_PassesSdkSiteIdAndToken()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 42,
+            Token = "device-abc-123",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+                Comment = "Kiosk update",
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            42,
+            Arg.Any<TimePlanningWorkingHoursUpdateModel>(),
+            "device-abc-123");
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_PersonalMode_MapsModelFieldsCorrectly()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 0,
+            Token = "",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+                Start1StartedAt = "2026-04-26T08:00:00",
+                Stop1StoppedAt = "2026-04-26T16:00:00",
+                Comment = "Morning shift",
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            null,
+            Arg.Is<TimePlanningWorkingHoursUpdateModel>(m =>
+                m.Date == DateTime.Parse("2026-04-26") &&
+                m.Shift1Start == 101 &&
+                m.Start1StartedAt == "2026-04-26T08:00:00" &&
+                m.Stop1StoppedAt == "2026-04-26T16:00:00" &&
+                m.CommentWorker == "Morning shift"),
+            null);
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_KioskMode_MapsDeviceMetadataToModel()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 42,
+            Token = "device-abc-123",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+                Comment = "Kiosk shift",
+            },
+            Device = new Grpc.DeviceMetadata
+            {
+                SoftwareVersion = "4.0.7",
+                DeviceModel = "Pixel 8",
+                Manufacturer = "Google",
+                OsVersion = "Android 15",
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            Arg.Any<int?>(),
+            Arg.Is<TimePlanningWorkingHoursUpdateModel>(m =>
+                m.SoftwareVersion == "4.0.7" &&
+                m.Model == "Pixel 8" &&
+                m.Manufacturer == "Google" &&
+                m.OsVersion == "Android 15"),
+            Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_PersonalMode_ServiceFailure_ReturnsErrorMessage()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(false, "User not found"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 0,
+            Token = "",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+                Comment = "Failing request",
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.False);
+        Assert.That(response.Message, Is.EqualTo("User not found"));
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_KioskMode_InvalidToken_ReturnsTokenNotFound()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(false, "Token not found"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 42,
+            Token = "invalid-token",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.False);
+        Assert.That(response.Message, Is.EqualTo("Token not found"));
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_EmptyTokenWithNonZeroSdkSiteId_SdkSiteIdPassesThrough()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 7,
+            Token = "",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            7,
+            Arg.Any<TimePlanningWorkingHoursUpdateModel>(),
+            null);
+    }
+
+    [Test]
+    public async Task UpdateWorkingHours_NonEmptyTokenWithZeroSdkSiteId_TokenPassesThrough()
+    {
+        _whService.UpdateWorkingHour(Arg.Any<int?>(), Arg.Any<TimePlanningWorkingHoursUpdateModel>(), Arg.Any<string>())
+            .Returns(new OperationResult(true, "Updated"));
+
+        var request = new UpdateWorkingHoursRequest
+        {
+            SdkSiteId = 0,
+            Token = "abc",
+            Date = "2026-04-26",
+            Model = new Grpc.WorkingHoursModel
+            {
+                Start1Id = 101,
+            }
+        };
+
+        var response = await _grpcService.UpdateWorkingHours(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+
+        await _whService.Received(1).UpdateWorkingHour(
+            null,
+            Arg.Any<TimePlanningWorkingHoursUpdateModel>(),
+            "abc");
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningWorkingHoursGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningWorkingHoursGrpcService.cs
@@ -45,10 +45,12 @@ public class TimePlanningWorkingHoursGrpcService
         var model = MapFromGrpc(request.Model, request.Device);
         model.Date = DateTime.Parse(request.Date, System.Globalization.CultureInfo.InvariantCulture);
 
+        var token = string.IsNullOrEmpty(request.Token) ? null : request.Token;
+        int? sdkSiteId = request.SdkSiteId == 0 ? null : request.SdkSiteId;
         var result = await _workingHoursService.UpdateWorkingHour(
-            request.SdkSiteId,
+            sdkSiteId,
             model,
-            request.Token);
+            token);
 
         return new UpdateWorkingHoursResponse
         {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -1428,9 +1428,10 @@ public class TimePlanningWorkingHoursService(
             return await UpdateWorkingHour(model).ConfigureAwait(false);
         }
 
+        RegistrationDevice? registrationDevice = null;
         if (token != null)
         {
-            var registrationDevice = await dbContext.RegistrationDevices
+            registrationDevice = await dbContext.RegistrationDevices
                 .Where(x => x.Token == token).FirstOrDefaultAsync();
             if (registrationDevice == null)
             {
@@ -1709,7 +1710,7 @@ public class TimePlanningWorkingHoursService(
                 Flex = 0,
                 WorkerComment = model.CommentWorker,
                 SdkSitId = sdkSiteId!.Value,
-                RegistrationDeviceId = registrationDevice.Id,
+                RegistrationDeviceId = registrationDevice?.Id,
                 Shift1PauseNumber = model.Shift1PauseNumber,
                 Shift2PauseNumber = model.Shift2PauseNumber,
             };
@@ -1796,7 +1797,7 @@ public class TimePlanningWorkingHoursService(
             planRegistration.Stop5Id = model.Shift5Stop ?? 0;
             planRegistration.Pause5Id = model.Shift5Pause ?? 0;
             planRegistration.WorkerComment = model.CommentWorker;
-            planRegistration.RegistrationDeviceId = registrationDevice.Id;
+            planRegistration.RegistrationDeviceId = registrationDevice?.Id;
 
             planRegistration.Start1StartedAt = string.IsNullOrEmpty(model.Start1StartedAt)
                 ? null

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -1426,22 +1426,24 @@ public class TimePlanningWorkingHoursService(
         if (token == null && sdkSiteId == null)
         {
             return await UpdateWorkingHour(model).ConfigureAwait(false);
-            //return new OperationResult(false, "Token not found");
         }
 
-        var registrationDevice = await dbContext.RegistrationDevices
-            .Where(x => x.Token == token).FirstOrDefaultAsync();
-        if (registrationDevice == null)
+        if (token != null)
         {
-            return new OperationDataResult<TimePlanningWorkingHoursModel>(false, "Token not found");
+            var registrationDevice = await dbContext.RegistrationDevices
+                .Where(x => x.Token == token).FirstOrDefaultAsync();
+            if (registrationDevice == null)
+            {
+                return new OperationDataResult<TimePlanningWorkingHoursModel>(false, "Token not found");
+            }
+
+            registrationDevice.OsVersion = model.OsVersion;
+            registrationDevice.Model = model.Model;
+            registrationDevice.Manufacturer = model.Manufacturer;
+            registrationDevice.SoftwareVersion = model.SoftwareVersion;
+
+            await registrationDevice.Update(dbContext);
         }
-
-        registrationDevice.OsVersion = model.OsVersion;
-        registrationDevice.Model = model.Model;
-        registrationDevice.Manufacturer = model.Manufacturer;
-        registrationDevice.SoftwareVersion = model.SoftwareVersion;
-
-        await registrationDevice.Update(dbContext);
 
         var todayAtMidnight = model.Date;
 


### PR DESCRIPTION
## Summary
- Convert `sdkSiteId=0` to `null` in the gRPC handler so the service falls through to the JWT-authenticated `UpdateWorkingHour(model)` overload, matching the REST controller behavior for personal mode.
- Guard the `RegistrationDevice` lookup/update behind a `token != null` check so personal-mode calls (no device token) skip device registration without erroring.

## Test plan
- [ ] CI passes (dotnet build + existing tests)
- [ ] Manual: punch clock in personal mode via gRPC — verify working hours are saved without "Token not found" error
- [ ] Manual: punch clock in device mode (with sdkSiteId + token) — verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)