### PR TITLE
chore(playwright): make retries: 0 explicit + document fail-fast intent

### DIFF
--- a/eform-client/playwright.config.ts
+++ b/eform-client/playwright.config.ts
@@ -3,6 +3,14 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: 'playwright/e2e',
   workers: 1,
+  // Explicit fail-fast — do NOT raise this. Shard b's specs form a chain of
+  // cumulative state mutations on a shared worker / week range with no
+  // per-spec DB reset; retrying through a partial failure stacks writes and
+  // produces confusing cascade failures downstream (e.g. expected 88.36, got
+  // 156.38 from a doubled WorkingHours pass). The actual fix for the
+  // underlying flake source belongs in test isolation (worker isolation OR
+  // a test-only reset endpoint), not in masking via retries.
+  retries: 0,
   use: {
     baseURL: 'http://localhost:4200',
     viewport: { width: 1920, height: 1080 },


### PR DESCRIPTION
## Summary

One-line config change to `eform-client/playwright.config.ts` plus a leading comment documenting why retries should never be raised. **No behavior change** — Playwright's default is already `retries: 0`. Just makes intent explicit.

## Why

Shard b's specs form a chain of cumulative state mutations (`dashboard-assert` → `dashboard-edit-a` → `dashboard-edit-b`) on a shared worker and shared week ranges with no per-spec DB reset. If retries get enabled to "stabilize" CI, a partial failure in one spec stacks its writes on top of the prior pass — downstream specs then see corrupted cumulative baselines (e.g. expected `88.36`, got `156.38` from a doubled-pass WorkingHours accumulation). The cascade buries the actual culprit under collateral damage.

Fail-fast forces the first flaky test to surface immediately, where triage is focused. Real flake-source fix (worker isolation / test-only reset endpoint / direct SQL cleanup) is a follow-up.

## Risk

None. Default is already 0; this change just blocks future "let's add retries: 1 to stabilize" attempts via the explicit comment.

## Test plan

- [ ] CI green on this PR (no actual playwright behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)