### PR TITLE
style(request-history): align layout with property-workers pattern

### DIFF
--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.html
@@ -1,44 +1,41 @@
-<eform-new-subheader>
-  <div class="subheader-title">
-    {{ 'Request History' | translate }}
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ 'Request History' | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12" id="time-planning-pn-request-history-filters">
+    <mat-form-field>
+      <mat-label>{{ 'Type' | translate }}</mat-label>
+      <select matNativeControl [(ngModel)]="filterType" id="requestHistoryTypeFilter">
+        <option value="">{{ 'All' | translate }}</option>
+        <option value="Handover">{{ 'Handover' | translate }}</option>
+        <option value="Absence">{{ 'Absence' | translate }}</option>
+      </select>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'Status' | translate }}</mat-label>
+      <select matNativeControl [(ngModel)]="filterStatus" id="requestHistoryStatusFilter">
+        <option value="">{{ 'All' | translate }}</option>
+        <option value="Pending">{{ 'Pending' | translate }}</option>
+        <option value="Approved">{{ 'Approved' | translate }}</option>
+        <option value="Rejected">{{ 'Rejected' | translate }}</option>
+        <option value="Cancelled">{{ 'Cancelled' | translate }}</option>
+      </select>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'Date From' | translate }}</mat-label>
+      <input matInput type="date" [(ngModel)]="filterFromDate" id="requestHistoryFromDate" />
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'Date To' | translate }}</mat-label>
+      <input matInput type="date" [(ngModel)]="filterToDate" id="requestHistoryToDate" />
+    </mat-form-field>
+
+    <button mat-raised-button color="primary" (click)="applyFilters()" id="applyFiltersBtn">
+      {{ 'Apply' | translate }}
+    </button>
   </div>
-</eform-new-subheader>
-
-<div class="filter-bar" id="time-planning-pn-request-history-filters">
-  <mat-form-field>
-    <mat-label>{{ 'Type' | translate }}</mat-label>
-    <select matNativeControl [(ngModel)]="filterType" id="requestHistoryTypeFilter">
-      <option value="">{{ 'All' | translate }}</option>
-      <option value="Handover">{{ 'Handover' | translate }}</option>
-      <option value="Absence">{{ 'Absence' | translate }}</option>
-    </select>
-  </mat-form-field>
-
-  <mat-form-field>
-    <mat-label>{{ 'Status' | translate }}</mat-label>
-    <select matNativeControl [(ngModel)]="filterStatus" id="requestHistoryStatusFilter">
-      <option value="">{{ 'All' | translate }}</option>
-      <option value="Pending">{{ 'Pending' | translate }}</option>
-      <option value="Approved">{{ 'Approved' | translate }}</option>
-      <option value="Rejected">{{ 'Rejected' | translate }}</option>
-      <option value="Cancelled">{{ 'Cancelled' | translate }}</option>
-    </select>
-  </mat-form-field>
-
-  <mat-form-field>
-    <mat-label>{{ 'Date From' | translate }}</mat-label>
-    <input matInput type="date" [(ngModel)]="filterFromDate" id="requestHistoryFromDate" />
-  </mat-form-field>
-
-  <mat-form-field>
-    <mat-label>{{ 'Date To' | translate }}</mat-label>
-    <input matInput type="date" [(ngModel)]="filterToDate" id="requestHistoryToDate" />
-  </mat-form-field>
-
-  <button mat-raised-button color="primary" (click)="applyFilters()" id="applyFiltersBtn">
-    {{ 'Apply' | translate }}
-  </button>
-</div>
+</mat-card>
 
 <mtx-grid
   [data]="filteredRows"

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.scss
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/components/request-history-page/request-history-page.component.scss
@@ -1,23 +1,3 @@
-.filter-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  // align-items: end matches the canonical toolbar pattern used elsewhere
-  // (eforms-page, property-workers, etc.) so the input pills and the
-  // Apply button share a baseline. The workspace theme's mat-slide-toggle
-  // rule and stacked label still work above.
-  align-items: end;
-  padding: 16px;
-
-  // Without this, each mat-form-field stretches to the full row width
-  // (1100+px) and forces every filter onto its own line. Cap each to
-  // 200px so all four fit on a single row next to the Apply button.
-  mat-form-field {
-    width: auto;
-    max-width: 200px;
-  }
-}
-
 .type-badge {
   display: inline-block;
   padding: 2px 8px;

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/request-history.module.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/request-history/request-history.module.ts
@@ -8,6 +8,7 @@ import { MtxGrid } from '@ng-matero/extensions/grid';
 import { FormsModule } from '@angular/forms';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
+import { MatCard } from '@angular/material/card';
 import {
   RequestHistoryPageComponent
 } from './components';
@@ -23,7 +24,8 @@ import {
     FormsModule,
     MatFormField,
     MatInput,
-    MatLabel
+    MatLabel,
+    MatCard
   ],
   declarations: [
     RequestHistoryPageComponent


### PR DESCRIPTION
## Summary

Two structural fixes to \`/plugins/time-planning-pn/request-history\` so it matches the canonical layout used at \`/plugins/backend-configuration-pn/property-workers\`:

1. **One title only.** The page rendered \`Anmodningshistorik\` twice — once as the page-title \`h2\` from \`<eform-new-subheader>\`'s \`[title]\` input, and again via a projected \`<div class="subheader-title">\` inside the same subheader.
2. **Filters right-aligned inside the same card.** The filters lived in a separate \`.filter-bar\` div below the subheader. Property-workers keeps the title and the filter row inside a single \`.eform-sub-header\` mat-card with the filters \`justify-content: end\`.

## Restructure

\`\`\`html
<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3"
          style="align-items: stretch;">
  <h2 style="margin: 0">{{ 'Request History' | translate }}</h2>
  <div class="d-flex flex-row flex-wrap align-items-end
              justify-content-end gap-12">
    <!-- Type / Status / Date From / Date To / Apply -->
  </div>
</mat-card>
\`\`\`

Drop the now-unused \`.filter-bar\` and \`.subheader-title\` SCSS rules.

## Test plan

- [ ] \`/plugins/time-planning-pn/request-history\` renders a single title \`Anmodningshistorik\` on the left.
- [ ] Type / Status / Date From / Date To filters + Apply button are right-aligned inside the same card.
- [ ] Applying filters still works.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)