### PR TITLE
fix(playwright): enable shifts 3-5 in 1m variant post-migration

### DIFF
--- a/eform-client/playwright/e2e/plugins/time-planning-pn/b1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/b1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/c1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/c1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/d1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/d1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/e1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/e1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/f1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/f1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/h1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/h1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/i1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/i1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/j1m/post-migration.sql
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/j1m/post-migration.sql
@@ -10,4 +10,9 @@
 -- shard exercises the flag-on rendering / form / picker code paths. The
 -- workflow runs this AFTER `Wait for app` (which gates on migrations being
 -- complete) and BEFORE the matrix Playwright invocation.
-UPDATE AssignedSites SET UseOneMinuteIntervals = 1 WHERE WorkflowState = 'created';
+UPDATE AssignedSites
+SET UseOneMinuteIntervals = 1,
+    ThirdShiftActive = 1,
+    FourthShiftActive = 1,
+    FifthShiftActive = 1
+WHERE WorkflowState = 'created';


### PR DESCRIPTION
## Summary

- Extends each `*1m` shard's `post-migration.sql` (b1m, c1m, d1m, e1m, f1m, h1m, i1m, j1m) to flip `ThirdShiftActive`, `FourthShiftActive`, and `FifthShiftActive` on alongside `UseOneMinuteIntervals` for every active `AssignedSites` row.
- Discovered through the 9-PR UseOneMinuteIntervals rollout: `UseOneMinuteIntervals = 1` only enables the worker-side flag — shifts 3-5 inputs in the workday-entity-dialog are gated by separate per-site boolean columns (added by base migration `20250226060341_Adding3MoreShifts`).
- Without this fix, variant specs that fill all 5 shifts (e.g. multishift round-trip clones) can't exercise shifts 3-5 at all, leaving them as UI-hidden inputs.

## Why

This unblocks FU-B / FU-C variant specs by removing the UI shift-gating constraint at the seed level instead of forcing each spec to navigate per-site settings dialogs.

## Risk surface

- Touches only Playwright variant shard SQL — no production code, no schema changes.
- Non-1m b shard has no `post-migration.sql` and no `420_*.sql` seed in this directory, so its flag-off behavior is untouched.
- Column names verified against `Microting.TimePlanningBase/Infrastructure/Data/Entities/AssignedSite.cs`.

## Test plan

- [ ] CI green on all 1m matrix shards (b1m, c1m, d1m, e1m, f1m, h1m, i1m, j1m).
- [ ] No regression on non-1m shards (b, c, d, ...).