### PR TITLE
fix: sort handover-eligible coworkers alphabetically (da-DK)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -69,6 +70,35 @@ public class ContentHandoverServiceTests : TestBaseSetup
     public Task GetHandoverEligibleCoworkersAsync_WorkerNotFound_ReturnsFailure()
     {
         return Task.CompletedTask;
+    }
+
+    // Regression: GetHandoverEligibleCoworkersAsync must return the eligible
+    // list sorted alphabetically by SiteName under Danish locale. The picker in
+    // flutter-time renders the list verbatim, so insertion-order output produced
+    // a scrambled UI (Lars, Søren, Anita, Ditte, ...). The service now applies
+    // OrderBy with a da-DK StringComparer; in Danish, Æ/Ø/Å come AFTER Z, in
+    // that order. Seeding the SDK Workers/SiteTags + BaseDbContext.Users path is
+    // out of scope here (the three sibling cases above are still ignored for
+    // the same reason), so we pin the canonical sort by exercising the same
+    // public comparer the service uses against representative names.
+    [Test]
+    public void GetHandoverEligibleCoworkers_ReturnsListSortedAlphabeticallyByName()
+    {
+        var candidates = new List<HandoverCoworkerModel>
+        {
+            new() { SiteName = "Søren" },
+            new() { SiteName = "Anita" },
+            new() { SiteName = "Åse" },
+            new() { SiteName = "Bo" },
+            new() { SiteName = "Ærke" },
+        };
+
+        var sorted = candidates
+            .OrderBy(c => c.SiteName, ContentHandoverService.HandoverCoworkerNameComparer)
+            .Select(c => c.SiteName)
+            .ToList();
+
+        Assert.That(sorted, Is.EqualTo(new[] { "Anita", "Bo", "Søren", "Ærke", "Åse" }));
     }
 
     [Test]

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
@@ -27,6 +27,7 @@ namespace TimePlanning.Pn.Services.ContentHandoverService;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Infrastructure.Helpers;
@@ -70,6 +71,12 @@ public class ContentHandoverService : IContentHandoverService
         _baseDbContext = baseDbContext;
         _pushNotificationService = pushNotificationService;
     }
+
+    // Danish-locale, case-insensitive comparer used to sort the handover-eligible
+    // coworker list. Exposed publicly so the regression test can pin the
+    // canonical da-DK collation order (Æ/Ø/Å come AFTER Z, in that order).
+    public static readonly StringComparer HandoverCoworkerNameComparer =
+        StringComparer.Create(CultureInfo.GetCultureInfo("da-DK"), ignoreCase: true);
 
     public Task<OperationDataResult<List<HandoverCoworkerModel>>> GetHandoverEligibleCoworkersAsync(DateTime date)
     {
@@ -247,6 +254,7 @@ public class ContentHandoverService : IContentHandoverService
                 })
                 .Where(x => x.Eligible)
                 .Select(x => x.Model)
+                .OrderBy(x => x.SiteName, HandoverCoworkerNameComparer)
                 .ToList();
 
             return new OperationDataResult<List<HandoverCoworkerModel>>(true, result);


### PR DESCRIPTION
## Summary
- Server-side sort fix in `ContentHandoverService.GetHandoverEligibleCoworkersAsync`: list is now returned alphabetically by `SiteName` using a Danish-locale (`da-DK`), case-insensitive `StringComparer` so Æ/Ø/Å land after Z in that order.
- Bug symptom (flutter-time): handover coworker picker rendered names in insertion order — Lars, Søren, Anita, Ditte, Gitte, Ionut, Julie, Lauritz. Client renders verbatim, so the canonical fix is server-side.
- Adds regression test `GetHandoverEligibleCoworkers_ReturnsListSortedAlphabeticallyByName` that pins the canonical da-DK order using the same public comparer the service uses against representative names (Søren, Anita, Åse, Bo, Ærke → Anita, Bo, Søren, Ærke, Åse).

## Test plan
- [x] dotnet clean + build at host root: 0 errors, only pre-existing warnings
- [ ] CI green on stable
- [ ] Manual sanity check after deploy: open handover picker on flutter-time, confirm names render alphabetically (Anita before Lars before Søren before Ærke before Åse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)