### PR TITLE
fix: planning lists all sites when no managers configured

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceExtendedTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceExtendedTests.cs
@@ -581,4 +581,185 @@ public class SettingsServiceExtendedTests : TestBaseSetup
         var siteIds = result.Model.Select(x => x.SiteId).OrderBy(x => x).ToList();
         Assert.That(siteIds, Is.EqualTo(new[] { 9000, 9001, 9002 }));
     }
+
+    // --- "no managers anywhere" fallback for GetAvailableSitesByCurrentUser ---
+    // Mirror of the TimePlanningPlanningService.Index() fallback that PR #1490
+    // introduced. Both manager-tag-filter tests below need a real BaseDbContext
+    // with seeded ApplicationUser + UserRoles + SecurityGroups so the
+    // (!isAdmin) branch actually runs against a known caller. The current test
+    // fixture passes null for baseDbContext, which skips the filter block
+    // entirely and makes the manager-vs-non-manager branches unobservable
+    // here. Same fixture gap that ContentHandoverService tests carve out via
+    // [Ignore]. Behavior is exercised end-to-end by the
+    // eform-backendconfiguration-plugin playwright test
+    // (time-registration-dashboard-visibility.spec.ts) for the
+    // manager-exists path.
+
+    [Test]
+    [Ignore("Follow-up: wire real BaseDbContext seeding (ApplicationUser + UserRoles + SecurityGroups) so the (!isAdmin) branch in GetAvailableSitesByCurrentUser can be exercised. The fix itself (anyManagerExists predicate) mirrors TimePlanningPlanningService.Index() (PR #1490) and is observed end-to-end by the planning page when no AssignedSite has IsManager=true.")]
+    public async Task GetAvailableSitesByCurrentUser_NoManagersAnywhere_ReturnsAllSites()
+    {
+        // Arrange — three AssignedSites, all IsManager=false. The caller is
+        // one of the non-managers. With no manager configured anywhere in
+        // the system, the manager-tag filter should be bypassed and the full
+        // non-resigned site list should come back.
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+        var language = await sdkDbContext.Languages.FirstOrDefaultAsync();
+        if (language == null)
+        {
+            language = new Microting.eForm.Infrastructure.Data.Entities.Language
+            {
+                LanguageCode = "en",
+                Name = "English"
+            };
+            await language.Create(sdkDbContext);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            var siteUid = 11000 + i;
+            var workerUid = 11100 + i;
+            var siteWorkerUid = 11200 + i;
+            var unitUid = 11300 + i;
+
+            var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+            {
+                Name = $"NoMgr {i}",
+                MicrotingUid = siteUid,
+                LanguageId = language.Id
+            };
+            await site.Create(sdkDbContext);
+
+            var worker = new Microting.eForm.Infrastructure.Data.Entities.Worker
+            {
+                FirstName = $"NoMgr{i}",
+                LastName = "Worker",
+                Email = $"nomgr{i}@test.com",
+                MicrotingUid = workerUid
+            };
+            await worker.Create(sdkDbContext);
+
+            var siteWorker = new Microting.eForm.Infrastructure.Data.Entities.SiteWorker
+            {
+                SiteId = site.Id,
+                WorkerId = worker.Id,
+                MicrotingUid = siteWorkerUid
+            };
+            await siteWorker.Create(sdkDbContext);
+
+            var unit = new Microting.eForm.Infrastructure.Data.Entities.Unit
+            {
+                SiteId = site.Id,
+                MicrotingUid = unitUid,
+                CustomerNo = 1,
+                OtpCode = 1
+            };
+            await unit.Create(sdkDbContext);
+
+            var assigned = new AssignedSiteEntity
+            {
+                SiteId = siteUid,
+                Resigned = false,
+                IsManager = false,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            };
+            await assigned.Create(TimePlanningPnDbContext);
+        }
+
+        // Act — call as one of the non-managers (e.g. nomgr0@test.com).
+        var result = await _settingsService.GetAvailableSitesByCurrentUser();
+
+        // Assert — all three sites come back, not just the caller's own.
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(3));
+        var siteIds = result.Model.Select(x => x.SiteId).OrderBy(x => x).ToList();
+        Assert.That(siteIds, Is.EqualTo(new[] { 11000, 11001, 11002 }));
+    }
+
+    [Test]
+    [Ignore("Follow-up: wire real BaseDbContext seeding (ApplicationUser + UserRoles + SecurityGroups) so the (!isAdmin) branch in GetAvailableSitesByCurrentUser can be exercised. Manager-exists path is covered end-to-end by eform-backendconfiguration-plugin's time-registration-dashboard-visibility.spec.ts.")]
+    public async Task GetAvailableSitesByCurrentUser_ManagerExists_NonManagerSeesOnlySelf()
+    {
+        // Arrange — three AssignedSites, one of them IsManager=true. The
+        // caller is a non-manager and should be filtered down to only its
+        // own site (existing pre-fix behavior, must remain unchanged).
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+        var language = await sdkDbContext.Languages.FirstOrDefaultAsync();
+        if (language == null)
+        {
+            language = new Microting.eForm.Infrastructure.Data.Entities.Language
+            {
+                LanguageCode = "en",
+                Name = "English"
+            };
+            await language.Create(sdkDbContext);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            var siteUid = 12000 + i;
+            var workerUid = 12100 + i;
+            var siteWorkerUid = 12200 + i;
+            var unitUid = 12300 + i;
+
+            var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+            {
+                Name = $"WithMgr {i}",
+                MicrotingUid = siteUid,
+                LanguageId = language.Id
+            };
+            await site.Create(sdkDbContext);
+
+            var worker = new Microting.eForm.Infrastructure.Data.Entities.Worker
+            {
+                FirstName = $"WithMgr{i}",
+                LastName = "Worker",
+                Email = $"withmgr{i}@test.com",
+                MicrotingUid = workerUid
+            };
+            await worker.Create(sdkDbContext);
+
+            var siteWorker = new Microting.eForm.Infrastructure.Data.Entities.SiteWorker
+            {
+                SiteId = site.Id,
+                WorkerId = worker.Id,
+                MicrotingUid = siteWorkerUid
+            };
+            await siteWorker.Create(sdkDbContext);
+
+            var unit = new Microting.eForm.Infrastructure.Data.Entities.Unit
+            {
+                SiteId = site.Id,
+                MicrotingUid = unitUid,
+                CustomerNo = 1,
+                OtpCode = 1
+            };
+            await unit.Create(sdkDbContext);
+
+            var assigned = new AssignedSiteEntity
+            {
+                SiteId = siteUid,
+                Resigned = false,
+                IsManager = i == 0, // first row is the manager
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            };
+            await assigned.Create(TimePlanningPnDbContext);
+        }
+
+        // Act — call as a non-manager (e.g. withmgr1@test.com).
+        var result = await _settingsService.GetAvailableSitesByCurrentUser();
+
+        // Assert — non-manager caller is filtered down to its own site.
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(1));
+        Assert.That(result.Model[0].SiteId, Is.EqualTo(12001));
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -381,62 +381,76 @@ public class TimeSettingService(
 
                 if (!isAdmin)
                 {
-                    var worker = await sdkDbContext.Workers
-                        .Include(x => x.SiteWorkers)
-                        .ThenInclude(x => x.Site)
+                    // Mirror the "no managers anywhere" fallback that
+                    // TimePlanningPlanningService.Index() uses (PR #1490). When no worker is
+                    // flagged as a manager anywhere in the system, the manager-tag filter has
+                    // nothing to filter against and would otherwise collapse non-manager users
+                    // down to just their own site. In that degenerate state, leave the full
+                    // non-resigned site list intact so the planning page isn't empty/self-only.
+                    var anyManagerExists = await dbContext.AssignedSites
                         .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                        .FirstOrDefaultAsync(x => x.Email == currentUser.Email);
+                        .AnyAsync(x => x.IsManager);
 
-                    if (worker != null && worker.SiteWorkers.Any())
+                    if (anyManagerExists)
                     {
-                        var workerSite = worker.SiteWorkers.First().Site;
-                        var assignedSite = assignedSites
-                            .FirstOrDefault(x => x.SiteId == workerSite.MicrotingUid);
+                        var worker = await sdkDbContext.Workers
+                            .Include(x => x.SiteWorkers)
+                            .ThenInclude(x => x.Site)
+                            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                            .FirstOrDefaultAsync(x => x.Email == currentUser.Email);
 
-                        if (assignedSite != null && assignedSite.IsManager)
+                        if (worker != null && worker.SiteWorkers.Any())
                         {
-                            var managingTagIds = await dbContext.AssignedSiteManagingTags
-                                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                                .Where(x => x.AssignedSiteId == assignedSite.Id)
-                                .Select(x => x.TagId)
-                                .ToListAsync();
+                            var workerSite = worker.SiteWorkers.First().Site;
+                            var assignedSite = assignedSites
+                                .FirstOrDefault(x => x.SiteId == workerSite.MicrotingUid);
 
-                            if (managingTagIds.Any())
+                            if (assignedSite != null && assignedSite.IsManager)
                             {
-                                var taggedSiteIds = await sdkDbContext.SiteTags
-                                    .Include(x => x.Site)
+                                var managingTagIds = await dbContext.AssignedSiteManagingTags
                                     .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                                    .Where(x => managingTagIds.Contains((int)x.TagId!))
-                                    .Select(x => x.Site.MicrotingUid)
-                                    .Distinct()
+                                    .Where(x => x.AssignedSiteId == assignedSite.Id)
+                                    .Select(x => x.TagId)
                                     .ToListAsync();
 
-                                assignedSites = assignedSites
-                                    .Where(x => taggedSiteIds.Contains(x.SiteId))
-                                    .ToList();
-                                if (assignedSites.All(x => x.Id != assignedSite.Id))
+                                if (managingTagIds.Any())
                                 {
-                                    assignedSites.Add(assignedSite);
+                                    var taggedSiteIds = await sdkDbContext.SiteTags
+                                        .Include(x => x.Site)
+                                        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                                        .Where(x => managingTagIds.Contains((int)x.TagId!))
+                                        .Select(x => x.Site.MicrotingUid)
+                                        .Distinct()
+                                        .ToListAsync();
+
+                                    assignedSites = assignedSites
+                                        .Where(x => taggedSiteIds.Contains(x.SiteId))
+                                        .ToList();
+                                    if (assignedSites.All(x => x.Id != assignedSite.Id))
+                                    {
+                                        assignedSites.Add(assignedSite);
+                                    }
+                                }
+                                else
+                                {
+                                    assignedSites = [assignedSite];
                                 }
                             }
-                            else
+                            else if (assignedSite != null)
                             {
                                 assignedSites = [assignedSite];
                             }
-                        }
-                        else if (assignedSite != null)
-                        {
-                            assignedSites = [assignedSite];
+                            else
+                            {
+                                assignedSites = [];
+                            }
                         }
                         else
                         {
                             assignedSites = [];
                         }
                     }
-                    else
-                    {
-                        assignedSites = [];
-                    }
+                    // else: no managers exist anywhere -> leave assignedSites unfiltered
                 }
             }
 


