### PR TITLE
fix: allow today's working-hours registration when both edit flags are off

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -855,12 +855,14 @@ public class TimePlanningWorkingHoursService(
         Console.WriteLine($"[DEBUG-GRPC-UPDATE] assignedSite found: {assignedSite != null}, AllowEdit={assignedSite?.AllowEditOfRegistrations}, DaysBackEnabled={assignedSite?.DaysBackInTimeAllowedEditingEnabled}");
 
         // Guard: when both editing flags are disabled, the worker is not allowed
-        // to mutate their own registrations from the mobile app.
+        // to mutate their own registrations from the mobile app — except for
+        // today's registration, which is the punchclock-equivalent flow.
+        var today = DateTime.Now.Date;
         if (assignedSite != null
             && !assignedSite.AllowEditOfRegistrations
-            && !assignedSite.DaysBackInTimeAllowedEditingEnabled)
+            && !assignedSite.DaysBackInTimeAllowedEditingEnabled
+            && model.Date.Date != today)
         {
-            Console.WriteLine($"[DEBUG-GRPC-UPDATE] EARLY RETURN: editing not allowed for worker (AllowEdit=false, DaysBack=false)");
             return new OperationResult(
                 false,
                 localizationService.GetString("EditingNotAllowedForWorker"));


### PR DESCRIPTION
## Summary

Worker pressing **Start arbejdstid** in the flutter-time personal-mobile app saw the modal stick open with no error. The gRPC server was returning `success=false, message=EditingNotAllowedForWorker`. Diagnosis: the guard added in c7732b40 (PR #1524) was too aggressive — it rejected **all** mobile updates whenever `AssignedSite.AllowEditOfRegistrations=false` **and** `DaysBackInTimeAllowedEditingEnabled=false`, including registering today's start.

The kiosk path (3-param `UpdateWorkingHour` overload at line 1507) has **no such guard**, so the punchclock kept working — exposing the inconsistency.

## Root cause

c7732b40 introduced the new "no editing" mobile-mode option. The intent was to forbid *editing past registrations*. The guard implementation forbade *all mutation* including today's first-time registration, which is the punchclock-equivalent flow.

## Fix

Narrow the guard so it fires only when `model.Date.Date != DateTime.Now.Date`:

- Today still goes through (punchclock-equivalent registration allowed).
- Past-date edits remain blocked when both flags are off.
- Future-date pre-registration also blocked (strict equality, per user-stated rule "only registration for today is allowed").

`DateTime.Now.Date` matches the rest of this service's "today" semantic (lines 111, 161, 259, 368, 419, 480, 528, 3266+).

Also drops the `[DEBUG-GRPC-UPDATE]` `Console.WriteLine` on this block; broader debug-line cleanup is a separate task.

## Out of scope

- Flutter UX bug where the modal stays open and shows no error on a real failure (`grpc_data_helper.dart` collapses the message; `*_shift_start_confirm_page.dart` else-branch only logs to Sentry). Separate fix once the today case works.
- Kiosk-side enforcement of "today only" — kiosk UI already enforces this itself; the 3-param overload has no guard and we are not adding one.
- Server-side authorization integration test — none exists for this service today; adding one would need DB+`AssignedSite`+`PlanRegistration` fixtures, out of scope.

## Test plan

- [x] `dotnet clean && dotnet build` at host root green
- [ ] CI green
- [ ] On-device: worker on `AssignedSite` with both flags off presses "Start arbejdstid" in personal mobile app pointed at the redeployed dev backend → modal closes, registration created for today
- [ ] On-device: same worker tries to edit a past day → still rejected with `EditingNotAllowedForWorker`

(In-progress flutter-time test on device on `1123.microting.com` once this lands and is redeployed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)