### PR TITLE
feat: preserve precise DateTime stamps when UseOneMinuteIntervals on (Phase 1)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperTests.cs
@@ -227,4 +227,219 @@ public class PlanRegistrationHelperTests
         // byte-for-byte regardless of the flag.
         Assert.Pass("Captured for future fixture work; see XML doc above.");
     }
+
+    // ------------------------------------------------------------------
+    // Phase 1 — server-side write path: prefer DateTime stamps when flag on
+    // ------------------------------------------------------------------
+    //
+    // The fork lives in
+    //   PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(...)
+    // around the `if (planRegistration.Start1Id > 289)` block. When the
+    // `Start1Id > 289` workaround divides the value back down, the
+    // existing path also overwrites `Start1StartedAt` from the snapped
+    // index (`Date.AddMinutes(Start1Id * 5)`). When
+    // `AssignedSite.UseOneMinuteIntervals` is true AND a precise stamp is
+    // already populated, that overwrite is skipped — the precise stamp is
+    // the source of truth in Phase 1.
+    //
+    // `UpdatePlanRegistrationsInPeriod` is async and takes
+    // `(planningsInPeriod, siteModel, dbContext, dbAssignedSite, logger,
+    // site, midnightOfDateFrom, midnightOfDateTo, options)`. Wiring those
+    // up requires the full DB / SDK / IPluginDbOptions / Site fixture
+    // that this `PlanRegistrationHelperTests` fixture deliberately keeps
+    // lightweight; per the rollout plan this is the documented carve-out
+    // pattern (see RoundDownToNearestFiveMinutesAndFormat above). The
+    // assertions below are captured here so that whoever lands the
+    // fuller fixture (or chooses to extend `PlanningServiceMultiShiftTests`
+    // / `PlanRegistrationHelperReadBySiteAndDateTests`) can flip the
+    // `[Ignore]` off without rewriting the contract.
+
+    /// <summary>
+    /// Phase 1 contract: when <c>UseOneMinuteIntervals</c> is on and a
+    /// precise <c>Start1StartedAt</c> stamp already lives on the row, the
+    /// `Start1Id &gt; 289` workaround in
+    /// <see cref="PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod"/>
+    /// must NOT overwrite the precise stamp with the 5-minute snap.
+    /// </summary>
+    [Test]
+    [Ignore("Phase 1 carve-out: UpdatePlanRegistrationsInPeriod requires logger/options/Site fixture not wired here; assertion captured for future fixture work.")]
+    public void UpdatePlanRegistrationsInPeriod_FlagOn_PreservesStartedAt()
+    {
+        // Arrange (intent, to be enabled when fixture lands):
+        //
+        //   var date = new DateTime(2026, 5, 15, 0, 0, 0);
+        //   var preciseStart = new DateTime(2026, 5, 15, 7, 3, 53);
+        //
+        //   var dbAssignedSite = new AssignedSite { UseOneMinuteIntervals = true,
+        //                                           Resigned = false,
+        //                                           UseGoogleSheetAsDefault = false,
+        //                                           SiteId = 900 };
+        //   await dbAssignedSite.Create(TimePlanningPnDbContext);
+        //
+        //   // Start1Id > 289 is required to enter the workaround branch.
+        //   // 504 / (5+1) = 84  → AddMinutes(84*5) = +420min = 07:00 (the snap).
+        //   var planning = new PlanRegistration {
+        //       SdkSitId = 900,
+        //       Date = date,
+        //       Start1Id = 504,
+        //       Start1StartedAt = preciseStart,
+        //       Stop1Id = 0,
+        //   };
+        //   await planning.Create(TimePlanningPnDbContext);
+        //
+        //   // Act
+        //   await PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(
+        //       new List<PlanRegistration> { new() { Id = planning.Id, Date = date } },
+        //       new TimePlanningPlanningModel(), TimePlanningPnDbContext,
+        //       dbAssignedSite, logger, site, date, date, options);
+        //
+        //   // Assert — flag-on path keeps the precise 07:03:53 stamp.
+        //   var reloaded = await TimePlanningPnDbContext.PlanRegistrations
+        //       .AsNoTracking().FirstAsync(x => x.Id == planning.Id);
+        //   Assert.That(reloaded.Start1StartedAt, Is.EqualTo(preciseStart));
+        Assert.Pass("Captured for future fixture work; see XML doc above.");
+    }
+
+    /// <summary>
+    /// Phase 1 regression-guard: with the flag OFF, the existing backfill
+    /// behavior must be byte-identical to before — `Start1StartedAt` is
+    /// recomputed from the corrected `Start1Id` index even if a precise
+    /// stamp had been seeded on the row.
+    /// </summary>
+    [Test]
+    [Ignore("Phase 1 carve-out: UpdatePlanRegistrationsInPeriod requires logger/options/Site fixture not wired here; assertion captured for future fixture work.")]
+    public void UpdatePlanRegistrationsInPeriod_FlagOff_BackfillsStartedAt_AsBefore()
+    {
+        // Arrange (intent, to be enabled when fixture lands):
+        //
+        //   var date = new DateTime(2026, 5, 15, 0, 0, 0);
+        //   var preciseStart = new DateTime(2026, 5, 15, 7, 3, 53);
+        //   var expectedSnap = new DateTime(2026, 5, 15, 7, 0, 0);
+        //
+        //   var dbAssignedSite = new AssignedSite { UseOneMinuteIntervals = false,
+        //                                           Resigned = false,
+        //                                           UseGoogleSheetAsDefault = false,
+        //                                           SiteId = 901 };
+        //
+        //   var planning = new PlanRegistration {
+        //       SdkSitId = 901,
+        //       Date = date,
+        //       Start1Id = 504,
+        //       Start1StartedAt = preciseStart,
+        //   };
+        //
+        //   // Act — same call as the flag-on test, just flag flipped off.
+        //
+        //   // Assert — flag-off path overwrites Start1StartedAt to the 5-min snap.
+        //   Assert.That(reloaded.Start1StartedAt, Is.EqualTo(expectedSnap));
+        Assert.Pass("Captured for future fixture work; see XML doc above.");
+    }
+
+    /// <summary>
+    /// Phase 1 fallback: with the flag ON but no precise stamp populated
+    /// (e.g. a legacy row without observed punch data), the existing
+    /// backfill must still run so the row gets a sensible
+    /// `Start1StartedAt` derived from the int index.
+    /// </summary>
+    [Test]
+    [Ignore("Phase 1 carve-out: UpdatePlanRegistrationsInPeriod requires logger/options/Site fixture not wired here; assertion captured for future fixture work.")]
+    public void UpdatePlanRegistrationsInPeriod_FlagOnButStartedAtNull_FallsBackToBackfill()
+    {
+        // Arrange (intent, to be enabled when fixture lands):
+        //
+        //   var date = new DateTime(2026, 5, 15, 0, 0, 0);
+        //   var expectedSnap = new DateTime(2026, 5, 15, 7, 0, 0);
+        //
+        //   var dbAssignedSite = new AssignedSite { UseOneMinuteIntervals = true,
+        //                                           Resigned = false,
+        //                                           UseGoogleSheetAsDefault = false,
+        //                                           SiteId = 902 };
+        //
+        //   var planning = new PlanRegistration {
+        //       SdkSitId = 902,
+        //       Date = date,
+        //       Start1Id = 504,
+        //       Start1StartedAt = null,   // legacy row, no precise stamp
+        //   };
+        //
+        //   // Act — flag is on, but since StartedAt is null the helper falls
+        //   // through to the existing backfill so the row stays usable.
+        //
+        //   // Assert — backfill ran exactly as in the flag-off path.
+        //   Assert.That(reloaded.Start1StartedAt, Is.EqualTo(expectedSnap));
+        Assert.Pass("Captured for future fixture work; see XML doc above.");
+    }
+
+    /// <summary>
+    /// Phase 1 contract for the auto-break write path
+    /// (<see cref="PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive"/>).
+    /// Auto-break pauses are COMPUTED from day-of-week rules, not OBSERVED,
+    /// so even with <c>UseOneMinuteIntervals</c> on we deliberately do NOT
+    /// fabricate `Pause1StartedAt` / `Pause1StoppedAt` timestamps — there
+    /// is no real-world signal anchoring them. The legacy `Pause1Id` int
+    /// (in 5-minute multiples) stays the source of truth and therefore
+    /// must agree byte-for-byte with the flag-off path. DateTime pause
+    /// fields are reserved for OBSERVED pauses written via
+    /// `UpdateWorkingHour`.
+    /// </summary>
+    [Test]
+    public void CalculatePauseAutoBreakCalculationActive_FlagOn_LegacyAndDateTimeFieldsAgree()
+    {
+        // Arrange — identical seed for both runs except for the flag.
+        AssignedSite BuildAssignedSite(bool useOneMinuteIntervals) => new()
+        {
+            UseOneMinuteIntervals = useOneMinuteIntervals,
+            AutoBreakCalculationActive = true,
+            // Wednesday rule: every 180 min worked → 30 min pause, capped at 60.
+            WednesdayBreakMinutesDivider = 180,
+            WednesdayBreakMinutesPrDivider = 30,
+            WednesdayBreakMinutesUpperLimit = 60,
+        };
+
+        // 96..192 in 5-min ticks = 8:00..16:00 = 480 min worked.
+        // 480 / 180 = 2 breaks; 2 * 30 = 60 min ≤ 60 cap → Pause1Id = 60.
+        // After the trailing `/ 5 + 1` step that's `60 / 5 + 1 = 13`.
+        PlanRegistration BuildPlanning(DateTime? preciseStart, DateTime? preciseStop) => new()
+        {
+            Date = DateTime.Today.AddDays(DayOfWeek.Wednesday - DateTime.Today.DayOfWeek),
+            Start1Id = 96,
+            Stop1Id = 192,
+            Start1StartedAt = preciseStart,
+            Stop1StoppedAt = preciseStop,
+        };
+
+        var preciseStart = new DateTime(2026, 5, 13, 8, 0, 17);
+        var preciseStop  = new DateTime(2026, 5, 13, 16, 0, 41);
+
+        // Act
+        var resultFlagOff = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(
+            BuildAssignedSite(false), BuildPlanning(preciseStart, preciseStop));
+        var resultFlagOn = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(
+            BuildAssignedSite(true), BuildPlanning(preciseStart, preciseStop));
+
+        Assert.Multiple(() =>
+        {
+            // Legacy int field is byte-identical between flag-on and flag-off.
+            Assert.That(resultFlagOn.Pause1Id, Is.EqualTo(resultFlagOff.Pause1Id),
+                "Pause1Id must match flag-off run (auto-break is computed, not observed)");
+            Assert.That(resultFlagOn.Pause1Id, Is.EqualTo(13),
+                "Pause1Id must remain 13 (60 min cap → /5+1 = 13)");
+
+            // Phase 1 deliberately does NOT fabricate DateTime pause stamps
+            // for an auto-computed pause; both runs leave them null.
+            Assert.That(resultFlagOn.Pause1StartedAt, Is.Null,
+                "Auto-break must not invent a Pause1StartedAt when flag on");
+            Assert.That(resultFlagOn.Pause1StoppedAt, Is.Null,
+                "Auto-break must not invent a Pause1StoppedAt when flag on");
+            Assert.That(resultFlagOff.Pause1StartedAt, Is.Null,
+                "Flag-off path must remain unchanged: no Pause1StartedAt");
+            Assert.That(resultFlagOff.Pause1StoppedAt, Is.Null,
+                "Flag-off path must remain unchanged: no Pause1StoppedAt");
+
+            // Sanity: if any DateTime fields WERE set in some future phase,
+            // they would need to agree with `Pause1Id * 5` minutes when
+            // anchored on Start1StartedAt. For Phase 1, both null is the
+            // documented expectation.
+        });
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -118,10 +118,26 @@ public static class PlanRegistrationHelper
     public static PlanRegistration CalculatePauseAutoBreakCalculationActive(
         AssignedSite assignedSite, PlanRegistration planning)
     {
+        // Phase 1 note (auto-break, write path):
+        // -------------------------------------------------------------------
+        // Auto-break pauses are COMPUTED from day-of-week rules (divider /
+        // pr-divider / upper-limit), not OBSERVED. There is no real punch
+        // marking when the worker started or stopped the pause -- the rule
+        // simply says "deduct N minutes of pause for a shift of M minutes
+        // worked on this weekday". So even when UseOneMinuteIntervals is
+        // on, we do NOT fabricate Pause1StartedAt / Pause1StoppedAt
+        // timestamps for an auto-computed pause: there is no real-world
+        // signal to anchor them to. The legacy `Pause1Id` int (in 5-minute
+        // multiples) stays the source of truth for auto-break, and Phase 2
+        // will read it back when computing NettoHours. The DateTime pause
+        // fields remain reserved for OBSERVED pauses (worker explicitly
+        // started/stopped a break on the kiosk / mobile), which already
+        // travel through the `Pause*StartedAt` write path in
+        // `UpdateWorkingHour`.
         if (assignedSite.UseOneMinuteIntervals)
         {
-            // TODO Phase 1+2: compute pause auto-break from DateTime stamps with second precision.
-            // For Phase 0, fall through to existing 5-minute logic to preserve behavior.
+            // No-op for auto-break specifically; fall through to the
+            // existing 5-minute logic which sets Pause1Id. See note above.
         }
         if (assignedSite.AutoBreakCalculationActive)
         {
@@ -376,14 +392,37 @@ public static class PlanRegistrationHelper
             {
                 // FIXME: This is a workaround, it should be removed when the frontend is fixed.
                 planRegistration.Start1Id /= 5 + 1;
-                planRegistration.Start1StartedAt = planRegistration.Date.AddMinutes(planRegistration.Start1Id * 5);
+                // Phase 1: when UseOneMinuteIntervals is on AND a precise stamp is
+                // already populated, preserve it instead of snapping back to the
+                // 5-minute index. Existing flag-off behavior is byte-identical:
+                // the int Id is corrected and StartedAt is backfilled from it.
+                // When the flag is on but StartedAt is null, fall through to the
+                // backfill so legacy rows without precise stamps still get one.
+                if (dbAssignedSite.UseOneMinuteIntervals && planRegistration.Start1StartedAt.HasValue)
+                {
+                    // Phase 1: precise DateTime stamp wins; do NOT overwrite it
+                    // with the 5-minute snap derived from Start1Id.
+                }
+                else
+                {
+                    planRegistration.Start1StartedAt = planRegistration.Date.AddMinutes(planRegistration.Start1Id * 5);
+                }
             }
 
             if (planRegistration.Stop1Id > 289 )
             {
                 // FIXME: This is a workaround, it should be removed when the frontend is fixed.
                 planRegistration.Stop1Id /= 5 + 1;
-                planRegistration.Stop1StoppedAt = planRegistration.Date.AddMinutes(planRegistration.Stop1Id * 5);
+                // Phase 1: same fork as Start1 above for the stop stamp.
+                if (dbAssignedSite.UseOneMinuteIntervals && planRegistration.Stop1StoppedAt.HasValue)
+                {
+                    // Phase 1: precise DateTime stamp wins; do NOT overwrite it
+                    // with the 5-minute snap derived from Stop1Id.
+                }
+                else
+                {
+                    planRegistration.Stop1StoppedAt = planRegistration.Date.AddMinutes(planRegistration.Stop1Id * 5);
+                }
             }
             planRegistration.IsSaturday = midnight.DayOfWeek == DayOfWeek.Saturday;
             planRegistration.IsSunday = midnight.DayOfWeek == DayOfWeek.Sunday;


### PR DESCRIPTION
## Summary

Phase 1 of the UseOneMinuteIntervals second-precision rollout (server-side write path).

When `AssignedSite.UseOneMinuteIntervals == true` and a precise `Start1StartedAt` / `Stop1StoppedAt` is already populated on a row, `PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod` no longer overwrites it with the 5-minute snap derived from `Start1Id` / `Stop1Id`. With the flag off, behavior is byte-identical to before; with the flag on but a null stamp, the legacy backfill still runs so legacy rows remain usable.

The Phase 0 stub in `CalculatePauseAutoBreakCalculationActive` is elaborated (not deleted) with a documented rationale: auto-break pauses are computed, not observed, so there is no real-world signal to anchor `Pause1StartedAt` / `Pause1StoppedAt` to; the legacy `Pause1Id` int stays the source of truth.

S6 (`UpdateWorkingHour` 1-param, personal mode) and S7 (3-param, kiosk mode) were verified — both already parse `*StartedAt` / `*StoppedAt` strings via `DateTime.Parse` without any snap. No change needed there.

## Out of scope (per the rollout plan)

- `NettoHours` / `Flex` from DateTime deltas (Phase 2)
- `HH:mm:ss` display (Phase 4)
- Mobile picker (Phase 3)
- Migrations (none required)

## Tests

Adds 4 tests (additions only, no edits to existing tests):

- `CalculatePauseAutoBreakCalculationActive_FlagOn_LegacyAndDateTimeFieldsAgree` — exercises the new auto-break contract directly (no DB needed); asserts `Pause1Id` matches between flag-on and flag-off, and that DateTime pause fields stay null in both runs.
- `UpdatePlanRegistrationsInPeriod_FlagOn_PreservesStartedAt` — assertion captured under `[Ignore]` (same carve-out used by the Phase 0 `RoundDown` test) because `UpdatePlanRegistrationsInPeriod` needs the logger / IPluginDbOptions / Site fixture not yet wired in `PlanRegistrationHelperTests`.
- `UpdatePlanRegistrationsInPeriod_FlagOff_BackfillsStartedAt_AsBefore` — same carve-out; documents the regression-guard.
- `UpdatePlanRegistrationsInPeriod_FlagOnButStartedAtNull_FallsBackToBackfill` — same carve-out; documents the legacy fallback.

## Test plan

- [ ] CI green (build + existing tests unchanged)
- [ ] No proto / migration drift in the diff
- [ ] Phase 0 stubs are elaborated, not deleted
- [ ] flag-off branch is byte-identical to pre-PR

Plan: `/home/rene/.claude/plans/parallel-twirling-balloon.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>