### PR TITLE
fix: period summary returns last-day SumFlexEnd and sums PaiedOutFlex

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningWorkingHoursGrpcServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningWorkingHoursGrpcServiceTests.cs
@@ -175,6 +175,72 @@ public class TimePlanningWorkingHoursGrpcServiceTests
     }
 
     [Test]
+    public async Task CalculateHoursSummary_MapsTotalPaidOutFlex()
+    {
+        // Verifies the gRPC handler forwards TotalPaidOutFlex from the service
+        // model to the proto's paid_out_flex field instead of hardcoding 0.
+        var summaryModel = new TimePlanningHoursSummaryModel
+        {
+            TotalPlanHours = 40.0,
+            TotalNettoHours = 38.5,
+            TotalPaidOutFlex = 2.0,
+            Difference = 3.5,
+        };
+
+        _whService.CalculateHoursSummary(
+                Arg.Any<DateTime>(), Arg.Any<DateTime>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new OperationDataResult<TimePlanningHoursSummaryModel>(true, summaryModel));
+
+        var request = new CalculateHoursSummaryRequest
+        {
+            StartDate = "2026-04-01",
+            EndDate = "2026-04-07",
+        };
+
+        var response = await _grpcService.CalculateHoursSummary(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+        Assert.That(response.Model, Is.Not.Null);
+        Assert.That(response.Model.PaidOutFlex, Is.EqualTo(2.0));
+    }
+
+    [Test]
+    public async Task CalculateHoursSummary_TotalFlexHours_TrustsServiceDifferenceVerbatim()
+    {
+        // Documents the new semantic: Difference now carries the last-day SumFlexEnd
+        // (end-of-period balance), not the recomputed sum(NettoHours) - sum(PlanHours).
+        // The gRPC handler must forward whatever the service returns without recomputing.
+        var summaryModel = new TimePlanningHoursSummaryModel
+        {
+            TotalPlanHours = 40.0,    // Period plan sum
+            TotalNettoHours = 38.5,   // Period net sum
+            TotalPaidOutFlex = 0.0,
+            Difference = 12.75,       // End-of-period flex balance, NOT 38.5 - 40.0
+        };
+
+        _whService.CalculateHoursSummary(
+                Arg.Any<DateTime>(), Arg.Any<DateTime>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new OperationDataResult<TimePlanningHoursSummaryModel>(true, summaryModel));
+
+        var request = new CalculateHoursSummaryRequest
+        {
+            StartDate = "2026-04-01",
+            EndDate = "2026-04-07",
+        };
+
+        var response = await _grpcService.CalculateHoursSummary(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(response.Success, Is.True);
+        Assert.That(response.Model, Is.Not.Null);
+        Assert.That(response.Model.TotalFlexHours, Is.EqualTo(12.75));
+        Assert.That(response.Model.TotalFlexMinutes, Is.EqualTo(0.75 * 60));
+    }
+
+    [Test]
     public async Task ReadWorkingHours_NullDateTimeFields_MappedAsEmptyStrings()
     {
         var model = new TimePlanningWorkingHoursModel

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningHoursSummaryModel.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningHoursSummaryModel.cs
@@ -4,6 +4,7 @@ public class TimePlanningHoursSummaryModel
 {
     public double TotalPlanHours { get; set; }
     public double TotalNettoHours { get; set; }
+    public double TotalPaidOutFlex { get; set; }
     public double Difference { get; set; }
     public int VacationDays { get; set; }
     public int SickDays { get; set; }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningWorkingHoursGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningWorkingHoursGrpcService.cs
@@ -149,7 +149,7 @@ public class TimePlanningWorkingHoursGrpcService
                 TotalPlannedMinutes = (result.Model.TotalPlanHours % 1) * 60,
                 TotalFlexHours = result.Model.Difference,
                 TotalFlexMinutes = (result.Model.Difference % 1) * 60,
-                PaidOutFlex = 0,
+                PaidOutFlex = result.Model.TotalPaidOutFlex,
                 VacationDays = result.Model.VacationDays,
                 SickDays = result.Model.SickDays,
                 OtherAbsenceDays = result.Model.OtherAbsenceDays,

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -693,13 +693,22 @@ public class TimePlanningWorkingHoursService(
 
             var totalPlanHours = planRegistrations.Sum(x => x.PlanHours);
             var totalNettoHours = planRegistrations.Sum(x => x.NettoHours);
-            var difference = totalNettoHours - totalPlanHours;
+            var totalPaidOutFlex = planRegistrations.Sum(x => x.PaiedOutFlex);
+            // The flex balance shown on the period status hero card is a point-in-time
+            // read of the last day's stored SumFlexEnd, not a recomputation of
+            // sum(NettoHours) - sum(PlanHours). The latter ignores opening balance
+            // and mid-period payouts.
+            var lastDay = planRegistrations
+                .OrderByDescending(x => x.Date)
+                .FirstOrDefault();
+            var endOfPeriodFlex = lastDay?.SumFlexEnd ?? 0;
 
             var summary = new TimePlanningHoursSummaryModel
             {
                 TotalPlanHours = totalPlanHours,
                 TotalNettoHours = totalNettoHours,
-                Difference = difference
+                TotalPaidOutFlex = totalPaidOutFlex,
+                Difference = endOfPeriodFlex
             };
 
             if (model != null)


### PR DESCRIPTION
## Summary

`CalculateHoursSummary` produced wrong values on the personal-view period status widget:

1. The flex balance hero card showed `sum(NettoHours) - sum(PlanHours)` (a recomputation that ignores opening balance and mid-period payouts) instead of the actual end-of-period flex.
2. The "paid out flex" line was always `0` because the gRPC handler hardcoded `PaidOutFlex = 0`.

This PR fixes both. The shared service is used by both JSON and gRPC paths, so one fix covers both.

## Changes

- `TimePlanningWorkingHoursService.CalculateHoursSummary` now sets `Difference` from the last day's `SumFlexEnd` (point-in-time end-of-period balance) and sums `PaiedOutFlex` over the period into a new `TotalPaidOutFlex`.
- `TimePlanningHoursSummaryModel`: new `TotalPaidOutFlex` property.
- `TimePlanningWorkingHoursGrpcService.CalculateHoursSummary`: forwards `result.Model.TotalPaidOutFlex` instead of `0`.
- 2 new gRPC mapping tests covering the new field plus the preserved trust of the service-supplied `Difference`.

The proto field name `Difference` is unchanged for wire compat; only its semantic shifts. Dart side already reads `m.totalFlexHours` and `m.paidOutFlex` correctly.

## Test plan

- [x] `dotnet build` at host root: green (0 errors)
- [ ] CI matrix green
- [ ] On-device sanity: hero card shows the user's actual end-of-period flex; paid-out line shows the period sum

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>