### PR TITLE
fix: persist pause clears on planning update

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanningServiceMultiShiftTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanningServiceMultiShiftTests.cs
@@ -140,4 +140,54 @@ public class PlanningServiceMultiShiftTests : TestBaseSetup
             Assert.That(reloaded.PlannedBreakOfShift5, Is.EqualTo(25));
         });
     }
+
+    [Test]
+    public async Task Update_ClearsPause1WhenSetToNull_PersistsZero()
+    {
+        // Arrange — site with simple pause editing (the buggy code path)
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 901,
+            UseDetailedPauseEditing = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        // Seed a PlanRegistration with non-zero Pause1Id (5 = 25 minutes).
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 901,
+            Date = DateTime.UtcNow.Date,
+            Pause1Id = 5,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Build the update model the way the trashcan-clear path sends it:
+        // Pause1Id = null, all other shift1 fields preserved.
+        var model = new TimePlanningPlanningPrDayModel
+        {
+            Id = planning.Id,
+            Date = planning.Date,
+            CommentOffice = "",
+            Pause1Id = null,
+            PlannedStartOfShift1 = 0, PlannedEndOfShift1 = 60, PlannedBreakOfShift1 = 5
+        };
+
+        // Act
+        var result = await _service.Update(planning.Id, model);
+
+        // Assert
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var reloaded = await TimePlanningPnDbContext.PlanRegistrations
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == planning.Id);
+
+        // The bug was: server's `?? planning.Pause1Id` kept the old 5 instead
+        // of clearing to 0. After the fix, null on the wire must persist as 0.
+        Assert.That(reloaded.Pause1Id, Is.EqualTo(0));
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -618,11 +618,11 @@ public class TimePlanningPlanningService(
 
             if (!assignedSite.UseDetailedPauseEditing)
             {
-                planning.Pause1Id = model.Pause1Id ?? planning.Pause1Id;
-                planning.Pause2Id = model.Pause2Id ?? planning.Pause2Id;
-                planning.Pause3Id = model.Pause3Id ?? planning.Pause3Id;
-                planning.Pause4Id = model.Pause4Id ?? planning.Pause4Id;
-                planning.Pause5Id = model.Pause5Id ?? planning.Pause5Id;
+                planning.Pause1Id = model.Pause1Id ?? 0;
+                planning.Pause2Id = model.Pause2Id ?? 0;
+                planning.Pause3Id = model.Pause3Id ?? 0;
+                planning.Pause4Id = model.Pause4Id ?? 0;
+                planning.Pause5Id = model.Pause5Id ?? 0;
             }
             else
             {
@@ -1175,11 +1175,11 @@ public class TimePlanningPlanningService(
 
             if (!assignedSite.UseDetailedPauseEditing)
             {
-                planning.Pause1Id = model.Pause1Id ?? planning.Pause1Id;
-                planning.Pause2Id = model.Pause2Id ?? planning.Pause2Id;
-                planning.Pause3Id = model.Pause3Id ?? planning.Pause3Id;
-                planning.Pause4Id = model.Pause4Id ?? planning.Pause4Id;
-                planning.Pause5Id = model.Pause5Id ?? planning.Pause5Id;
+                planning.Pause1Id = model.Pause1Id ?? 0;
+                planning.Pause2Id = model.Pause2Id ?? 0;
+                planning.Pause3Id = model.Pause3Id ?? 0;
+                planning.Pause4Id = model.Pause4Id ?? 0;
+                planning.Pause5Id = model.Pause5Id ?? 0;
             }
             else
             {


### PR DESCRIPTION
## Summary

- Server's `Update` (and Update/UpsertPlanning) used `planning.PauseNId = model.PauseNId ?? planning.PauseNId` in the simple-pause-editing branch, so the Angular trashcan flow that sends `pause1Id: null` had its clear silently dropped.
- Replaces the coalesce default with `0` (entity semantic for "no pause"), matching client intent.
- Adds `PlanningServiceMultiShiftTests.Update_ClearsPause1WhenSetToNull_PersistsZero` that seeds `Pause1Id = 5`, calls `Update` with `model.Pause1Id = null`, and asserts the row reloads with `Pause1Id == 0`.

## Scope check

- Detailed-pause-editing branch already uses `?? 0` for Pause3..5Id (Pause1/2 are computed from minute totals there) — left alone.
- All `Start1..5Id`/`Stop1..5Id` assignments already use `?? 0` — left alone.

## Test plan

- [ ] CI green
- [ ] Manual: open planning page, click trashcan on a pause column, confirm DB row's `Pause1Id` becomes 0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>