### PR TITLE
fix: mobile gRPC returns unfiltered coworker list (no proto change)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningSettingsGrpcServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningSettingsGrpcServiceTests.cs
@@ -81,7 +81,7 @@ public class TimePlanningSettingsGrpcServiceTests
             },
         };
 
-        _settingService.GetAvailableSitesByCurrentUser()
+        _settingService.GetAllRegistrationSitesByCurrentUser()
             .Returns(new OperationDataResult<List<Infrastructure.Models.Settings.Site>>(
                 true, "OK", sites));
 
@@ -144,7 +144,7 @@ public class TimePlanningSettingsGrpcServiceTests
     [Test]
     public async Task GetRegistrationSitesByCurrentUser_Failure_ReturnsErrorMessage()
     {
-        _settingService.GetAvailableSitesByCurrentUser()
+        _settingService.GetAllRegistrationSitesByCurrentUser()
             .Returns(new OperationDataResult<List<Infrastructure.Models.Settings.Site>>(
                 false, "Access denied"));
 
@@ -161,7 +161,7 @@ public class TimePlanningSettingsGrpcServiceTests
     [Test]
     public async Task GetRegistrationSitesByCurrentUser_EmptyList_ReturnsSuccessWithNoSites()
     {
-        _settingService.GetAvailableSitesByCurrentUser()
+        _settingService.GetAllRegistrationSitesByCurrentUser()
             .Returns(new OperationDataResult<List<Infrastructure.Models.Settings.Site>>(
                 true, "OK", new List<Infrastructure.Models.Settings.Site>()));
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceExtendedTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceExtendedTests.cs
@@ -299,4 +299,286 @@ public class SettingsServiceExtendedTests : TestBaseSetup
         Assert.That(s.HoursStarted, Is.False);
         Assert.That(s.PauseStarted, Is.False);
     }
+
+    // --- GetAllRegistrationSitesByCurrentUser tests ---
+    // Mobile gRPC entry point: must return the complete unfiltered coworker
+    // list. The web admin JSON path keeps the manager-tag filter; this method
+    // ignores it. Resigned/removed/workflow-state guards still apply.
+
+    [Test]
+    public async Task GetAllRegistrationSitesByCurrentUser_ReturnsAllSites_IgnoringManagerTagFilter()
+    {
+        // Arrange — seed 4 candidate sites with different tag associations.
+        // Manager-tag filtering is *out of scope* for this entry point, so all
+        // four must come back regardless of which (if any) tag they carry.
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+        var language = await sdkDbContext.Languages.FirstOrDefaultAsync();
+        if (language == null)
+        {
+            language = new Microting.eForm.Infrastructure.Data.Entities.Language
+            {
+                LanguageCode = "en",
+                Name = "English"
+            };
+            await language.Create(sdkDbContext);
+        }
+
+        for (var i = 0; i < 4; i++)
+        {
+            var siteUid = 1000 + i;
+            var workerUid = 2000 + i;
+            var siteWorkerUid = 3000 + i;
+            var unitUid = 4000 + i;
+
+            var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+            {
+                Name = $"Coworker {i}",
+                MicrotingUid = siteUid,
+                LanguageId = language.Id
+            };
+            await site.Create(sdkDbContext);
+
+            var worker = new Microting.eForm.Infrastructure.Data.Entities.Worker
+            {
+                FirstName = $"First{i}",
+                LastName = $"Last{i}",
+                Email = $"coworker{i}@test.com",
+                MicrotingUid = workerUid
+            };
+            await worker.Create(sdkDbContext);
+
+            var siteWorker = new Microting.eForm.Infrastructure.Data.Entities.SiteWorker
+            {
+                SiteId = site.Id,
+                WorkerId = worker.Id,
+                MicrotingUid = siteWorkerUid
+            };
+            await siteWorker.Create(sdkDbContext);
+
+            var unit = new Microting.eForm.Infrastructure.Data.Entities.Unit
+            {
+                SiteId = site.Id,
+                MicrotingUid = unitUid,
+                CustomerNo = 1,
+                OtpCode = 1
+            };
+            await unit.Create(sdkDbContext);
+
+            var assigned = new AssignedSiteEntity
+            {
+                SiteId = siteUid,
+                Resigned = false,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            };
+            await assigned.Create(TimePlanningPnDbContext);
+        }
+
+        // Act
+        var result = await _settingsService.GetAllRegistrationSitesByCurrentUser();
+
+        // Assert — all 4 sites returned, no manager-tag culling.
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(4));
+        var siteIds = result.Model.Select(x => x.SiteId).OrderBy(x => x).ToList();
+        Assert.That(siteIds, Is.EqualTo(new[] { 1000, 1001, 1002, 1003 }));
+    }
+
+    [Test]
+    public async Task GetAllRegistrationSitesByCurrentUser_StillExcludesResignedAndRemoved()
+    {
+        // Arrange — 2 active + 1 resigned + 1 workflow-state-removed.
+        // The unfiltered mobile path must still respect those guards.
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+        var language = await sdkDbContext.Languages.FirstOrDefaultAsync();
+        if (language == null)
+        {
+            language = new Microting.eForm.Infrastructure.Data.Entities.Language
+            {
+                LanguageCode = "en",
+                Name = "English"
+            };
+            await language.Create(sdkDbContext);
+        }
+
+        async Task SeedSdkSiteAsync(int siteUid, int workerUid, int siteWorkerUid, int unitUid, string label)
+        {
+            var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+            {
+                Name = label,
+                MicrotingUid = siteUid,
+                LanguageId = language.Id
+            };
+            await site.Create(sdkDbContext);
+
+            var worker = new Microting.eForm.Infrastructure.Data.Entities.Worker
+            {
+                FirstName = label,
+                LastName = "Worker",
+                Email = $"{label.ToLower().Replace(' ', '_')}@test.com",
+                MicrotingUid = workerUid
+            };
+            await worker.Create(sdkDbContext);
+
+            var siteWorker = new Microting.eForm.Infrastructure.Data.Entities.SiteWorker
+            {
+                SiteId = site.Id,
+                WorkerId = worker.Id,
+                MicrotingUid = siteWorkerUid
+            };
+            await siteWorker.Create(sdkDbContext);
+
+            var unit = new Microting.eForm.Infrastructure.Data.Entities.Unit
+            {
+                SiteId = site.Id,
+                MicrotingUid = unitUid,
+                CustomerNo = 1,
+                OtpCode = 1
+            };
+            await unit.Create(sdkDbContext);
+        }
+
+        await SeedSdkSiteAsync(5000, 6000, 7000, 8000, "Active1");
+        await SeedSdkSiteAsync(5001, 6001, 7001, 8001, "Active2");
+        await SeedSdkSiteAsync(5002, 6002, 7002, 8002, "Resigned1");
+        await SeedSdkSiteAsync(5003, 6003, 7003, 8003, "Removed1");
+
+        var active1 = new AssignedSiteEntity
+        {
+            SiteId = 5000,
+            Resigned = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await active1.Create(TimePlanningPnDbContext);
+
+        var active2 = new AssignedSiteEntity
+        {
+            SiteId = 5001,
+            Resigned = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await active2.Create(TimePlanningPnDbContext);
+
+        var resigned = new AssignedSiteEntity
+        {
+            SiteId = 5002,
+            Resigned = true,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await resigned.Create(TimePlanningPnDbContext);
+
+        var removed = new AssignedSiteEntity
+        {
+            SiteId = 5003,
+            Resigned = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await removed.Create(TimePlanningPnDbContext);
+        // Soft-delete via Delete() so WorkflowState becomes Removed.
+        await removed.Delete(TimePlanningPnDbContext);
+
+        // Act
+        var result = await _settingsService.GetAllRegistrationSitesByCurrentUser();
+
+        // Assert — only the two active sites come back.
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(2));
+        var siteIds = result.Model.Select(x => x.SiteId).OrderBy(x => x).ToList();
+        Assert.That(siteIds, Is.EqualTo(new[] { 5000, 5001 }));
+    }
+
+    [Test]
+    public async Task GetAllRegistrationSitesByCurrentUser_NonManager_StillReceivesAllPeers()
+    {
+        // The manager-only restriction lives in GetAvailableSitesByCurrentUser
+        // (web admin JSON path). For the mobile gRPC entry point there is no
+        // such gate: even a non-manager caller (no AssignedSite.IsManager flag
+        // set on any row) must receive every peer's site.
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+        var language = await sdkDbContext.Languages.FirstOrDefaultAsync();
+        if (language == null)
+        {
+            language = new Microting.eForm.Infrastructure.Data.Entities.Language
+            {
+                LanguageCode = "en",
+                Name = "English"
+            };
+            await language.Create(sdkDbContext);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            var siteUid = 9000 + i;
+            var workerUid = 9100 + i;
+            var siteWorkerUid = 9200 + i;
+            var unitUid = 9300 + i;
+
+            var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+            {
+                Name = $"Peer {i}",
+                MicrotingUid = siteUid,
+                LanguageId = language.Id
+            };
+            await site.Create(sdkDbContext);
+
+            var worker = new Microting.eForm.Infrastructure.Data.Entities.Worker
+            {
+                FirstName = $"Peer{i}",
+                LastName = "Worker",
+                Email = $"peer{i}@test.com",
+                MicrotingUid = workerUid
+            };
+            await worker.Create(sdkDbContext);
+
+            var siteWorker = new Microting.eForm.Infrastructure.Data.Entities.SiteWorker
+            {
+                SiteId = site.Id,
+                WorkerId = worker.Id,
+                MicrotingUid = siteWorkerUid
+            };
+            await siteWorker.Create(sdkDbContext);
+
+            var unit = new Microting.eForm.Infrastructure.Data.Entities.Unit
+            {
+                SiteId = site.Id,
+                MicrotingUid = unitUid,
+                CustomerNo = 1,
+                OtpCode = 1
+            };
+            await unit.Create(sdkDbContext);
+
+            // No IsManager flag — every assigned site is a regular non-manager row.
+            var assigned = new AssignedSiteEntity
+            {
+                SiteId = siteUid,
+                Resigned = false,
+                IsManager = false,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            };
+            await assigned.Create(TimePlanningPnDbContext);
+        }
+
+        // Act
+        var result = await _settingsService.GetAllRegistrationSitesByCurrentUser();
+
+        // Assert — non-manager caller still receives every peer's site.
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(3));
+        var siteIds = result.Model.Select(x => x.SiteId).OrderBy(x => x).ToList();
+        Assert.That(siteIds, Is.EqualTo(new[] { 9000, 9001, 9002 }));
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
@@ -277,7 +277,11 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
     public override async Task<GetRegistrationSitesResponse> GetRegistrationSitesByCurrentUser(
         GetRegistrationSitesByCurrentUserRequest request, ServerCallContext context)
     {
-        var result = await _settingService.GetAvailableSitesByCurrentUser();
+        // Mobile gRPC entry point: return the complete unfiltered coworker list.
+        // The web admin JSON path (TimePlanningSettingsController) still calls the
+        // filtered GetAvailableSitesByCurrentUser so the manager-tag filter
+        // (PR #1524) continues to apply there.
+        var result = await _settingService.GetAllRegistrationSitesByCurrentUser();
 
         var response = new GetRegistrationSitesResponse
         {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/ISettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/ISettingService.cs
@@ -46,6 +46,7 @@ public interface ISettingService
 
     Task<OperationDataResult<List<Site>>> GetAvailableSites(string token);
     Task<OperationDataResult<List<Site>>> GetAvailableSitesByCurrentUser();
+    Task<OperationDataResult<List<Site>>> GetAllRegistrationSitesByCurrentUser();
     Task<OperationDataResult<AssignedSite>> GetAssignedSite(int siteId);
     Task<OperationResult> UpdateAssignedSite(AssignedSite site);
     Task<OperationDataResult<AssignedSite>> GetAssignedSiteByCurrentUserName();

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -440,23 +440,82 @@ public class TimeSettingService(
                 }
             }
 
-            var sites = new List<Site>();
-            foreach (var assignedSite in assignedSites)
-            {
-                var site = await sdkDbContext.Sites.SingleOrDefaultAsync(x =>
-                    x.MicrotingUid == assignedSite.SiteId);
-                if (site == null) continue;
-                var siteWorker = await sdkDbContext.SiteWorkers
-                    .Where(x => x.SiteId == site.Id)
-                    .FirstOrDefaultAsync();
-                if (siteWorker == null) continue;
-                var worker = await sdkDbContext.Workers
-                    .Where(x => x.Id == siteWorker.WorkerId)
-                    .FirstOrDefaultAsync();
-                if (worker == null) continue;
-                var unit = await sdkDbContext.Units.FirstOrDefaultAsync(x => x.SiteId == site.Id);
-                var language = await sdkDbContext.Languages
-                    .FirstOrDefaultAsync(x => x.Id == site.LanguageId);
+            var sites = await BuildSitesFromAssignedSitesAsync(assignedSites, sdkDbContext);
+
+            return new OperationDataResult<List<Site>>(true, sites);
+        }
+        catch (Exception e)
+        {
+            SentrySdk.CaptureException(e);
+            Console.WriteLine(e);
+            logger.LogError(e.Message);
+            return new OperationDataResult<List<Site>>(
+                false,
+                localizationService.GetString("ErrorWhileObtainingSites"));
+        }
+    }
+
+    /// <summary>
+    /// Mobile gRPC entry point — returns the complete unfiltered coworker list.
+    /// Mirrors <see cref="GetAvailableSitesByCurrentUser"/> but skips the manager-tag
+    /// filter block. Resigned/removed/workflow-state guards still apply.
+    /// </summary>
+    public async Task<OperationDataResult<List<Site>>> GetAllRegistrationSitesByCurrentUser()
+    {
+        try
+        {
+            var core1 = await core.GetCore();
+            var sdkDbContext = core1.DbContextHelper.GetDbContext();
+            var assignedSites = await dbContext.AssignedSites
+                .AsNoTracking()
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => x.Resigned != true)
+                .ToListAsync();
+
+            // No manager-tag filter here: mobile clients always receive the full list.
+
+            var sites = await BuildSitesFromAssignedSitesAsync(assignedSites, sdkDbContext);
+
+            return new OperationDataResult<List<Site>>(true, sites);
+        }
+        catch (Exception e)
+        {
+            SentrySdk.CaptureException(e);
+            Console.WriteLine(e);
+            logger.LogError(e.Message);
+            return new OperationDataResult<List<Site>>(
+                false,
+                localizationService.GetString("ErrorWhileObtainingSites"));
+        }
+    }
+
+    /// <summary>
+    /// Builds the response <see cref="Site"/> list from a (possibly filtered) collection
+    /// of <see cref="AssignedSite"/> rows. Shared by the JSON web admin path
+    /// (<see cref="GetAvailableSitesByCurrentUser"/>) and the unfiltered mobile gRPC
+    /// path (<see cref="GetAllRegistrationSitesByCurrentUser"/>).
+    /// </summary>
+    private async Task<List<Site>> BuildSitesFromAssignedSitesAsync(
+        List<Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite> assignedSites,
+        Microting.eForm.Infrastructure.MicrotingDbContext sdkDbContext)
+    {
+        var sites = new List<Site>();
+        foreach (var assignedSite in assignedSites)
+        {
+            var site = await sdkDbContext.Sites.SingleOrDefaultAsync(x =>
+                x.MicrotingUid == assignedSite.SiteId);
+            if (site == null) continue;
+            var siteWorker = await sdkDbContext.SiteWorkers
+                .Where(x => x.SiteId == site.Id)
+                .FirstOrDefaultAsync();
+            if (siteWorker == null) continue;
+            var worker = await sdkDbContext.Workers
+                .Where(x => x.Id == siteWorker.WorkerId)
+                .FirstOrDefaultAsync();
+            if (worker == null) continue;
+            var unit = await sdkDbContext.Units.FirstOrDefaultAsync(x => x.SiteId == site.Id);
+            var language = await sdkDbContext.Languages
+                .FirstOrDefaultAsync(x => x.Id == site.LanguageId);
 
                         var today = DateTime.UtcNow.Date;
                         var midnight = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0);
@@ -545,21 +604,10 @@ public class TimeSettingService(
                         }
                         newSite.PhoneNumber = worker.PhoneNumber ?? "";
                         sites.Add(newSite);
-            }
-
-            sites = sites.OrderBy(x => x.SiteName).ToList();
-
-            return new OperationDataResult<List<Site>>(true, sites);
         }
-        catch (Exception e)
-        {
-            SentrySdk.CaptureException(e);
-            Console.WriteLine(e);
-            logger.LogError(e.Message);
-            return new OperationDataResult<List<Site>>(
-                false,
-                localizationService.GetString("ErrorWhileObtainingSites"));
-        }
+
+        sites = sites.OrderBy(x => x.SiteName).ToList();
+        return sites;
     }
 
     public async Task<OperationDataResult<Infrastructure.Models.Settings.AssignedSite>> GetAssignedSite(int siteId)


