### PR TITLE
fix: guard ConfigureDbContext() Migrate() with IHistoryRepository (Galera-safe)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/EformTimePlanningPlugin.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/EformTimePlanningPlugin.cs
@@ -55,6 +55,8 @@ using Infrastructure.Data.Seed.Data;
 using Infrastructure.Models.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microting.eFormApi.BasePn;
@@ -189,7 +191,11 @@ public class EformTimePlanningPlugin : IEformPlugin
         var contextFactory = new TimePlanningPnContextFactory();
         var context = contextFactory.CreateDbContext(new[] { connectionString });
         Console.WriteLine("Starting to migrate TimePlanningPnDbContext to latest version");
-        context.Database.Migrate();
+        var historyRepo = context.GetService<IHistoryRepository>();
+        if (!historyRepo.Exists() || context.Database.GetPendingMigrations().Any())
+        {
+            context.Database.Migrate();
+        }
         Console.WriteLine("TimePlanningPnDbContext migrated to latest version");
 
         // Seed database


### PR DESCRIPTION
## Summary

- Wrap `Database.Migrate()` in `ConfigureDbContext()` with an `IHistoryRepository.Exists()` guard to eliminate unnecessary DDL on every API pod restart

## Why

On a MariaDB 11.4 Galera cluster with ~250 tenants, `Database.Migrate()` issues DDL (`CREATE TABLE IF NOT EXISTS __EFMigrationsHistory`, `GET_LOCK`) on every app restart even when the schema is already current. With multiple pods per tenant this causes cluster-wide desync/resync on every rolling update.

The guard pattern:
- `IHistoryRepository.Exists()` — safe `information_schema` read, returns false if history table is absent
- `GetPendingMigrations().Any()` — only called when the table exists
- `Database.Migrate()` — called **only** when needed: fresh install, or pending migrations

In production (schema current): no DDL, no `GET_LOCK`. On fresh plugin activation: falls through and creates the schema.

## Test Plan
- [ ] Plugin activates from UI correctly (schema created on first activation)
- [ ] Subsequent pod restarts do not trigger DDL when schema is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)