### PR TITLE
fix: restore manager-tag filter in GetAvailableSitesByCurrentUser

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -356,6 +356,90 @@ public class TimeSettingService(
                 .Where(x => x.Resigned != true)
                 .ToListAsync();
 
+            // Filter sites by current user when called from browser (not device token).
+            // Skip entirely when baseDbContext is null (unit-test wiring).
+            if (baseDbContext != null)
+            {
+                var currentUserAsync = await userService.GetCurrentUserAsync();
+                var currentUser = baseDbContext.Users
+                    .Include(x => x.UserRoles)
+                    .ThenInclude(x => x.Role)
+                    .Single(x => x.Id == currentUserAsync.Id);
+
+                var isAdmin = currentUser.UserRoles.Any(x => x.Role.Name == "admin");
+
+                if (!isAdmin)
+                {
+                    var userSecurityGroups = baseDbContext.SecurityGroupUsers
+                        .Include(x => x.SecurityGroup)
+                        .Where(x => x.EformUserId == currentUser.Id)
+                        .ToList();
+                    var eFormAdminsGroup = userSecurityGroups
+                        .Any(x => x.SecurityGroup.Name == "eForm admins");
+                    isAdmin = eFormAdminsGroup;
+                }
+
+                if (!isAdmin)
+                {
+                    var worker = await sdkDbContext.Workers
+                        .Include(x => x.SiteWorkers)
+                        .ThenInclude(x => x.Site)
+                        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                        .FirstOrDefaultAsync(x => x.Email == currentUser.Email);
+
+                    if (worker != null && worker.SiteWorkers.Any())
+                    {
+                        var workerSite = worker.SiteWorkers.First().Site;
+                        var assignedSite = assignedSites
+                            .FirstOrDefault(x => x.SiteId == workerSite.MicrotingUid);
+
+                        if (assignedSite != null && assignedSite.IsManager)
+                        {
+                            var managingTagIds = await dbContext.AssignedSiteManagingTags
+                                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                                .Where(x => x.AssignedSiteId == assignedSite.Id)
+                                .Select(x => x.TagId)
+                                .ToListAsync();
+
+                            if (managingTagIds.Any())
+                            {
+                                var taggedSiteIds = await sdkDbContext.SiteTags
+                                    .Include(x => x.Site)
+                                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                                    .Where(x => managingTagIds.Contains((int)x.TagId!))
+                                    .Select(x => x.Site.MicrotingUid)
+                                    .Distinct()
+                                    .ToListAsync();
+
+                                assignedSites = assignedSites
+                                    .Where(x => taggedSiteIds.Contains(x.SiteId))
+                                    .ToList();
+                                if (assignedSites.All(x => x.Id != assignedSite.Id))
+                                {
+                                    assignedSites.Add(assignedSite);
+                                }
+                            }
+                            else
+                            {
+                                assignedSites = [assignedSite];
+                            }
+                        }
+                        else if (assignedSite != null)
+                        {
+                            assignedSites = [assignedSite];
+                        }
+                        else
+                        {
+                            assignedSites = [];
+                        }
+                    }
+                    else
+                    {
+                        assignedSites = [];
+                    }
+                }
+            }
+
             var sites = new List<Site>();
             foreach (var assignedSite in assignedSites)
             {


### PR DESCRIPTION
## Summary

Restores the role-based site filter that was accidentally dropped when PR #1522 (commit `0ad1af89`) split the dual-purpose `GetAvailableSites(string? token)` into separate browser and kiosk methods.

The new `GetAvailableSitesByCurrentUser()` returned ALL non-resigned `AssignedSites` unconditionally, leaking sites to managers who should only see their tagged subset.

## Regression caught by

The Playwright test in the sibling `eform-backendconfiguration-plugin` repo:

- Run: `25045858128`
- Job: `pn-playwright-test (k)`
- Spec: `time-registration-dashboard-visibility.spec.ts`
- Test: `should show correct workers based on user role and tags`

## Fix

Reintroduced the deleted role/manager-tag filter block at the top of `GetAvailableSitesByCurrentUser()` after `assignedSites` is loaded. The block restores:

- admin / `eForm admins` security group  bypass (return all sites)
- manager with managing tags  restrict `assignedSites` to those joined through `AssignedSiteManagingTags` -> `SiteTags`, plus self
- non-admin / non-manager  restrict to single `assignedSite`
- no `SiteWorker`  empty list

The restored block is byte-for-byte equivalent to the deleted code in `0ad1af89`. The only divergence is the outer guard:

- Before: `if (token == null && baseDbContext != null)`
- After:  `if (baseDbContext != null)`

This is correct because the new method has no `token` parameter, so the `token == null` half of the conjunction is implicit. The `baseDbContext != null` guard is preserved for unit-test wiring.

## Out of scope

- The kiosk method `GetAvailableSites(string token)` is NOT touched.
- No other methods modified.
- No reformatting.

## Test plan

- [ ] CI builds green
- [ ] Re-run the failing playwright test in `eform-backendconfiguration-plugin` against this branch  manager users see only their tagged sites
- [ ] Existing unit tests still pass (the restored block honors the `baseDbContext == null` escape hatch from the original)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>