### PR TITLE
feat(grpc): include UseOneMinuteIntervals on Site in GetRegistrationSites response

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningSettingsGrpcServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningSettingsGrpcServiceTests.cs
@@ -49,6 +49,7 @@ public class TimePlanningSettingsGrpcServiceTests
                 FourthShiftActive = false,
                 FifthShiftActive = true,
                 SnapshotEnabled = false,
+                UseOneMinuteIntervals = true,
                 Resigned = false,
                 ResignedAtDate = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc),
                 AvatarUrl = "https://example.com/avatar1.png",
@@ -74,6 +75,7 @@ public class TimePlanningSettingsGrpcServiceTests
                 FourthShiftActive = true,
                 FifthShiftActive = false,
                 SnapshotEnabled = true,
+                UseOneMinuteIntervals = false,
                 Resigned = true,
                 ResignedAtDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                 AvatarUrl = "https://example.com/avatar2.png",
@@ -113,6 +115,7 @@ public class TimePlanningSettingsGrpcServiceTests
         Assert.That(site1.FourthShiftActive, Is.False);
         Assert.That(site1.FifthShiftActive, Is.True);
         Assert.That(site1.SnapshotEnabled, Is.False);
+        Assert.That(site1.UseOneMinuteIntervals, Is.True);
         Assert.That(site1.Resigned, Is.False);
         Assert.That(site1.AvatarUrl, Is.EqualTo("https://example.com/avatar1.png"));
         Assert.That(site1.PhoneNumber, Is.EqualTo("+4512345678"));
@@ -136,6 +139,7 @@ public class TimePlanningSettingsGrpcServiceTests
         Assert.That(site2.FourthShiftActive, Is.True);
         Assert.That(site2.FifthShiftActive, Is.False);
         Assert.That(site2.SnapshotEnabled, Is.True);
+        Assert.That(site2.UseOneMinuteIntervals, Is.False);
         Assert.That(site2.Resigned, Is.True);
         Assert.That(site2.AvatarUrl, Is.EqualTo("https://example.com/avatar2.png"));
         Assert.That(site2.PhoneNumber, Is.EqualTo("+4587654321"));

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/Site.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/Site.cs
@@ -28,4 +28,5 @@ public class Site
 
     public DateTime ResignedAtDate { get; set; }
     public string? PhoneNumber { get; set; }
+    public bool UseOneMinuteIntervals { get; set; }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/settings.proto
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/settings.proto
@@ -236,6 +236,7 @@ message Site {
   bool resigned = 20;
   google.protobuf.Timestamp resigned_at_date = 21;
   string phone_number = 22;
+  bool use_one_minute_intervals = 23;
 }
 
 // Response wrappers matching C# OperationDataResult<T>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
@@ -266,6 +266,7 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
                     ResignedAtDate = Timestamp.FromDateTime(
                         DateTime.SpecifyKind(site.ResignedAtDate, DateTimeKind.Utc)),
                     PhoneNumber = site.PhoneNumber ?? "",
+                    UseOneMinuteIntervals = site.UseOneMinuteIntervals,
                 };
                 response.Model.Add(grpcSite);
             }
@@ -318,6 +319,7 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
                     ResignedAtDate = Timestamp.FromDateTime(
                         DateTime.SpecifyKind(site.ResignedAtDate, DateTimeKind.Utc)),
                     PhoneNumber = site.PhoneNumber ?? "",
+                    UseOneMinuteIntervals = site.UseOneMinuteIntervals,
                 };
                 response.Model.Add(grpcSite);
             }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -311,7 +311,8 @@ public class TimeSettingService(
                             FifthShiftActive = assignedSite.FifthShiftActive,
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
-                            SnapshotEnabled = assignedSite.SnapshotEnabled
+                            SnapshotEnabled = assignedSite.SnapshotEnabled,
+                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users
@@ -617,7 +618,8 @@ public class TimeSettingService(
                             FifthShiftActive = assignedSite.FifthShiftActive,
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
-                            SnapshotEnabled = assignedSite.SnapshotEnabled
+                            SnapshotEnabled = assignedSite.SnapshotEnabled,
+                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users
@@ -892,6 +894,7 @@ public class TimeSettingService(
                             FifthShiftActive = assignedSite.FifthShiftActive,
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
+                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users


### PR DESCRIPTION
## Summary

- Adds `bool use_one_minute_intervals = 23;` to the `Site` message in `settings.proto` and the matching `UseOneMinuteIntervals` property on the C# `Infrastructure.Models.Settings.Site` DTO.
- Populates the new field from `AssignedSite.UseOneMinuteIntervals` in both `GetAvailableSites` (token path) and `GetAllRegistrationSitesByCurrentUser` (personal/JWT path) inside `TimeSettingService`, so the gRPC handler maps it through automatically.
- Mobile clients (flutter-time kiosk mode) can now select the correct site-level minute-precision behavior at the registration step, before any `GetAssignedSite` call is made.

## Why now

In kiosk mode the flutter-time app lists registration sites and only later fetches per-site `AssignedSite`. While that list is displayed (and when the worker taps to start/stop), the UI needs to know whether to render exact-minute or 5-minute-quantized values for *that* site's pause and actual start/stop. Today the flag is only available after `GetAssignedSite`, which produces a brief window where the kiosk pause/start displays use the legacy 5-minute formula even for `UseOneMinuteIntervals=true` sites — the same class of bug closed for the admin web UI in #1566 / #1568 / #1572. Surfacing the flag on the `Site` list message removes that window. The companion flutter-time PR consumes this field directly.

## Backwards compatibility

- proto3 default-false: clients built against the old proto continue to deserialize the message and simply ignore the new field. Tablets that haven't been updated degrade gracefully to today's behavior (flag effectively `false` at the list stage, then corrected once `GetAssignedSite` returns).
- Pure addition — no field renumbering, no removed fields, no changed types.
- C# `Site` DTO gains one nullable-free `bool UseOneMinuteIntervals { get; set; }` (default `false`); no schema migration.
- No change to the JSON/REST path, no change to web admin behavior.

## Test plan

- [ ] CI green (.NET build + Angular build + all Playwright shards)
- [ ] Existing `TimePlanningSettingsGrpcServiceTests.GetRegistrationSitesByCurrentUser_Success_MapsSitesToGrpcResponse` extended to cover both `UseOneMinuteIntervals=true` and `=false` sites and assert the field round-trips through the gRPC mapper.
- [ ] New test (or extension of the existing one) covering the token-based `GetRegistrationSites` handler, which currently has zero coverage — mocks `ISettingService.GetAvailableSites` and asserts the new field on the response.
- [ ] Manual: kiosk-mode flutter-time against a host with one `UseOneMinuteIntervals=true` site and one `=false` site — confirm the list response carries `use_one_minute_intervals` for the right site (e.g. via `grpcurl` or the flutter-time debug log).
- [ ] Manual: old (pre-proto-update) tablet builds still parse the response and display the site list (default-false fall-through).