### PR DESCRIPTION
## Summary

- The flutter-time mobile "people at work" widget was receiving a filtered coworker list because `TimePlanningSettingsGrpcService.GetRegistrationSitesByCurrentUser` shared a single service method (`GetAvailableSitesByCurrentUser`) with the web admin dashboard. PR #1524 restored a manager-tag filter on that shared method which is correct for the web admin but undesirable for mobile.
- Adds `GetAllRegistrationSitesByCurrentUser` — same setup as the existing method, no manager-tag/manager-only filter, but resigned/removed/workflow-state guards still apply. The mobile gRPC handler now calls the new method.
- Web admin path unchanged; the manager-tag filter still applies to JSON callers via `TimePlanningSettingsController.GetAvailableSites` -> `GetAvailableSitesByCurrentUser`. The `eform-backendconfiguration-plugin` playwright test `time-registration-dashboard-visibility.spec.ts` therefore continues to assert against the same filtered behavior it did before.
- Result-building code shared by both methods has been extracted into a private helper `BuildSitesFromAssignedSitesAsync` to avoid duplication.
- No proto change — no flutter app release required.

## Test plan

- [ ] CI build green (`pn-test (a)` / `pn-test (b)` / `pn-playwright-test (b)`)
- [ ] New unit tests pass:
  - `GetAllRegistrationSitesByCurrentUser_ReturnsAllSites_IgnoringManagerTagFilter`
  - `GetAllRegistrationSitesByCurrentUser_StillExcludesResignedAndRemoved`
  - `GetAllRegistrationSitesByCurrentUser_NonManager_StillReceivesAllPeers`
- [ ] Existing `GetAvailableSitesByCurrentUser_*` tests still pass (filter behavior unchanged for the JSON path)
- [ ] Playwright `time-registration-dashboard-visibility.spec.ts` still passes (web admin filter intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)