### PR TITLE
style(absence-requests): proper segmented view-switcher buttons

### DIFF
--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/absence-requests/components/absence-requests-container/absence-requests-container.component.scss
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/absence-requests/components/absence-requests-container/absence-requests-container.component.scss
@@ -1,9 +1,41 @@
+// Segmented control / tab-style switcher used in the subheader to flip
+// between the Inbox and "My requests" views.
+//
+// .btn-secondary alone gives plain <button> elements the browser-default
+// `border: 2px outset black` in both workspace and classic themes (no
+// `--icon-left` variant fires the proper outlined styles), and the prior
+// .active rule referenced an undefined `--primary-color` token. Override
+// both with explicit outlined/filled states pinned to the canonical
+// `--mdc-theme-primary` token used by .btn-primary across the app.
 .view-switcher {
   display: flex;
   gap: 8px;
-}
 
-.btn-secondary.active {
-  background-color: var(--primary-color);
-  color: white;
+  .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    padding: 0 16px;
+    background: transparent;
+    color: var(--mdc-theme-primary);
+    border: 1px solid var(--mdc-theme-primary);
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover:not(.active) {
+      background-color: color-mix(in srgb, var(--mdc-theme-primary) 8%, transparent);
+    }
+
+    &.active {
+      background-color: var(--mdc-theme-primary);
+      // !important needed: the workspace .btn-secondary rule paints color
+      // with !important, otherwise on-primary white loses the cascade.
+      color: var(--mdc-theme-on-primary, #fff) !important;
+    }
+  }
 }

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/absence-requests/components/absence-requests-container/absence-requests-container.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/absence-requests/components/absence-requests-container/absence-requests-container.component.ts
@@ -14,6 +14,7 @@ import { selectAuthUser } from 'src/app/state';
 @Component({
   selector: 'app-absence-requests-container',
   templateUrl: './absence-requests-container.component.html',
+  styleUrls: ['./absence-requests-container.component.scss'],
   standalone: false
 })
 export class AbsenceRequestsContainerComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## Summary

Fix the Inbox / Mine anmodninger view-switcher buttons at \`/plugins/time-planning-pn/absence-requests\` which were rendering with browser-default \`border: 2px outset rgb(0, 0, 0)\`.

## Root cause

Three intertwined issues:

1. The \`@Component\` decorator never declared \`styleUrls\`. The sibling \`absence-requests-container.component.scss\` existed but was never loaded.
2. \`.btn-secondary\` on a plain \`<button>\` does not trigger the workspace theme's \`--icon-left\` outlined styles, so no border/bg/color CSS fired.
3. The pre-existing \`.active\` rule referenced an undefined \`--primary-color\` token.

## Fixes

- Wire \`styleUrls: ['./absence-requests-container.component.scss']\` on the \`@Component\` so the colocated stylesheet loads.
- Replace the stub \`.view-switcher\` rule with explicit segmented-control styles scoped to \`.view-switcher .btn-secondary\`:
  - **inactive**: 40px outlined pill, \`--mdc-theme-primary\` border + text, transparent background, primary-tinted hover
  - **\`.active\`**: filled \`--mdc-theme-primary\` background with \`--mdc-theme-on-primary\` text. The active text color carries \`!important\` to defeat the workspace \`.btn-secondary { color: var(--md-primary) !important }\` rule.

## Verified

Playwright \`getComputedStyle\` after the fix:

| Button | bg | color | border |
|---|---|---|---|
| Indbakke (active) | \`rgb(11, 87, 208)\` | \`rgb(255, 255, 255)\` | \`1px solid rgb(11, 87, 208)\` |
| Mine anmodninger (inactive) | transparent | \`rgb(11, 87, 208)\` | \`1px solid rgb(11, 87, 208)\` |

Both 40px tall, same baseline.

## Test plan

- [ ] \`/plugins/time-planning-pn/absence-requests\` on workspace theme: switcher renders as a clean segmented control.
- [ ] Click Mine anmodninger → it becomes filled blue with white text, Indbakke becomes outlined.
- [ ] No regression on classic theme (rules use \`--mdc-theme-primary\` which both themes expose).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)