### PR TITLE
fix(time-planning): null-guard model param in Update — second NRE site

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanningServiceMultiShiftTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanningServiceMultiShiftTests.cs
@@ -311,4 +311,56 @@ public class PlanningServiceMultiShiftTests : TestBaseSetup
             Assert.That(reloaded.NettoHoursInSeconds, Is.EqualTo(11520 - 1500));
         });
     }
+
+    /// <summary>
+    /// Regression for the second NRE site PR #1545's b1m playwright variant
+    /// surfaced after PR #1546 patched the `currentUserAsync.Id` site.
+    ///
+    /// Server stack frame on b1m round 5 confirmed that `[FromBody] model`
+    /// itself can be null when the front-end PUTs a body that fails model-
+    /// binding (the dashboard sends a partial-actual-only payload that the
+    /// server treats as an empty body in some branches). The first dereference
+    /// in Update() — `planning.PlannedStartOfShift1 = model.PlannedStartOfShift1`
+    /// — then NRE'd inside the catch block as a generic 200/{success:false}.
+    ///
+    /// Post-fix: the call returns Success = false WITHOUT throwing. The
+    /// localized "ErrorWhileUpdatingPlanning" message is matched here because
+    /// the test's _localizationService is wired to echo the key back.
+    /// </summary>
+    [Test]
+    public async Task Update_NullModel_ReturnsFailureWithoutException()
+    {
+        // Arrange — seed an AssignedSite + PlanRegistration so any code path
+        // that dereferences `planning` after the null-model guard would still
+        // have something to work with. The fix must short-circuit BEFORE
+        // those lookups, but seeding makes the test robust against future
+        // refactors that move the guard around.
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 903,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 903,
+            Date = DateTime.UtcNow.Date,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act — simulate the [FromBody] null path. Must not throw.
+        var result = await _service.Update(planning.Id, null);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Success, Is.False,
+            "Update(null) must return a failure result, not silently succeed.");
+        Assert.That(result.Message, Is.EqualTo("ErrorWhileUpdatingPlanning"),
+            "Localization key must match the existing catch-block fallback so " +
+            "the front-end's error surfacing is unchanged.");
+    }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -586,6 +586,21 @@ public class TimePlanningPlanningService(
     {
         try
         {
+            // Phase 2/5 fix (PR #1545 b1m round 5): the dashboard fires a PUT
+            // with only off-grid actual stamps and no planning fields. When
+            // model-binding falls through (malformed/empty body), [FromBody]
+            // hands us a null model and the very next line — model.Planned-
+            // StartOfShift1 — NRE'd inside the catch block as a generic
+            // "ErrorWhileUpdatingPlanning" 200/{success:false}. Returning a
+            // structured failure instead lets the front-end surface a real
+            // validation error rather than silently retrying the save.
+            if (model == null)
+            {
+                return new OperationResult(
+                    false,
+                    localizationService.GetString("ErrorWhileUpdatingPlanning"));
+            }
+
             var currentUserAsync = await userService.GetCurrentUserAsync();
             var planning = dbContext.PlanRegistrations
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)


### PR DESCRIPTION
## Summary

Second NRE site in `TimePlanningPlanningService.Update`. PR #1546 patched the first (`currentUserAsync.Id`); PR #1545's b1m playwright variant round 5 then surfaced this one at line 612: `planning.PlannedStartOfShift1 = model.PlannedStartOfShift1`. The server stack frame confirmed `[FromBody] model` itself is null when the dashboard PUTs a body that fails model-binding (edit carries only off-grid actual stamps, no planning fields).

The catch block swallowed the NRE as a generic 200/{success:false}, the front-end stopped firing the follow-up `/index` POST, and the playwright spec timed out.

## What & why

- Add explicit null-guard at top of `Update()`'s `try` block. Returns `OperationResult(false, "ErrorWhileUpdatingPlanning")`, matching the existing catch-block fallback so the front-end's error surfacing is unchanged.
- Happy-path behavior is byte-identical: `if (model == null) return failure;` only fires on the malformed-body path; non-null inputs flow into the same code as before, no reordering.
- Add `Update_NullModel_ReturnsFailureWithoutException` to `PlanningServiceMultiShiftTests`. Asserts `Success == false`, no exception, message matches the existing localization key.

## Refs

- Builds on #1546 (first NRE site)
- Unblocks #1545 b1m playwright variant

## Test plan

- [x] `dotnet clean && dotnet build` passes (0 errors, 129 warnings, all pre-existing)
- [ ] CI: dotnet-ubuntu green
- [ ] CI: playwright shards green (b1m on PR #1545 after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)