### PR DESCRIPTION
## Summary
- `GetAvailableSitesByCurrentUser` in `TimeSettingService.cs` collapsed non-manager users down to "self only" even when **no worker** was flagged as manager anywhere in the system, leaving the web admin `/plugins/time-planning-pn/planning` page showing only the caller.
- Mirrors the "no managers anywhere -> show all" fallback `TimePlanningPlanningService.Index()` already got in PR #1490; the same predicate (`dbContext.AssignedSites.AnyAsync(x => x.IsManager)` over non-removed rows) is now applied here too.
- The existing manager-tag filter block from PR #1524 is unchanged - it's just wrapped in `if (anyManagerExists)`. When at least one manager exists, behavior is identical to before.

## Test plan
- [x] `dotnet clean && dotnet build` at host root - 0 errors, 129 pre-existing warnings
- [x] Added `GetAvailableSitesByCurrentUser_NoManagersAnywhere_ReturnsAllSites` and `GetAvailableSitesByCurrentUser_ManagerExists_NonManagerSeesOnlySelf` in `SettingsServiceExtendedTests.cs` - marked `[Ignore]` with the same fixture-gap rationale as `ContentHandoverServiceTests` (no real `BaseDbContext` user/role seeding available; the (!isAdmin) branch is unobservable through `null` baseDbContext)
- [ ] CI green on `fix/planning-no-manager-show-all`
- [ ] Manager-exists path stays covered by `eform-backendconfiguration-plugin` playwright `time-registration-dashboard-visibility.spec.ts` (unchanged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>