### PR TITLE
fix: clear shift int columns on source after handover accept

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
@@ -716,4 +716,90 @@ public class ContentHandoverServiceTests : TestBaseSetup
         var s = await TimePlanningPnDbContext.PlanRegistrations.FindAsync(source.Id);
         Assert.That(s.PlannedEndOfShift1, Is.EqualTo(12 * 60));
     }
+
+    // Regression: previously MoveContent used reflection to clear non-nullable
+    // PlannedStart/End/BreakOfShift{1..5} ints by calling SetValue(source, null),
+    // which threw ArgumentException and was swallowed by a try/catch. The result
+    // was that the sender's shift columns stayed populated even though PlanHours
+    // and PlanText were nulled directly. UI symptom: planHours changed but the
+    // shift bar still showed on the sender's day.
+    [Test]
+    public async Task AcceptAsync_FullDay_TransfersAllShiftIntsAndZerosSource()
+    {
+        // Arrange
+        var date = new DateTime(2024, 1, 1);
+        var sourcePR = new PlanRegistration
+        {
+            Date = date,
+            SdkSitId = 1,
+            PlanHours = 8,
+            PlanHoursInSeconds = 28800,
+            PlanText = "Important work",
+            PlannedStartOfShift1 = 8 * 3600,
+            PlannedEndOfShift1 = 16 * 3600,
+            PlannedBreakOfShift1 = 30 * 60,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await sourcePR.Create(TimePlanningPnDbContext);
+
+        var targetPR = new PlanRegistration
+        {
+            Date = date,
+            SdkSitId = 2,
+            PlanHours = 0,
+            PlanHoursInSeconds = 0,
+            PlanText = null,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await targetPR.Create(TimePlanningPnDbContext);
+
+        var request = new PlanRegistrationContentHandoverRequest
+        {
+            FromSdkSitId = 1,
+            ToSdkSitId = 2,
+            Date = date,
+            FromPlanRegistrationId = sourcePR.Id,
+            ToPlanRegistrationId = targetPR.Id,
+            Status = HandoverRequestStatus.Pending,
+            RequestedAtUtc = DateTime.UtcNow,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await request.Create(TimePlanningPnDbContext);
+
+        var model = new ContentHandoverDecisionModel
+        {
+            DecisionComment = "Accepted"
+        };
+
+        // Act
+        var result = await _contentHandoverService.AcceptAsync(request.Id, 2, model);
+
+        // Assert
+        Assert.That(result.Success, Is.True, $"Expected success but got error: {result.Message}");
+
+        var updatedSource = await TimePlanningPnDbContext.PlanRegistrations.FindAsync(sourcePR.Id);
+        var updatedTarget = await TimePlanningPnDbContext.PlanRegistrations.FindAsync(targetPR.Id);
+
+        // Source shift1 ints zeroed (the regression).
+        Assert.That(updatedSource.PlannedStartOfShift1, Is.EqualTo(0),
+            "Source PlannedStartOfShift1 must be zeroed after full-day handover");
+        Assert.That(updatedSource.PlannedEndOfShift1, Is.EqualTo(0),
+            "Source PlannedEndOfShift1 must be zeroed after full-day handover");
+        Assert.That(updatedSource.PlannedBreakOfShift1, Is.EqualTo(0),
+            "Source PlannedBreakOfShift1 must be zeroed after full-day handover");
+
+        // Target receives the seeded shift1 values.
+        Assert.That(updatedTarget.PlannedStartOfShift1, Is.EqualTo(8 * 3600));
+        Assert.That(updatedTarget.PlannedEndOfShift1, Is.EqualTo(16 * 3600));
+        Assert.That(updatedTarget.PlannedBreakOfShift1, Is.EqualTo(30 * 60));
+
+        // PlanHours / PlanText behaviour preserved (matches AcceptAsync_MovesContent_FromSourceToTarget).
+        Assert.That(updatedSource.PlanHoursInSeconds, Is.EqualTo(0));
+        Assert.That(updatedSource.PlanText, Is.Null);
+        Assert.That(updatedTarget.PlanHoursInSeconds, Is.EqualTo(28800));
+        Assert.That(updatedTarget.PlanText, Is.EqualTo("Important work"));
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
@@ -948,107 +948,46 @@ public class ContentHandoverService : IContentHandoverService
         target.PlanText = source.PlanText;
         target.PlanHours = source.PlanHours;
         target.PlanHoursInSeconds = source.PlanHoursInSeconds;
-        
-        // Try to move planned shift fields if they exist
-        try
-        {
-            var prType = source.GetType();
-            
-            for (int i = 1; i <= 5; i++)
-            {
-                var startProp = prType.GetProperty($"PlannedStartOfShift{i}");
-                if (startProp != null && startProp.CanRead && startProp.CanWrite)
-                {
-                    var value = startProp.GetValue(source);
-                    startProp.SetValue(target, value);
-                }
-                
-                var endProp = prType.GetProperty($"PlannedEndOfShift{i}");
-                if (endProp != null && endProp.CanRead && endProp.CanWrite)
-                {
-                    var value = endProp.GetValue(source);
-                    endProp.SetValue(target, value);
-                }
-                
-                var breakProp = prType.GetProperty($"PlannedBreakOfShift{i}");
-                if (breakProp != null && breakProp.CanRead && breakProp.CanWrite)
-                {
-                    var value = breakProp.GetValue(source);
-                    breakProp.SetValue(target, value);
-                }
-            }
-            
-            var isDoubleShiftProp = prType.GetProperty("IsDoubleShift");
-            if (isDoubleShiftProp != null && isDoubleShiftProp.CanRead && isDoubleShiftProp.CanWrite)
-            {
-                var value = isDoubleShiftProp.GetValue(source);
-                isDoubleShiftProp.SetValue(target, value);
-            }
-        }
-        catch
-        {
-            // Ignore if properties don't exist
-        }
+
+        // Move all five planned shift slots from source to target
+        target.PlannedStartOfShift1 = source.PlannedStartOfShift1;
+        target.PlannedEndOfShift1 = source.PlannedEndOfShift1;
+        target.PlannedBreakOfShift1 = source.PlannedBreakOfShift1;
+        target.PlannedStartOfShift2 = source.PlannedStartOfShift2;
+        target.PlannedEndOfShift2 = source.PlannedEndOfShift2;
+        target.PlannedBreakOfShift2 = source.PlannedBreakOfShift2;
+        target.PlannedStartOfShift3 = source.PlannedStartOfShift3;
+        target.PlannedEndOfShift3 = source.PlannedEndOfShift3;
+        target.PlannedBreakOfShift3 = source.PlannedBreakOfShift3;
+        target.PlannedStartOfShift4 = source.PlannedStartOfShift4;
+        target.PlannedEndOfShift4 = source.PlannedEndOfShift4;
+        target.PlannedBreakOfShift4 = source.PlannedBreakOfShift4;
+        target.PlannedStartOfShift5 = source.PlannedStartOfShift5;
+        target.PlannedEndOfShift5 = source.PlannedEndOfShift5;
+        target.PlannedBreakOfShift5 = source.PlannedBreakOfShift5;
+        target.IsDoubleShift = source.IsDoubleShift;
 
         // Clear the moved fields on source
         source.PlanText = null;
         source.PlanHours = 0;
         source.PlanHoursInSeconds = 0;
-        
-        // Try to clear planned shift fields if they exist
-        try
-        {
-            var prType = source.GetType();
-            var plannedStartOfShift1Prop = prType.GetProperty("PlannedStartOfShift1");
-            if (plannedStartOfShift1Prop != null && plannedStartOfShift1Prop.CanWrite)
-            {
-                plannedStartOfShift1Prop.SetValue(source, null);
-            }
-            
-            var plannedEndOfShift1Prop = prType.GetProperty("PlannedEndOfShift1");
-            if (plannedEndOfShift1Prop != null && plannedEndOfShift1Prop.CanWrite)
-            {
-                plannedEndOfShift1Prop.SetValue(source, null);
-            }
-            
-            var plannedBreakOfShift1Prop = prType.GetProperty("PlannedBreakOfShift1");
-            if (plannedBreakOfShift1Prop != null && plannedBreakOfShift1Prop.CanWrite)
-            {
-                plannedBreakOfShift1Prop.SetValue(source, null);
-            }
-            
-            // Repeat for shifts 2-5
-            for (int i = 2; i <= 5; i++)
-            {
-                var startProp = prType.GetProperty($"PlannedStartOfShift{i}");
-                if (startProp != null && startProp.CanWrite)
-                {
-                    startProp.SetValue(source, null);
-                }
-                
-                var endProp = prType.GetProperty($"PlannedEndOfShift{i}");
-                if (endProp != null && endProp.CanWrite)
-                {
-                    endProp.SetValue(source, null);
-                }
-                
-                var breakProp = prType.GetProperty($"PlannedBreakOfShift{i}");
-                if (breakProp != null && breakProp.CanWrite)
-                {
-                    breakProp.SetValue(source, null);
-                }
-            }
-            
-            var isDoubleShiftProp = prType.GetProperty("IsDoubleShift");
-            if (isDoubleShiftProp != null && isDoubleShiftProp.CanWrite)
-            {
-                isDoubleShiftProp.SetValue(source, false);
-            }
-        }
-        catch
-        {
-            // Ignore if properties don't exist or can't be set
-        }
+
+        source.PlannedStartOfShift1 = 0;
+        source.PlannedEndOfShift1 = 0;
+        source.PlannedBreakOfShift1 = 0;
+        source.PlannedStartOfShift2 = 0;
+        source.PlannedEndOfShift2 = 0;
+        source.PlannedBreakOfShift2 = 0;
+        source.PlannedStartOfShift3 = 0;
+        source.PlannedEndOfShift3 = 0;
+        source.PlannedBreakOfShift3 = 0;
+        source.PlannedStartOfShift4 = 0;
+        source.PlannedEndOfShift4 = 0;
+        source.PlannedBreakOfShift4 = 0;
+        source.PlannedStartOfShift5 = 0;
+        source.PlannedEndOfShift5 = 0;
+        source.PlannedBreakOfShift5 = 0;
+        source.IsDoubleShift = false;
     }
 
     private static void MoveShift(PlanRegistration source, PlanRegistration target, int n)


### PR DESCRIPTION
## Summary
- `MoveContent` used reflection to clear `PlannedStartOfShift{1..5}`, `PlannedEndOfShift{1..5}`, `PlannedBreakOfShift{1..5}` on the sender after copying them to the receiver. Those properties are non-nullable `int`, so `SetValue(source, null)` threw `ArgumentException`, which was swallowed by a try/catch wrapping the loop. Sender's shift columns stayed populated even though `PlanHours`/`PlanText` were nulled directly. UI symptom: "planHours changes but the shift bar still shows on the sender's day."
- Replaces both the copy and clear blocks with direct property assignments mirroring sibling `MoveShift`. Drops the now-unnecessary try/catch — direct assignment cannot fail. Partial-shift branch (`shiftIndex.HasValue` → `MoveShift`) is preserved unchanged.
- Adds a new regression test `AcceptAsync_FullDay_TransfersAllShiftIntsAndZerosSource` (no existing tests modified) that seeds non-zero shift1 ints on source, calls `AcceptAsync`, re-fetches from DB, and asserts source ints are 0 and target receives the values.

Bug existed since d6747161; not a regression from the gRPC migration.

## Test plan
- [ ] CI: TimePlanning.Pn.Test green, including the new test
- [ ] CI: existing `AcceptAsync_MovesContent_FromSourceToTarget` still passes (PlanText/PlanHours invariants unchanged)
- [ ] CI: playwright shards green
- [ ] Manual smoke (post-merge): accept a full-day handover on dev, verify sender's shift bar disappears

Generated with Claude Code