### PR TITLE
feat: add Dagsoversigt day-overview sheet to timeplanning Excel exports

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -256,9 +256,9 @@ jobs:
           - name: f
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
     steps:
     - uses: actions/checkout@v3
     - name: Create docker network

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -245,9 +245,9 @@ jobs:
           - name: f
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
     steps:
     - uses: actions/checkout@v3
     - name: Create docker network

--- a/docs/superpowers/plans/2026-06-09-dagsoversigt-export-sheet.md
+++ b/docs/superpowers/plans/2026-06-09-dagsoversigt-export-sheet.md
@@ -1,0 +1,684 @@
+# Dagsoversigt Export Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new "Dagsoversigt" (Day overview) worksheet as the first tab in both the single-worker and all-workers timeplanning Excel exports, replicating the layout and formatting of the reference file.
+
+**Architecture:** A single shared private builder `BuildDayOverviewWorksheet` produces a fully-referenced, banded Excel-Table worksheet from a flat list of `DayOverviewRow` items. Both export methods construct the row list (single-worker from its `timePlannings`; all-workers by flattening `perSiteCache`, sorted by date then employee no.) and create the sheet as relationship `rId1`, shifting the existing parts' relationship ids accordingly. The sheet name is localized via a new `Translations.DayOverview` resx key; all 21 column headers reuse existing resx keys.
+
+**Tech Stack:** C# / .NET 10, DocumentFormat.OpenXml 3.5.1 (raw SDK), NUnit 4 + Testcontainers.MariaDb test project. Dev mode: edit in host-app mirror `eform-angular-frontend/eFormAPI/Plugins/TimePlanning.Pn/`, then `devgetchanges.sh` back to the source repo before committing.
+
+**Key file (all line numbers below refer to it unless stated):**
+`eform-angular-frontend/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs`
+
+**Reference fixed 21-column layout** (always all 5 shifts):
+`Employee no` · `Worker` · `DayOfWeek` · `Date` · `Week number` · `Shift 1: start/end/pause` … `Shift 5: start/end/pause` · `NettoHours`. All map to existing resx keys (verified: `Employee no`→"Medarbejder nr.", `Shift 1: end`→"Skift 1: stop", `NettoHours`→"Timer netto").
+
+---
+
+## Task 1: Add the `DayOverview` translation key (sheet name)
+
+**Files (host-app mirror `…/TimePlanning.Pn/TimePlanning.Pn/Resources/`):**
+- Modify: `Translations.resx` (neutral / English)
+- Modify: `Translations.Designer.cs` (add strongly-typed accessor)
+- Modify: `Translations.da.resx` … and all 24 other culture `.resx` files
+
+Existing keys use natural-language `data name` strings with spaces/colons; the neutral
+`Translations.Designer.cs` accessor calls `ResourceManager.GetString("<data name>", resourceCulture)`.
+For the new key use a space-free name `DayOverview` so the accessor name equals the key.
+
+- [ ] **Step 1: Add the neutral entry to `Translations.resx`**
+
+Insert alongside the other `<data>` elements:
+
+```xml
+  <data name="DayOverview" xml:space="preserve">
+    <value>Day overview</value>
+  </data>
+```
+
+- [ ] **Step 2: Add the strongly-typed accessor to `Translations.Designer.cs`**
+
+Add this property inside the `internal class Translations { … }` body (match the existing block style, e.g. next to `NettoHours`):
+
+```csharp
+        internal static string DayOverview {
+            get {
+                return ResourceManager.GetString("DayOverview", resourceCulture);
+            }
+        }
+```
+
+- [ ] **Step 3: Add the translated value to every culture `.resx` file**
+
+Add a `<data name="DayOverview" xml:space="preserve"><value>…</value></data>` entry to each file, using these values (the `data name` MUST be identical across all files):
+
+| File | value |
+|------|-------|
+| `Translations.da.resx` | Dagsoversigt |
+| `Translations.de.resx` | Tagesübersicht |
+| `Translations.nl-NL.resx` | Dagoverzicht |
+| `Translations.sv-SE.resx` | Dagsöversikt |
+| `Translations.no-NO.resx` | Dagsoversikt |
+| `Translations.fi-FI.resx` | Päiväkatsaus |
+| `Translations.fr-FR.resx` | Aperçu de la journée |
+| `Translations.es-ES.resx` | Resumen diario |
+| `Translations.it-IT.resx` | Riepilogo giornaliero |
+| `Translations.pt-BR.resx` | Resumo diário |
+| `Translations.pt-PT.resx` | Resumo diário |
+| `Translations.pl-PL.resx` | Przegląd dnia |
+| `Translations.et-EE.resx` | Päevaülevaade |
+| `Translations.lv-LV.resx` | Dienas pārskats |
+| `Translations.lt-LT.resx` | Dienos apžvalga |
+| `Translations.ro-RO.resx` | Rezumat zilnic |
+| `Translations.hr-HR.resx` | Dnevni pregled |
+| `Translations.sl-SI.resx` | Dnevni pregled |
+| `Translations.cs-CZ.resx` | Denní přehled |
+| `Translations.sk-SK.resx` | Denný prehľad |
+| `Translations.hu-HU.resx` | Napi áttekintés |
+| `Translations.bg-BG.resx` | Дневен преглед |
+| `Translations.el-GR.resx` | Ημερήσια επισκόπηση |
+| `Translations.is-IS.resx` | Dagsyfirlit |
+| `Translations.uk-UA.resx` | Огляд за день |
+
+> Flag for user review (lower confidence): `fi-FI`, `ro-RO`, `uk-UA`, `el-GR`. All values are < 31 chars and contain no Excel-illegal sheet-name chars (`: \ / ? * [ ]`).
+
+- [ ] **Step 4: Verify the project still builds**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj`
+Expected: Build succeeded (the resx files compile into satellite assemblies; the new accessor resolves).
+
+- [ ] **Step 5: Commit** (in the source repo after `devgetchanges.sh`; see Task 7. For now, do not commit — accumulate changes and commit once at the end of the cycle.)
+
+---
+
+## Task 2: Add the new cell styles to the stylesheet
+
+**Files:**
+- Modify: `…/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OpenXMLHelper.cs` — `GenerateWorkbookStylesPart1Content`
+
+Current state (verified): no `NumberingFormats` element exists; `CellFormats.Count = 3U` with
+StyleIndex 0 = default, 1 = bold header, 2 = date (built-in numFmtId 14, locale short date).
+Adding new styles at indices 3/4/5 leaves existing indices untouched, so the other sheets are
+unaffected. Schema order requires `NumberingFormats` to be appended **before** `Fonts`.
+
+- [ ] **Step 1: Add a `NumberingFormats` element with custom formats**
+
+Find the line that creates `CellFormats cellFormats1 = new CellFormats(){ Count = (UInt32Value)3U };` (line ~128). Immediately before the existing `Fonts`/stylesheet construction, add:
+
+```csharp
+            NumberingFormats numberingFormats1 = new NumberingFormats() { Count = (UInt32Value)2U };
+            numberingFormats1.Append(new NumberingFormat() { NumberFormatId = (UInt32Value)164U, FormatCode = "dd/mm/yyyy" });
+            numberingFormats1.Append(new NumberingFormat() { NumberFormatId = (UInt32Value)165U, FormatCode = "hh:mm" });
+```
+
+(Place this declaration wherever the other style-element declarations are; it gets appended to the stylesheet in Step 3.)
+
+- [ ] **Step 2: Add three new `CellFormat` entries and bump the count**
+
+Change the count and append three formats after the existing `cellFormats1.Append(cellFormat4);`:
+
+```csharp
+            CellFormats cellFormats1 = new CellFormats(){ Count = (UInt32Value)6U };
+            CellFormat cellFormat2 = new CellFormat(){ NumberFormatId = (UInt32Value)0U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U };
+            CellFormat cellFormat3 = new CellFormat(){ NumberFormatId = (UInt32Value)0U, FontId = (UInt32Value)1U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyFont = true };
+            CellFormat cellFormat4 = new CellFormat(){ NumberFormatId = (UInt32Value)14U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+            // New: StyleIndex 3 = time hh:mm
+            CellFormat cellFormat5 = new CellFormat(){ NumberFormatId = (UInt32Value)165U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+            // New: StyleIndex 4 = number 0.00 (built-in numFmtId 2)
+            CellFormat cellFormat6 = new CellFormat(){ NumberFormatId = (UInt32Value)2U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+            // New: StyleIndex 5 = date dd/mm/yyyy (custom numFmtId 164)
+            CellFormat cellFormat7 = new CellFormat(){ NumberFormatId = (UInt32Value)164U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+
+            cellFormats1.Append(cellFormat2);
+            cellFormats1.Append(cellFormat3);
+            cellFormats1.Append(cellFormat4);
+            cellFormats1.Append(cellFormat5);
+            cellFormats1.Append(cellFormat6);
+            cellFormats1.Append(cellFormat7);
+```
+
+- [ ] **Step 3: Append `NumberingFormats` first in the stylesheet append block**
+
+In the `stylesheet1.Append(...)` sequence (lines ~161-169), add as the **first** append (before the fonts append):
+
+```csharp
+            stylesheet1.Append(numberingFormats1);
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj`
+Expected: Build succeeded.
+
+---
+
+## Task 3: Add the builder, DTO, and helpers
+
+**Files:**
+- Modify: `…/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs`
+- Test: `…/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs` (new, added in Task 6)
+
+Add a private nested DTO, a pure time-fraction helper, referenced-cell helpers, and the
+worksheet builder. `GetColumnLetter(int)` (existing, 1-based, returns "A" for 1 … "U" for 21) is reused.
+
+- [ ] **Step 1: Add the `DayOverviewRow` DTO**
+
+Add next to the existing `private sealed class AllWorkersSiteCache` (line ~3901):
+
+```csharp
+    private sealed class DayOverviewRow
+    {
+        public string EmployeeNo { get; set; }
+        public string WorkerName { get; set; }
+        public DateTime Date { get; set; }
+        public TimePlanningWorkingHoursModel Planning { get; set; }
+        public bool UseOneMinuteIntervals { get; set; }
+    }
+```
+
+- [ ] **Step 2: Add the pure time-fraction helper**
+
+The shift int fields (`Shift1Start` etc.) are a 1-based index into a 288-entry 5-minute grid
+(`(index-1)*5` minutes; `289` is the special 24:00). When `useOneMinuteIntervals` and a stamp
+exist, use the stamp's time-of-day. Returns `null` for an absent shift (→ empty, formatted cell).
+
+```csharp
+    internal double? GetShiftTimeFraction(int? shift, DateTime? actualStamp, bool useOneMinuteIntervals)
+    {
+        if (useOneMinuteIntervals && actualStamp.HasValue)
+        {
+            return actualStamp.Value.TimeOfDay.TotalMinutes / 1440.0;
+        }
+        if (!shift.HasValue || shift.Value <= 0)
+        {
+            return null;
+        }
+        if (shift.Value == 289)
+        {
+            return 1.0; // 24:00 — end of day; renders as 00:00 under hh:mm (known minor edge)
+        }
+        return (shift.Value - 1) * 5 / 1440.0;
+    }
+```
+
+- [ ] **Step 3: Add referenced-cell helpers**
+
+These set `CellReference` (required for cells inside an Excel Table):
+
+```csharp
+    private Cell DayOverviewStringCell(int col, uint rowIdx, string value)
+    {
+        return new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(value ?? string.Empty),
+            DataType = CellValues.String
+        };
+    }
+
+    private Cell DayOverviewNumberCell(int col, uint rowIdx, double value, uint? styleIndex)
+    {
+        var cell = new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)),
+            DataType = CellValues.Number
+        };
+        if (styleIndex.HasValue)
+        {
+            cell.StyleIndex = styleIndex.Value;
+        }
+        return cell;
+    }
+
+    private Cell DayOverviewDateCell(int col, uint rowIdx, DateTime date)
+    {
+        return new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(date.ToOADate().ToString(CultureInfo.InvariantCulture)),
+            DataType = CellValues.Number,
+            StyleIndex = (UInt32Value)5U // dd/mm/yyyy
+        };
+    }
+
+    private Cell DayOverviewTimeCell(int col, uint rowIdx, double? fraction)
+    {
+        var cell = new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            DataType = CellValues.Number,
+            StyleIndex = (UInt32Value)3U // hh:mm
+        };
+        if (fraction.HasValue)
+        {
+            cell.CellValue = new CellValue(fraction.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        return cell;
+    }
+```
+
+- [ ] **Step 4: Add the `BuildDayOverviewWorksheet` builder**
+
+```csharp
+    private void BuildDayOverviewWorksheet(WorksheetPart worksheetPart, List<DayOverviewRow> rows, CultureInfo culture)
+    {
+        const int colCount = 21;
+        var headers = new[]
+        {
+            Translations.Employee_no, Translations.Worker, Translations.DayOfWeek,
+            Translations.Date, Translations.Week_number,
+            Translations.Shift_1__start, Translations.Shift_1__end, Translations.Shift_1__pause,
+            Translations.Shift_2__start, Translations.Shift_2__end, Translations.Shift_2__pause,
+            Translations.Shift_3__start, Translations.Shift_3__end, Translations.Shift_3__pause,
+            Translations.Shift_4__start, Translations.Shift_4__end, Translations.Shift_4__pause,
+            Translations.Shift_5__start, Translations.Shift_5__end, Translations.Shift_5__pause,
+            Translations.NettoHours
+        };
+
+        var worksheet = new Worksheet()
+            { MCAttributes = new MarkupCompatibilityAttributes() { Ignorable = "x14ac xr xr2 xr3" } };
+        worksheet.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        worksheet.AddNamespaceDeclaration("mc", "http://schemas.openxmlformats.org/markup-compatibility/2006");
+        worksheet.AddNamespaceDeclaration("x14ac", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac");
+        worksheet.AddNamespaceDeclaration("xr", "http://schemas.microsoft.com/office/spreadsheetml/2014/revision");
+        worksheet.AddNamespaceDeclaration("xr2", "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2");
+        worksheet.AddNamespaceDeclaration("xr3", "http://schemas.microsoft.com/office/spreadsheetml/2016/revision3");
+
+        var sheetFormatProperties = new SheetFormatProperties() { DefaultRowHeight = 15D, DyDescent = 0.25D };
+
+        var columns = new Columns();
+        columns.Append(new Column() { Min = 1U, Max = 1U, Width = 18D, CustomWidth = true });
+        columns.Append(new Column() { Min = 2U, Max = 2U, Width = 15D, CustomWidth = true });
+        columns.Append(new Column() { Min = 3U, Max = 3U, Width = 10D, CustomWidth = true });
+        columns.Append(new Column() { Min = 4U, Max = 4U, Width = 11D, CustomWidth = true });
+        columns.Append(new Column() { Min = 5U, Max = 5U, Width = 8D, CustomWidth = true });
+        columns.Append(new Column() { Min = 6U, Max = 20U, Width = 13.5D, CustomWidth = true });
+        columns.Append(new Column() { Min = 21U, Max = 21U, Width = 12D, CustomWidth = true });
+
+        var sheetData = new SheetData();
+
+        var headerRow = new Row() { RowIndex = (UInt32Value)1U };
+        for (int c = 0; c < colCount; c++)
+        {
+            headerRow.Append(new Cell
+            {
+                CellReference = $"{GetColumnLetter(c + 1)}1",
+                CellValue = new CellValue(headers[c]),
+                DataType = CellValues.String,
+                StyleIndex = (UInt32Value)1U
+            });
+        }
+        sheetData.Append(headerRow);
+
+        uint rowIndex = 2;
+        foreach (var row in rows)
+        {
+            var dataRow = new Row() { RowIndex = rowIndex };
+            int c = 1;
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.EmployeeNo));
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.WorkerName));
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.Date.ToString("dddd", culture)));
+            dataRow.Append(DayOverviewDateCell(c++, rowIndex, row.Date));
+            var weekNumber = culture.Calendar.GetWeekOfYear(row.Date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
+            dataRow.Append(DayOverviewNumberCell(c++, rowIndex, weekNumber, null));
+
+            var p = row.Planning;
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Start, p.Start1StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Stop, p.Stop1StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Start, p.Start2StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Stop, p.Stop2StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Start, p.Start3StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Stop, p.Stop3StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Start, p.Start4StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Stop, p.Stop4StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Start, p.Start5StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Stop, p.Stop5StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Pause, null, row.UseOneMinuteIntervals)));
+
+            var netto = p.NettoHoursOverrideActive ? p.NettoHoursOverride : p.NettoHours;
+            dataRow.Append(DayOverviewNumberCell(c, rowIndex, netto, (UInt32Value)4U));
+
+            sheetData.Append(dataRow);
+            rowIndex++;
+        }
+
+        uint lastRow = rowIndex - 1; // header-only when no data => 1
+        string reference = $"A1:{GetColumnLetter(colCount)}{lastRow}";
+
+        var pageMargins = new PageMargins() { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
+
+        worksheet.Append(sheetFormatProperties);
+        worksheet.Append(columns);
+        worksheet.Append(sheetData);
+        worksheet.Append(pageMargins);
+
+        var tableDefinitionPart = worksheetPart.AddNewPart<TableDefinitionPart>("rIdDayOverviewTable");
+        var table = new Table()
+        {
+            Id = (UInt32Value)1U,
+            Name = "DayOverview",
+            DisplayName = "DayOverview",
+            Reference = reference,
+            TotalsRowShown = false
+        };
+        table.Append(new AutoFilter() { Reference = reference });
+        var tableColumns = new TableColumns() { Count = (UInt32Value)(uint)colCount };
+        for (uint tc = 1; tc <= colCount; tc++)
+        {
+            tableColumns.Append(new TableColumn() { Id = (UInt32Value)tc, Name = headers[tc - 1] });
+        }
+        table.Append(tableColumns);
+        table.Append(new TableStyleInfo()
+        {
+            Name = "TableStyleMedium2",
+            ShowFirstColumn = false,
+            ShowLastColumn = false,
+            ShowRowStripes = true,
+            ShowColumnStripes = false
+        });
+        tableDefinitionPart.Table = table;
+
+        var tableParts = new TableParts() { Count = (UInt32Value)1U };
+        tableParts.Append(new TablePart() { Id = "rIdDayOverviewTable" });
+        worksheet.Append(tableParts);
+
+        worksheetPart.Worksheet = worksheet;
+    }
+```
+
+- [ ] **Step 5: Confirm required usings are present**
+
+`System.Globalization` (CultureInfo, CalendarWeekRule), `System.Linq`, the OpenXml Spreadsheet namespace, and `TimePlanning.Pn.Resources` are already imported in this file (the existing export uses all of them). No new `using` needed. Build to confirm:
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj`
+Expected: Build succeeded.
+
+---
+
+## Task 4: Wire the single-worker export
+
+**Files:**
+- Modify: `…/TimePlanningWorkingHoursService.cs` `GenerateExcelDashboard(TimePlanningWorkingHoursRequestModel)` (lines ~2421-2433)
+
+In-scope variables already available: `site`, `worker` (with `worker.EmployeeNo`), `assignedSite`
+(with `.UseOneMinuteIntervals`), `timePlannings` (List<TimePlanningWorkingHoursModel>), `culture`.
+
+rId remap: Dagsoversigt = rId1, Dashboard = rId2, Theme = rId3, Styles = rId4.
+
+- [ ] **Step 1: Register two sheets and shift the part rIds**
+
+Replace lines 2425-2433:
+
+```csharp
+                OpenXMLHelper.GenerateWorkbookPart1Content(workbookPart1,
+                    [new(Translations.DayOverview, "rId1"), new("Dashboard", "rId2")]);
+
+                WorkbookStylesPart workbookStylesPart1 = workbookPart1.AddNewPart<WorkbookStylesPart>("rId4");
+                OpenXMLHelper.GenerateWorkbookStylesPart1Content(workbookStylesPart1);
+
+                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>("rId3");
+                OpenXMLHelper.GenerateThemePart1Content(themePart1);
+
+                // Dagsoversigt (Day overview) — first tab
+                WorksheetPart dayOverviewWorksheetPart = workbookPart1.AddNewPart<WorksheetPart>("rId1");
+                var dayOverviewRows = timePlannings.Select(p => new DayOverviewRow
+                {
+                    EmployeeNo = worker.EmployeeNo ?? string.Empty,
+                    WorkerName = site.Name,
+                    Date = p.Date,
+                    Planning = p,
+                    UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
+                }).ToList();
+                BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
+
+                WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>("rId2");
+```
+
+(The remainder of the method — building the Dashboard sheet on `worksheetPart1` — is unchanged.)
+
+- [ ] **Step 2: Build to verify**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj`
+Expected: Build succeeded.
+
+---
+
+## Task 5: Wire the all-workers export
+
+**Files:**
+- Modify: `…/TimePlanningWorkingHoursService.cs` `GenerateExcelDashboard(TimePlanningWorkingHoursReportForAllWorkersRequestModel)` (lines ~2955-3081)
+
+rId remap: Dagsoversigt = rId1, Total = rId2, per-site = rId{i+3}, Theme = rId{count+3}, Styles = rId{count+4}.
+
+- [ ] **Step 1: Insert Dagsoversigt into `worksheetNames` and shift the rest**
+
+Replace lines 2960-2972:
+
+```csharp
+                var worksheetNames = new List<KeyValuePair<string, string>>();
+                worksheetNames.Add(new KeyValuePair<string, string>(Translations.DayOverview, "rId1"));
+                worksheetNames.Add(new KeyValuePair<string, string>("Total", "rId2"));
+
+                for (int i = 0; i < siteIdCount; i++)
+                {
+                    var site = await sdkContext.Sites.SingleOrDefaultAsync(x =>
+                        x.MicrotingUid == siteIds[i] && x.WorkflowState != Constants.WorkflowStates.Removed);
+                    if (site == null) continue;
+                    worksheetNames.Add(
+                        new KeyValuePair<string, string>($"{site.Name.Substring(0, Math.Min(31, site.Name.Length))}",
+                            $"rId{i + 3}"));
+                }
+```
+
+- [ ] **Step 2: Shift Theme/Styles part rIds**
+
+Replace lines 2977-2982:
+
+```csharp
+                WorkbookStylesPart workbookStylesPart1 =
+                    workbookPart1.AddNewPart<WorkbookStylesPart>($"rId{siteIdCount + 4}");
+                OpenXMLHelper.GenerateWorkbookStylesPart1Content(workbookStylesPart1);
+
+                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>($"rId{siteIdCount + 3}");
+                OpenXMLHelper.GenerateThemePart1Content(themePart1);
+```
+
+- [ ] **Step 3: Build the Dagsoversigt sheet (rId1) right after the Theme part**
+
+Insert immediately after the `GenerateThemePart1Content(themePart1);` line from Step 2 and before `#region TotalSheetSetup`:
+
+```csharp
+                #region DayOverviewSheetSetup
+
+                WorksheetPart dayOverviewWorksheetPart = workbookPart1.AddNewPart<WorksheetPart>("rId1");
+                var dayOverviewRows = new List<DayOverviewRow>();
+                for (int i = 0; i < siteIdCount; i++)
+                {
+                    var doSite = await sdkContext.Sites.FirstOrDefaultAsync(x => x.MicrotingUid == siteIds[i]);
+                    if (doSite == null) continue;
+                    var doSiteWorker = await sdkContext.SiteWorkers.FirstAsync(x => x.SiteId == doSite.Id);
+                    var doWorker = await sdkContext.Workers.FirstAsync(x => x.Id == doSiteWorker.WorkerId);
+                    perSiteCache.TryGetValue(siteIds[i], out var doCache);
+                    var doPlannings = doCache?.TimePlannings ?? new List<TimePlanningWorkingHoursModel>();
+                    var doUseOneMinute = doCache?.AssignedSite?.UseOneMinuteIntervals ?? false;
+                    foreach (var planning in doPlannings)
+                    {
+                        dayOverviewRows.Add(new DayOverviewRow
+                        {
+                            EmployeeNo = doWorker.EmployeeNo ?? string.Empty,
+                            WorkerName = doSite.Name,
+                            Date = planning.Date,
+                            Planning = planning,
+                            UseOneMinuteIntervals = doUseOneMinute
+                        });
+                    }
+                }
+                dayOverviewRows = dayOverviewRows
+                    .OrderBy(r => r.Date)
+                    .ThenBy(r => int.TryParse(r.EmployeeNo, out var n) ? n : int.MaxValue)
+                    .ThenBy(r => r.EmployeeNo)
+                    .ToList();
+                BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
+
+                #endregion
+```
+
+- [ ] **Step 4: Shift the Total and per-site worksheet part rIds**
+
+- Line 2986: `WorksheetPart totalWorksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId1");` → `$"rId2"`.
+- Line 3081: `WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId{i + 2}");` → `$"rId{i + 3}"`.
+
+- [ ] **Step 5: Build to verify**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj`
+Expected: Build succeeded.
+
+---
+
+## Task 6: Tests
+
+**Files:**
+- Test: `…/TimePlanning.Pn/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs` (new)
+
+Follow the existing `WorkingHoursExcelExportE2ETests` conventions: NUnit 4 (`[TestFixture]`,
+`[Test]`, `Assert.That`), extend the same base setup, seed via the same helpers, open the produced
+xlsx with `SpreadsheetDocument.Open`, and assert positionally. The localization substitute returns
+the key as the value, so under that fixture the sheet name resolves to the resx-backed value via
+`Translations.DayOverview` + `CurrentUICulture` (set inside the export). Note `ValidateExcel`
+swallows errors, so assertions must read the file directly.
+
+> Before writing, open `WorkingHoursExcelExportE2ETests.cs` and copy its `[SetUp]`, the seed
+> helper (`SeedSiteAndPlanRegistration`), and the cell-reading helper pattern so the new fixture
+> matches exactly (constructor wiring of `IUserService`, `ITimePlanningLocalizationService`,
+> `IEFormCoreService`, `TimePlanningPnDbContext`, `IPluginDbOptions`).
+
+- [ ] **Step 1: Unit test the pure time-fraction helper**
+
+`GetShiftTimeFraction` is `internal`. If the test project already has `InternalsVisibleTo` for it (check `TimePlanning.Pn.csproj` / any `AssemblyInfo`), test it directly; otherwise add `[assembly: InternalsVisibleTo("TimePlanning.Pn.Test")]` to the plugin (e.g. in `EformTimePlanningPlugin.cs` top or a new `AssemblyInfo.cs`). Test:
+
+```csharp
+[Test]
+public void GetShiftTimeFraction_FiveMinuteIndex_Returns_TimeOfDayFraction()
+{
+    var service = /* the same _service instance the fixture builds */;
+    // index 97 => (97-1)*5 = 480 min = 08:00 => 480/1440 = 0.3333...
+    Assert.That(service.GetShiftTimeFraction(97, null, false), Is.EqualTo(480.0 / 1440.0).Within(1e-9));
+    Assert.That(service.GetShiftTimeFraction(null, null, false), Is.Null);
+    Assert.That(service.GetShiftTimeFraction(0, null, false), Is.Null);
+    Assert.That(service.GetShiftTimeFraction(289, null, false), Is.EqualTo(1.0));
+    // one-minute stamp path: 08:04 => (8*60+4)/1440
+    Assert.That(service.GetShiftTimeFraction(0, new DateTime(2026, 5, 15, 8, 4, 0), true),
+        Is.EqualTo((8 * 60 + 4) / 1440.0).Within(1e-9));
+}
+```
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet test Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/TimePlanning.Pn.Test.csproj --filter GetShiftTimeFraction`
+Expected: PASS.
+
+- [ ] **Step 2: Single-worker — Dagsoversigt is the first sheet with the right header**
+
+```csharp
+[Test]
+public async Task SingleWorker_FirstSheet_IsDagsoversigt_WithFixedHeader()
+{
+    await SeedSiteAndPlanRegistration(
+        siteUid: 9801, date: new DateTime(2026, 5, 14),
+        useOneMinuteIntervals: false, start1: null, stop1: null, start1Id: 85, stop1Id: 181);
+
+    var result = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+    {
+        SiteId = 9801, DateFrom = new DateTime(2026, 5, 14), DateTo = new DateTime(2026, 5, 14),
+    });
+
+    Assert.That(result.Success, Is.True, result.Message);
+    using var doc = SpreadsheetDocument.Open(result.Model!, false);
+    var sheets = doc.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().ToList();
+    Assert.That(sheets.First().Name!.Value, Is.EqualTo("Dagsoversigt").Or.EqualTo("DayOverview"),
+        "first tab must be the localized Day-overview sheet");
+
+    // Resolve the first sheet's worksheet part and read header row (positionally).
+    var firstPart = (WorksheetPart)doc.WorkbookPart.GetPartById(sheets.First().Id!);
+    var headerCells = firstPart.Worksheet.Descendants<Row>().First().Elements<Cell>().ToList();
+    Assert.That(headerCells.Count, Is.EqualTo(21));
+    // Header values are localized (key == value under the test fixture localizer is bypassed —
+    // these come from Translations.X). Assert positions A and U map to the expected keys' da values.
+    // (Adjust expected strings to match the test culture; under da: "Medarbejder nr." and "Timer netto".)
+}
+```
+
+> When writing, set the seeded user's language so `CurrentUICulture` is deterministic, and assert
+> the concrete header strings for that culture (e.g. da → A1 "Medarbejder nr.", U1 "Timer netto").
+> Verify a `TableDefinitionPart` exists: `Assert.That(firstPart.TableDefinitionParts.Count(), Is.EqualTo(1));`
+> and its `Table.Reference` equals `"A1:U2"` for one data row.
+
+Run the single-worker test; Expected: PASS.
+
+- [ ] **Step 3: Single-worker — date/time/netto cells carry the new styles**
+
+Read a data-row cell and assert: Date cell `StyleIndex == 5` & `DataType == Number`; a populated
+shift cell `StyleIndex == 3`; the netto cell `StyleIndex == 4`. Assert the shift cell's `CellValue`
+equals the expected OADate fraction for the seeded index.
+
+Run; Expected: PASS.
+
+- [ ] **Step 4: All-workers — first sheet is Dagsoversigt, rows combined & sorted**
+
+Seed two sites with overlapping dates (e.g. site 9802 emp "1" and site 9803 emp "2", each with a
+day on 2026-05-14 and 2026-05-15). Call `GenerateExcelDashboard(new TimePlanningWorkingHoursReportForAllWorkersRequestModel { DateFrom, DateTo })`. Assert:
+- first sheet is the Day-overview sheet, then "Total", then the two site sheets (4 sheets total);
+- the Dagsoversigt data rows are ordered by date then employee no.: (14th, emp1), (14th, emp2), (15th, emp1), (15th, emp2) — assert the EmployeeNo column (A) and Date column (D) sequence.
+
+Run; Expected: PASS.
+
+- [ ] **Step 5: Run the full TimePlanning test project**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet test Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/TimePlanning.Pn.Test.csproj`
+Expected: All tests pass (the existing export tests must still pass — existing sheets/styles are unchanged; the single-worker file now has Dagsoversigt as the first sheet, so any existing test that assumed the first sheet was "Dashboard" must be updated to select the Dashboard sheet by name. Check `WorkingHoursExcelExportE2ETests` `ReadShift1Cells`, which does `WorksheetParts.First()` — update it to select the Dashboard sheet by its `Sheet.Id` rather than `.First()`).
+
+> Important regression note: `WorkingHoursExcelExportE2ETests.ReadShift1Cells` (line ~226) uses
+> `WorkbookPart.WorksheetParts.First().Worksheet`. After this change the first worksheet is
+> Dagsoversigt, not Dashboard. Update that helper to resolve the "Dashboard" sheet by name/id so the
+> existing assertions keep targeting the Dashboard sheet.
+
+---
+
+## Task 7: Verification, code review, and sync back (normal cycle)
+
+- [ ] **Step 1: Full build + test pass (evidence)**
+
+Run: `cd /home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI && dotnet build Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj && dotnet test Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/TimePlanning.Pn.Test.csproj`
+Expected: build succeeded; all tests pass. Capture the summary line.
+
+- [ ] **Step 2: Manual browser check**
+
+Remind the user to trigger both report downloads in the running app and open the files: confirm
+Dagsoversigt is the first tab, banded table with autofilter, `hh:mm` times, `dd/mm/yyyy` dates,
+`0.00` net hours, combined+sorted rows in the all-workers file, and that the existing
+Dashboard/Total/per-site sheets are unchanged.
+
+- [ ] **Step 3: Code review**
+
+Use `superpowers:requesting-code-review` on the diff (service + OpenXMLHelper + resx + Designer + tests).
+
+- [ ] **Step 4: Sync to source repo**
+
+From the source plugin repo `/home/rene/Documents/workspace/microting/eform-angular-timeplanning-plugin`, run `./devgetchanges.sh`, then `git checkout *.csproj *.conf.ts *.xlsx *.docx` to discard build/config artifacts, then `git status` and verify only the intended files changed (service, OpenXMLHelper, Resources/*.resx, Translations.Designer.cs, the new test file). `git checkout` any unintended files.
+
+- [ ] **Step 5: Commit (only after user confirms the final `git status`)**
+
+Stage specific files by name (never `git add .`) on the `stable` branch and commit. End the commit message with the required `Co-Authored-By` trailer.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** sheet in both exports as first tab (Tasks 4,5) ✓; combined all-workers sheet sorted by date then employee (Task 5 Step 3) ✓; always-all-5-shifts fixed 21 columns (Task 3 builder) ✓; rows = planning days from `Index()`/`perSiteCache` (Tasks 4,5) ✓; NettoHours reused override-aware (Task 3 builder) ✓; match-example formatting via hh:mm/dd-mm-yyyy/0.00 styles + banded Table (Tasks 2,3) ✓; one new translation key `DayOverview` in all 26 resx + accessor, all 25 languages filled (Task 1) ✓; existing header keys reused (Task 3 builder) ✓.
+- **Known minor edge:** a shift ending exactly at 24:00 (index 289) stores fraction 1.0, which renders as `00:00` under `hh:mm`. Documented; acceptable given rarity.
+- **Regression guard:** existing `ReadShift1Cells` `.First()` worksheet assumption must be updated to select Dashboard by name (Task 6 Step 5).
+- **Type consistency:** `BuildDayOverviewWorksheet(WorksheetPart, List<DayOverviewRow>, CultureInfo)`, `DayOverviewRow` fields, `GetShiftTimeFraction(int?, DateTime?, bool)`, and the cell helpers are used consistently across Tasks 3-6.

--- a/docs/superpowers/specs/2026-06-09-dagsoversigt-export-sheet-design.md
+++ b/docs/superpowers/specs/2026-06-09-dagsoversigt-export-sheet-design.md
@@ -1,0 +1,244 @@
+# Design: "Dagsoversigt" day-overview export sheet
+
+**Date:** 2026-06-09
+**Plugin:** eform-angular-timeplanning-plugin (`TimePlanning.Pn`)
+**Dev mode:** Base dev mode — edit in the `eform-angular-frontend` host-app mirror, then `devgetchanges.sh` back to the source repo for committing. No base repo involved.
+
+## Summary
+
+Add a new **Dagsoversigt** ("Day overview") sheet as the **first tab** in both existing
+Excel exports of the timeplanning plugin:
+
+- **All-workers** export (`GET reports/file-all-workers`) — one **combined** Dagsoversigt
+  sheet containing every worker's planning days, followed by the existing Total +
+  per-site sheets.
+- **Single-worker** export (`GET reports/file`) — the same sheet for just that one
+  worker, followed by the existing Dashboard sheet.
+
+The sheet replicates the layout and formatting of the reference file
+`/home/rene/Downloads/Dagsoversigt.xlsx`.
+
+## Motivation
+
+The current exports present data per-worker (Dashboard) or as a per-site breakdown
+(Total + per-site). There is no single flat day-by-day overview that lists each
+worker's shifts per day in one scannable table. The Dagsoversigt sheet fills that gap
+and is requested as the first thing the reader sees when opening either workbook.
+
+## Reference file analysis
+
+`Dagsoversigt.xlsx` is a single banded Excel Table (`A1:U11`), one row per
+*(employee × day)*:
+
+| Col | Header (da) | Resx key | Notes |
+|-----|-------------|----------|-------|
+| A | Medarbejder nr. | `Employee no` | worker employee number |
+| B | Medarbejder | `Worker` | worker / site name |
+| C | Ugedag | `DayOfWeek` | localized weekday, lowercase (`torsdag`) |
+| D | Dato | `Date` | real date, `dd/mm/yyyy` |
+| E | Uge nr | `Week number` | ISO-ish week number |
+| F–H | Skift 1: start / stop / pause | `Shift 1: start` / `Shift 1: end` / `Shift 1: pause` | real `h:mm` time values |
+| I–K | Skift 2: … | `Shift 2: …` | |
+| L–N | Skift 3: … | `Shift 3: …` | |
+| O–Q | Skift 4: … | `Shift 4: …` | |
+| R–T | Skift 5: … | `Shift 5: …` | |
+| U | Timer netto | `NettoHours` | net hours, `0.00` |
+
+Notes from the reference:
+- All 5 shift blocks are always present (fixed 21-column layout), even when only
+  shift 1 has data.
+- Banded Excel Table with autofilter and a bold header row.
+- The reference's `Timer netto` cells hold placeholder text; this design instead
+  fills the column with the export's real computed net-hours value.
+
+## Decisions (settled during brainstorming)
+
+1. **Both exports** get the sheet, as the **first tab**.
+2. **All-workers** → **one combined sheet** (not per-site), rows interleaved across all
+   assigned, non-resigned, non-removed sites.
+3. **Sort order**: by **date ascending, then employee number ascending** (matches the
+   reference grouping: all employees for a day, then the next day).
+4. **Shift columns**: **always all 5** (fixed 21 columns), regardless of each site's
+   `Third/Fourth/FifthShiftActive` flags — unlike the existing Dashboard/Total sheets
+   which hide inactive shift columns.
+5. **Row scope**: one row per **planning day** per worker — the same day-set the
+   existing `Index(...)` already returns (no new query logic; reuse it).
+6. **Timer netto**: reuse the existing override-aware computed value
+   (`NettoHoursOverrideActive ? NettoHoursOverride : NettoHours`). Days without a
+   registration simply show `0.00`.
+7. **Formatting fidelity**: **match the reference exactly** — real `h:mm` time values,
+   `dd/mm/yyyy` dates, `0.00` net hours, and a banded Excel Table with autofilter +
+   bold header.
+8. **Translations**: reuse existing resx keys for all 21 headers; add exactly **one**
+   new key for the sheet name, translated into **all 25 culture files** (+ neutral).
+9. `DayOfWeek` keeps the existing lowercase localized weekday
+   (`planning.Date.ToString("dddd", culture)`).
+
+## Architecture
+
+### Existing structure (for context)
+
+- Service: `Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs`
+  - Single worker: `GenerateExcelDashboard(TimePlanningWorkingHoursRequestModel)` (~line 2343)
+    — creates one `"Dashboard"` worksheet.
+  - All workers: `GenerateExcelDashboard(TimePlanningWorkingHoursReportForAllWorkersRequestModel)`
+    (~line 2847) — creates a `"Total"` sheet + one sheet per site; pre-computes a
+    `perSiteCache` (`AllWorkersSiteCache`) of working-hours/pay data.
+  - Shared cell builders: `CreateCell`, `CreateNumericCell`, `CreateDateCell`
+    (StyleIndex 2), `CreateWeekNumberCell`; row builder `FillDataRow`.
+  - `CurrentUICulture` is set before headers are read (lines ~2375 and ~2877), so
+    `Translations.X` resolves in the user's language.
+- Low-level OpenXML helper: `Infrastructure/Helpers/OpenXMLHelper.cs`
+  - `GenerateWorkbookPart1Content(WorkbookPart, List<KeyValuePair<string,string>> sheets)`
+    registers the workbook's `Sheet` elements (name → relationship id).
+  - `GenerateWorkbookStylesPart1Content(...)` builds the stylesheet (`CellFormats`);
+    date format is `StyleIndex 2`.
+- Library: `DocumentFormat.OpenXml` 3.5.1 (transitive via `Microting.eFormApi.BasePn`).
+- Translations: strongly-typed `Translations` (neutral `Resources/Translations.Designer.cs`)
+  + per-culture `Resources/Translations.<culture>.resx` satellite assemblies. The
+  per-culture `Translations_xx` Designer classes are unused by the export.
+
+### New units
+
+**1. `BuildDayOverviewWorksheet(...)` — shared private method (new)**
+
+Single, isolated builder responsible for the entire Dagsoversigt worksheet:
+
+- **Input**: an ordered list of row items, each carrying the data needed for one row:
+  `(EmployeeNo, WorkerOrSiteName, Date, planning)` — enough to emit all 21 cells.
+  Both export methods construct this list and pass it in.
+- **Output**: appends a fully-built `WorksheetPart` (worksheet + sheet data + table +
+  autofilter + page margins) for the Dagsoversigt sheet.
+- **Responsibilities**:
+  - Header row from the existing resx keys (fixed 21 columns).
+  - One data row per item: employee no (string), worker/site name (string), localized
+    weekday (string), date (real date cell, `dd/mm/yyyy`), week number (numeric), five
+    shift blocks as real `h:mm` time cells, net hours (numeric, `0.00`).
+  - The banded Excel `TableDefinitionPart` over the full range with autofilter and
+    header row.
+- **Why isolated**: one clear purpose (render the overview), well-defined input, no
+  dependency on the surrounding export method's local state beyond the row list and
+  culture/language. Independently reasoned about and testable.
+
+**2. Time-value helper (new, small)**
+
+Convert a shift time into an OADate time-of-day fraction (minutes-since-midnight ÷ 1440)
+so cells are real `h:mm` time values rather than strings. Sourced from the same
+underlying shift data the existing `GetShiftTime(...)` reads; empty/absent shift times
+produce an empty cell (not `0:00`), matching the reference where unused shifts are blank.
+
+> Implementation note: confirm the unit of `planning.ShiftNStart/Stop/Pause` and how
+> `GetShiftTime` derives its `HH:mm` string, then convert from that same source to the
+> fraction. This is the main implementation-time investigation.
+
+**3. New cell styles in `OpenXMLHelper` stylesheet**
+
+Add (or reuse, if already present) the `CellFormats` needed:
+- `h:mm` time format (for shift start/stop/pause cells),
+- `0.00` number format (for net hours),
+- `dd/mm/yyyy` date format (verify whether existing `StyleIndex 2` already is `dd/mm/yyyy`;
+  if not, add a dedicated style and use it for the Dagsoversigt Date column).
+
+New `CellFormat` entries get new `StyleIndex` values; the builder references those
+indices. Existing styles/indices are left unchanged to avoid disturbing the other
+sheets.
+
+**4. Sheet registration changes**
+
+- Single-worker export: change the workbook sheet list from `[("Dashboard","rId1")]`
+  to `[(Translations.DayOverview,"rId1"), ("Dashboard","rId2")]`, create the Dagsoversigt
+  worksheet part as `rId1` and the Dashboard part as `rId2`.
+- All-workers export: prepend `(Translations.DayOverview, "rId?")` as the first sheet and
+  shift the existing relationship ids (Total + per-site) accordingly.
+- Excel tab-name limit (31 chars) and illegal chars (`: \ / ? * [ ]`): "Dagsoversigt"
+  (and the chosen translations) must be validated/sanitized the same way existing
+  per-site names are truncated. "Dagsoversigt" is 12 chars and clean.
+
+### Data flow
+
+```
+Single-worker GenerateExcelDashboard(model)
+  Index(model)  ──►  per-day plannings (Skip(1))
+                       └─► build row list (one worker)  ──►  BuildDayOverviewWorksheet
+                       └─► existing Dashboard sheet (unchanged)
+
+All-workers GenerateExcelDashboard(model)
+  perSiteCache (existing pre-pass over all sites)
+     └─► flatten to row list (all workers × their planning days)
+            └─► sort by (Date asc, EmployeeNo asc)  ──►  BuildDayOverviewWorksheet
+     └─► existing Total + per-site sheets (unchanged)
+```
+
+The all-workers builder reuses the already-computed `perSiteCache` so no extra DB query
+is introduced. The single-worker builder reuses its existing `Index(...)` result.
+
+### Translation
+
+Add one key, **`DayOverview`**:
+
+1. Neutral `Resources/Translations.resx`: `<data name="DayOverview"><value>Day overview</value></data>`.
+2. `Resources/Translations.da.resx`: `<value>Dagsoversigt</value>`.
+3. All other 24 culture `.resx` files: a translated value each (filled for every
+   language; any lower-confidence translations flagged for review).
+4. Neutral `Resources/Translations.Designer.cs`: add accessor
+   ```csharp
+   internal static string DayOverview {
+       get { return ResourceManager.GetString("DayOverview", resourceCulture); }
+   }
+   ```
+   (key string `"DayOverview"`, no spaces, so accessor name == key.)
+5. Use `Translations.DayOverview` as the sheet name in both export methods.
+   `CurrentUICulture` is already set before this point in both methods.
+
+The per-culture `Translations_xx` Designer classes are unused by the export and are not
+edited. The `localization.json` / `ITimePlanningLocalizationService` path is not needed
+(headers/sheet names use the resx path).
+
+## Error handling
+
+- The builder follows the existing pattern: wrap row construction in try/catch,
+  `SentrySdk.CaptureException`, log, rethrow (consistent with `FillDataRow`).
+- Both export methods already finalize with `ValidateExcel(...)` (`OpenXmlValidator`);
+  the added worksheet + table part must pass validation. The Excel Table part is the
+  highest-risk element for validation — it must declare correct `ref`, column count,
+  unique table id/name, and matching autofilter range.
+- Empty shift times render as empty cells (not `0:00`).
+- A worker/day with no data still renders a row with `0.00` net hours (decision 6).
+
+## Testing
+
+- **Unit-style / focused**: a test that feeds `BuildDayOverviewWorksheet` a small known
+  row list and asserts the produced sheet has 21 headers in the right order, the right
+  number of data rows, correct date/time/number style indices, and a valid table part
+  (passes `OpenXmlValidator`).
+- **Sort**: assert combined all-workers rows come out ordered by (date, employee no).
+- **Translation**: assert the sheet name resolves to "Dagsoversigt" under `da` and
+  "Day overview" under the neutral/`en` culture.
+- **Integration**: run both endpoints against seed data and open the resulting files to
+  confirm Dagsoversigt is the first tab, the table is banded with autofilter, times show
+  as `h:mm`, dates as `dd/mm/yyyy`, net hours as `0.00`, and the existing sheets are
+  unchanged.
+- Follow the plugin's existing test conventions (verify how the current export is
+  tested, if at all, during implementation and match it).
+
+## Out of scope
+
+- No changes to the existing Dashboard / Total / per-site sheets' content or layout.
+- No new DB queries or schema changes (no base repo).
+- No frontend/Angular changes (the export is triggered by existing endpoints/buttons).
+- No new column data beyond the reference's 21 columns (PlanText, Flex, Message,
+  Comments, pay-codes, etc. are intentionally excluded from this sheet).
+
+## Files to change
+
+All in the host-app mirror `eform-angular-frontend/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/`
+(mirrored back to the source repo via `devgetchanges.sh`):
+
+- `Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs`
+  — new `BuildDayOverviewWorksheet` + time-value helper; wire both export methods to add
+  the sheet as first tab and adjust relationship ids.
+- `Infrastructure/Helpers/OpenXMLHelper.cs` — add `h:mm`, `0.00`, and (if needed)
+  `dd/mm/yyyy` cell styles.
+- `Resources/Translations.resx` + `Resources/Translations.<25 cultures>.resx` — new
+  `DayOverview` key.
+- `Resources/Translations.Designer.cs` — new `DayOverview` accessor.

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.Index;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using PlanRegistrationEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration;
+using SdkLanguage = Microting.eForm.Infrastructure.Data.Entities.Language;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using SdkSiteWorker = Microting.eForm.Infrastructure.Data.Entities.SiteWorker;
+using SdkWorker = Microting.eForm.Infrastructure.Data.Entities.Worker;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// End-to-end coverage for the new "Dagsoversigt" (Day overview) worksheet that
+/// is added as the FIRST tab of both the single-worker and all-workers Excel
+/// exports. These tests open the produced xlsx with OpenXml and assert the sheet
+/// order, the 21-column header, the Excel Table definition, the cell styles and
+/// the OADate cell values. The export's <c>ValidateExcel</c> swallows schema
+/// errors, so opening/reading the file in a test is the only thing that catches
+/// a malformed worksheet or table.
+/// </summary>
+[TestFixture]
+public class DagsoversigtWorksheetExportTests : TestBaseSetup
+{
+    private TimePlanningWorkingHoursService _service = null!;
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+
+        var localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        var coreService = Substitute.For<IEFormCoreService>();
+        var core = await GetCore();
+        coreService.GetCore().Returns(core);
+
+        // Ensure a Danish Language exists in the SDK DB and bind it to the
+        // user-language stub so Thread.CurrentUICulture is deterministically "da".
+        var sdkDb = core.DbContextHelper.GetDbContext();
+        var language = await sdkDb.Languages.FirstOrDefaultAsync(l => l.LanguageCode == "da");
+        if (language == null)
+        {
+            language = new SdkLanguage { LanguageCode = "da", Name = "Danish" };
+            await language.Create(sdkDb);
+        }
+        userService.GetCurrentUserLanguage().Returns(language);
+
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
+        _service = new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            TimePlanningPnDbContext!,
+            userService,
+            localizationService,
+            baseDbContext: null!,
+            options,
+            coreService);
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Pure helper: GetShiftTimeFraction
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void GetShiftTimeFraction_CoversGridStampAndEdgeCases()
+    {
+        // Legacy 5-minute grid: index 97 -> 08:00 -> 480 minutes / 1440.
+        Assert.That(_service.GetShiftTimeFraction(97, null, false)!.Value,
+            Is.EqualTo(480.0 / 1440.0).Within(1e-9));
+
+        // Absent shift -> null.
+        Assert.That(_service.GetShiftTimeFraction(null, null, false), Is.Null);
+
+        // Index 0 is treated as "no shift" -> null.
+        Assert.That(_service.GetShiftTimeFraction(0, null, false), Is.Null);
+
+        // Index 289 -> 24:00 -> 1.0 (whole day).
+        Assert.That(_service.GetShiftTimeFraction(289, null, false)!.Value,
+            Is.EqualTo(1.0).Within(1e-9));
+
+        // One-minute interval path: real stamp 08:04 -> (8*60+4)/1440.
+        Assert.That(
+            _service.GetShiftTimeFraction(97, new DateTime(2026, 5, 15, 8, 4, 0), true)!.Value,
+            Is.EqualTo((8 * 60 + 4) / 1440.0).Within(1e-9));
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Single-worker: first sheet is Dagsoversigt with 21-column header.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task SingleWorker_FirstSheetIsDagsoversigt_With21ColumnHeaderAndTable()
+    {
+        await SeedSiteAndPlanRegistration(
+            siteUid: 9801,
+            employeeNo: "1",
+            date: new DateTime(2026, 5, 15),
+            useOneMinuteIntervals: false,
+            start1Id: 97, stop1Id: 121);
+
+        var result = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = 9801,
+            DateFrom = new DateTime(2026, 5, 15),
+            DateTo = new DateTime(2026, 5, 15),
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+
+        result.Model!.Position = 0;
+        using var doc = SpreadsheetDocument.Open(result.Model!, false);
+        var workbookPart = doc.WorkbookPart!;
+        var sheets = workbookPart.Workbook.Descendants<Sheet>().ToList();
+
+        // First tab is the localized "Dagsoversigt".
+        Assert.That(sheets[0].Name!.Value, Is.EqualTo("Dagsoversigt"));
+
+        var firstPart = (WorksheetPart)workbookPart.GetPartById(sheets[0].Id!);
+        var headerRow = firstPart.Worksheet.Descendants<Row>().First(r => r.RowIndex! == 1U);
+        var headerCells = headerRow.Elements<Cell>().ToList();
+        Assert.That(headerCells.Count, Is.EqualTo(21), "Dagsoversigt header must have 21 columns");
+
+        Assert.That(CellText(headerCells[0], workbookPart), Is.EqualTo("Medarbejder nr."));
+        Assert.That(CellText(headerCells[20], workbookPart), Is.EqualTo("Timer netto"));
+
+        // Exactly one Excel Table, named region A1:U{1+dataRows}.
+        Assert.That(firstPart.TableDefinitionParts.Count(), Is.EqualTo(1));
+        var dataRows = firstPart.Worksheet.Descendants<Row>().Count(r => r.RowIndex! > 1U);
+        Assert.That(dataRows, Is.EqualTo(1), "Single seeded plan registration => one data row");
+        Assert.That(firstPart.TableDefinitionParts.First().Table!.Reference!.Value,
+            Is.EqualTo($"A1:U{1 + dataRows}"));
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Single-worker: cell styles & values for a data row.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task SingleWorker_DataRow_HasCorrectStylesAndOaDateValues()
+    {
+        await SeedSiteAndPlanRegistration(
+            siteUid: 9802,
+            employeeNo: "1",
+            date: new DateTime(2026, 5, 15),
+            useOneMinuteIntervals: false,
+            start1Id: 97, stop1Id: 121);
+
+        var result = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = 9802,
+            DateFrom = new DateTime(2026, 5, 15),
+            DateTo = new DateTime(2026, 5, 15),
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        result.Model!.Position = 0;
+        using var doc = SpreadsheetDocument.Open(result.Model!, false);
+        var workbookPart = doc.WorkbookPart!;
+        var sheets = workbookPart.Workbook.Descendants<Sheet>().ToList();
+        var firstPart = (WorksheetPart)workbookPart.GetPartById(sheets[0].Id!);
+
+        var dataRow = firstPart.Worksheet.Descendants<Row>().First(r => r.RowIndex! == 2U);
+
+        // Date cell (col D): StyleIndex 5 (dd/mm/yyyy), numeric OADate.
+        var dateCell = dataRow.Elements<Cell>().Single(c => c.CellReference == "D2");
+        Assert.That(dateCell.StyleIndex!.Value, Is.EqualTo(5U));
+        Assert.That(dateCell.DataType!.Value, Is.EqualTo(CellValues.Number));
+        Assert.That(double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture),
+            Is.EqualTo(new DateTime(2026, 5, 15).ToOADate()).Within(1e-9));
+
+        // Shift 1 start cell (col F): StyleIndex 3 (hh:mm), value = (97-1)*5/1440.
+        var shift1StartCell = dataRow.Elements<Cell>().Single(c => c.CellReference == "F2");
+        Assert.That(shift1StartCell.StyleIndex!.Value, Is.EqualTo(3U));
+        Assert.That(double.Parse(shift1StartCell.CellValue!.Text, CultureInfo.InvariantCulture),
+            Is.EqualTo((97 - 1) * 5 / 1440.0).Within(1e-9));
+
+        // NettoHours cell (col U): StyleIndex 4 (0.00).
+        var nettoCell = dataRow.Elements<Cell>().Single(c => c.CellReference == "U2");
+        Assert.That(nettoCell.StyleIndex!.Value, Is.EqualTo(4U));
+    }
+
+    // ------------------------------------------------------------------
+    // 4. All-workers: first sheet is Dagsoversigt; rows combined & sorted.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task AllWorkers_FirstSheetIsDagsoversigt_RowsCombinedAndSorted()
+    {
+        // Two sites, employee numbers "1" and "2", each with a registration on
+        // 2026-05-14 and 2026-05-15.
+        await SeedSiteWithTwoDays(siteUid: 9901, employeeNo: "1",
+            dateA: new DateTime(2026, 5, 14), dateB: new DateTime(2026, 5, 15));
+        await SeedSiteWithTwoDays(siteUid: 9902, employeeNo: "2",
+            dateA: new DateTime(2026, 5, 14), dateB: new DateTime(2026, 5, 15));
+
+        var result = await _service.GenerateExcelDashboard(
+            new TimePlanningWorkingHoursReportForAllWorkersRequestModel
+            {
+                DateFrom = new DateTime(2026, 5, 14),
+                DateTo = new DateTime(2026, 5, 15),
+            });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        result.Model!.Position = 0;
+        using var doc = SpreadsheetDocument.Open(result.Model!, false);
+        var workbookPart = doc.WorkbookPart!;
+        var sheets = workbookPart.Workbook.Descendants<Sheet>().ToList();
+
+        // Sheet order: [Dagsoversigt, Total, Site 9901, Site 9902].
+        Assert.That(sheets.Count, Is.EqualTo(4));
+        Assert.That(sheets[0].Name!.Value, Is.EqualTo("Dagsoversigt"));
+        Assert.That(sheets[1].Name!.Value, Is.EqualTo("Total"));
+        Assert.That(sheets[2].Name!.Value, Is.EqualTo("Site 9901"));
+        Assert.That(sheets[3].Name!.Value, Is.EqualTo("Site 9902"));
+
+        var firstPart = (WorksheetPart)workbookPart.GetPartById(sheets[0].Id!);
+        var rowsByIndex = firstPart.Worksheet.Descendants<Row>()
+            .Where(r => r.RowIndex! > 1U)
+            .OrderBy(r => r.RowIndex!.Value)
+            .ToList();
+
+        Assert.That(rowsByIndex.Count, Is.EqualTo(4),
+            "Two sites x two days => four combined data rows");
+
+        var date14 = new DateTime(2026, 5, 14).ToOADate();
+        var date15 = new DateTime(2026, 5, 15).ToOADate();
+
+        // Ordered by Date then EmployeeNo:
+        // row2=(14,"1"), row3=(14,"2"), row4=(15,"1"), row5=(15,"2").
+        AssertRowDateAndEmployee(rowsByIndex[0], workbookPart, date14, "1");
+        AssertRowDateAndEmployee(rowsByIndex[1], workbookPart, date14, "2");
+        AssertRowDateAndEmployee(rowsByIndex[2], workbookPart, date15, "1");
+        AssertRowDateAndEmployee(rowsByIndex[3], workbookPart, date15, "2");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static void AssertRowDateAndEmployee(Row row, WorkbookPart wb, double expectedOaDate, string expectedEmployeeNo)
+    {
+        var employeeCell = row.Elements<Cell>().Single(c =>
+            c.CellReference!.Value!.StartsWith("A"));
+        var dateCell = row.Elements<Cell>().Single(c =>
+            c.CellReference!.Value!.StartsWith("D"));
+
+        Assert.That(CellText(employeeCell, wb), Is.EqualTo(expectedEmployeeNo));
+        Assert.That(double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture),
+            Is.EqualTo(expectedOaDate).Within(1e-9));
+    }
+
+    private static string CellText(Cell c, WorkbookPart wb)
+    {
+        var sst = wb.SharedStringTablePart?.SharedStringTable;
+        var raw = c.CellValue?.Text ?? c.InnerText ?? "";
+        if (c.DataType?.Value == CellValues.SharedString && sst != null && int.TryParse(raw, out var idx))
+        {
+            return sst.ElementAt(idx).InnerText;
+        }
+        return raw;
+    }
+
+    /// <summary>
+    /// Seeds one SDK Site/Worker/SiteWorker + an AssignedSite + a prior-day and a
+    /// requested-day PlanRegistration. Mirrors the helper in
+    /// <c>WorkingHoursExcelExportE2ETests</c> but takes an explicit employee number.
+    /// </summary>
+    private async Task SeedSiteAndPlanRegistration(
+        int siteUid, string employeeNo, DateTime date, bool useOneMinuteIntervals,
+        int start1Id, int stop1Id)
+    {
+        var core = await GetCore();
+        var sdkDb = core.DbContextHelper.GetDbContext();
+
+        var site = new SdkSite { Name = $"Site {siteUid}", MicrotingUid = siteUid };
+        await site.Create(sdkDb);
+
+        var worker = new SdkWorker
+        {
+            FirstName = "Test",
+            LastName = "Worker",
+            Email = $"test{siteUid}@example.com",
+            MicrotingUid = 1000 + siteUid,
+            EmployeeNo = employeeNo,
+        };
+        await worker.Create(sdkDb);
+
+        var siteWorker = new SdkSiteWorker
+        {
+            SiteId = site.Id,
+            WorkerId = worker.Id,
+            MicrotingUid = 2000 + siteUid,
+        };
+        await siteWorker.Create(sdkDb);
+
+        await new AssignedSiteEntity
+        {
+            SiteId = siteUid,
+            UseOneMinuteIntervals = useOneMinuteIntervals,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        // Prior-day registration so Index() emits a "prePlanning" row at index 0
+        // that the export drops via Skip(1).
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = siteUid,
+            Date = date.AddDays(-1),
+            Start1Id = 0,
+            Stop1Id = 0,
+            Pause1Id = 0,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = siteUid,
+            Date = date,
+            Start1Id = start1Id,
+            Stop1Id = stop1Id,
+            Pause1Id = 0,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+    }
+
+    /// <summary>
+    /// Seeds a site with a prior-day registration (dropped via Skip(1)) plus two
+    /// in-range registrations on <paramref name="dateA"/> and <paramref name="dateB"/>.
+    /// </summary>
+    private async Task SeedSiteWithTwoDays(
+        int siteUid, string employeeNo, DateTime dateA, DateTime dateB)
+    {
+        var core = await GetCore();
+        var sdkDb = core.DbContextHelper.GetDbContext();
+
+        var site = new SdkSite { Name = $"Site {siteUid}", MicrotingUid = siteUid };
+        await site.Create(sdkDb);
+
+        var worker = new SdkWorker
+        {
+            FirstName = "Test",
+            LastName = "Worker",
+            Email = $"test{siteUid}@example.com",
+            MicrotingUid = 1000 + siteUid,
+            EmployeeNo = employeeNo,
+        };
+        await worker.Create(sdkDb);
+
+        var siteWorker = new SdkSiteWorker
+        {
+            SiteId = site.Id,
+            WorkerId = worker.Id,
+            MicrotingUid = 2000 + siteUid,
+        };
+        await siteWorker.Create(sdkDb);
+
+        await new AssignedSiteEntity
+        {
+            SiteId = siteUid,
+            UseOneMinuteIntervals = false,
+            Resigned = false,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        // Prior-day registration (dropped by Skip(1)).
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = siteUid,
+            Date = dateA.AddDays(-1),
+            Start1Id = 0,
+            Stop1Id = 0,
+            Pause1Id = 0,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        foreach (var date in new[] { dateA, dateB })
+        {
+            await new PlanRegistrationEntity
+            {
+                SdkSitId = siteUid,
+                Date = date,
+                Start1Id = 97,
+                Stop1Id = 121,
+                Pause1Id = 0,
+                PlanText = "",
+                CommentOffice = "",
+                CommentOfficeAll = "",
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1,
+            }.Create(TimePlanningPnDbContext!);
+        }
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursExcelExportE2ETests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursExcelExportE2ETests.cs
@@ -225,8 +225,14 @@ public class WorkingHoursExcelExportE2ETests : TestBaseSetup
     {
         xlsx.Position = 0;
         using var doc = SpreadsheetDocument.Open(xlsx, false);
-        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
-        var sst = doc.WorkbookPart.SharedStringTablePart?.SharedStringTable;
+        var workbookPart = doc.WorkbookPart!;
+        // The first worksheet is now "Dagsoversigt" (Day overview); resolve the
+        // Dashboard sheet explicitly by name so these assertions keep targeting it.
+        var dashboardSheet = workbookPart.Workbook.Descendants<Sheet>()
+            .First(s => s.Name == "Dashboard");
+        var dashboardPart = (WorksheetPart)workbookPart.GetPartById(dashboardSheet.Id!);
+        var sheet = dashboardPart.Worksheet;
+        var sst = workbookPart.SharedStringTablePart?.SharedStringTable;
         string CellText(Cell c)
         {
             var raw = c.CellValue?.Text ?? c.InnerText ?? "";

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OpenXMLHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OpenXMLHelper.cs
@@ -125,14 +125,27 @@ public static class OpenXMLHelper
 
         cellStyleFormats1.Append(cellFormat1);
 
-        CellFormats cellFormats1 = new CellFormats(){ Count = (UInt32Value)3U };
+        NumberingFormats numberingFormats1 = new NumberingFormats() { Count = (UInt32Value)2U };
+        numberingFormats1.Append(new NumberingFormat() { NumberFormatId = (UInt32Value)164U, FormatCode = "dd/mm/yyyy" });
+        numberingFormats1.Append(new NumberingFormat() { NumberFormatId = (UInt32Value)165U, FormatCode = "hh:mm" });
+
+        CellFormats cellFormats1 = new CellFormats(){ Count = (UInt32Value)6U };
         CellFormat cellFormat2 = new CellFormat(){ NumberFormatId = (UInt32Value)0U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U };
         CellFormat cellFormat3 = new CellFormat(){ NumberFormatId = (UInt32Value)0U, FontId = (UInt32Value)1U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyFont = true };
         CellFormat cellFormat4 = new CellFormat(){ NumberFormatId = (UInt32Value)14U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+        // New: StyleIndex 3 = time hh:mm
+        CellFormat cellFormat5 = new CellFormat(){ NumberFormatId = (UInt32Value)165U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+        // New: StyleIndex 4 = number 0.00 (built-in numFmtId 2)
+        CellFormat cellFormat6 = new CellFormat(){ NumberFormatId = (UInt32Value)2U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
+        // New: StyleIndex 5 = date dd/mm/yyyy (custom numFmtId 164)
+        CellFormat cellFormat7 = new CellFormat(){ NumberFormatId = (UInt32Value)164U, FontId = (UInt32Value)0U, FillId = (UInt32Value)0U, BorderId = (UInt32Value)0U, FormatId = (UInt32Value)0U, ApplyNumberFormat = true };
 
         cellFormats1.Append(cellFormat2);
         cellFormats1.Append(cellFormat3);
         cellFormats1.Append(cellFormat4);
+        cellFormats1.Append(cellFormat5);
+        cellFormats1.Append(cellFormat6);
+        cellFormats1.Append(cellFormat7);
 
         CellStyles cellStyles1 = new CellStyles(){ Count = (UInt32Value)1U };
         CellStyle cellStyle1 = new CellStyle(){ Name = "Normal", FormatId = (UInt32Value)0U, BuiltinId = (UInt32Value)0U };
@@ -158,6 +171,7 @@ public static class OpenXMLHelper
         stylesheetExtensionList1.Append(stylesheetExtension1);
         stylesheetExtensionList1.Append(stylesheetExtension2);
 
+        stylesheet1.Append(numberingFormats1);
         stylesheet1.Append(fonts1);
         stylesheet1.Append(fills1);
         stylesheet1.Append(borders1);

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.Designer.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.Designer.cs
@@ -290,5 +290,11 @@ namespace TimePlanning.Pn.Resources {
                 return ResourceManager.GetString("Normal Hours", resourceCulture);
             }
         }
+
+        internal static string DayOverview {
+            get {
+                return ResourceManager.GetString("DayOverview", resourceCulture);
+            }
+        }
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.bg-BG.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.bg-BG.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Общо часове</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Дневен преглед</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.cs-CZ.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.cs-CZ.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Celkem hodin</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Denní přehled</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.da.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.da.resx
@@ -192,4 +192,7 @@
     <data name="UserNotFound" xml:space="preserve">
         <value>Bruger ikke fundet.</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dagsoversigt</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.de.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.de.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Gesamtstunden</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Tagesübersicht</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.el-GR.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.el-GR.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Σύνολο ωρών</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Ημερήσια επισκόπηση</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.es-ES.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.es-ES.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Horas totales</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Resumen diario</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.et-EE.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.et-EE.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Tunnid kokku</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Päevaülevaade</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.fi-FI.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.fi-FI.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Tunnit yhteensä</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Päiväkatsaus</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.fr-FR.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.fr-FR.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Heures totales</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Aperçu de la journée</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.hr-HR.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.hr-HR.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Ukupno sati</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dnevni pregled</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.hu-HU.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.hu-HU.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Összes óra</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Napi áttekintés</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.is-IS.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.is-IS.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Heildarstundir</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dagsyfirlit</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.it-IT.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.it-IT.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Ore totali</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Riepilogo giornaliero</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.lt-LT.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.lt-LT.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Iš viso valandų</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dienos apžvalga</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.lv-LV.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.lv-LV.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Kopējās stundas</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dienas pārskats</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.nl-NL.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.nl-NL.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Totale uren</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dagoverzicht</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.no-NO.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.no-NO.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Totale timer</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dagsoversikt</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pl-PL.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pl-PL.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Całkowite godziny</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Przegląd dnia</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pt-BR.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pt-BR.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Horas totais</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Resumo diário</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pt-PT.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.pt-PT.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Horas totais</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Resumo diário</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.resx
@@ -192,4 +192,7 @@
     <data name="UserNotFound" xml:space="preserve">
         <value>User not found.</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Day overview</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.ro-RO.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.ro-RO.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Total ore</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Rezumat zilnic</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sk-SK.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sk-SK.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Celkom hodín</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Denný prehľad</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sl-SI.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sl-SI.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Skupaj ur</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dnevni pregled</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sv-SE.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.sv-SE.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Totala timmar</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Dagsöversikt</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.uk-UA.resx
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Resources/Translations.uk-UA.resx
@@ -137,4 +137,7 @@
     <data name="Total Hours" xml:space="preserve">
         <value>Всього годин</value>
     </data>
+    <data name="DayOverview" xml:space="preserve">
+        <value>Огляд за день</value>
+    </data>
 </root>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -2422,15 +2422,28 @@ public class TimePlanningWorkingHoursService(
                    document = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
             {
                 WorkbookPart workbookPart1 = document.AddWorkbookPart();
-                OpenXMLHelper.GenerateWorkbookPart1Content(workbookPart1, [new("Dashboard", "rId1")]);
+                OpenXMLHelper.GenerateWorkbookPart1Content(workbookPart1,
+                    [new(Translations.DayOverview, "rId1"), new("Dashboard", "rId2")]);
 
-                WorkbookStylesPart workbookStylesPart1 = workbookPart1.AddNewPart<WorkbookStylesPart>("rId3");
+                WorkbookStylesPart workbookStylesPart1 = workbookPart1.AddNewPart<WorkbookStylesPart>("rId4");
                 OpenXMLHelper.GenerateWorkbookStylesPart1Content(workbookStylesPart1);
 
-                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>("rId2");
+                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>("rId3");
                 OpenXMLHelper.GenerateThemePart1Content(themePart1);
 
-                WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>("rId1");
+                // Dagsoversigt (Day overview) — first tab
+                WorksheetPart dayOverviewWorksheetPart = workbookPart1.AddNewPart<WorksheetPart>("rId1");
+                var dayOverviewRows = timePlannings.Select(p => new DayOverviewRow
+                {
+                    EmployeeNo = worker.EmployeeNo ?? string.Empty,
+                    WorkerName = site.Name,
+                    Date = p.Date,
+                    Planning = p,
+                    UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
+                }).ToList();
+                BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
+
+                WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>("rId2");
 
                 var headers = new[]
                 {
@@ -2958,8 +2971,8 @@ public class TimePlanningWorkingHoursService(
                 var siteIdCount = siteIds.Count;
 
                 var worksheetNames = new List<KeyValuePair<string, string>>();
-                worksheetNames.Add(
-                    new KeyValuePair<string, string>("Total", "rId1"));
+                worksheetNames.Add(new KeyValuePair<string, string>(Translations.DayOverview, "rId1"));
+                worksheetNames.Add(new KeyValuePair<string, string>("Total", "rId2"));
 
                 for (int i = 0; i < siteIdCount; i++)
                 {
@@ -2968,22 +2981,56 @@ public class TimePlanningWorkingHoursService(
                     if (site == null) continue;
                     worksheetNames.Add(
                         new KeyValuePair<string, string>($"{site.Name.Substring(0, Math.Min(31, site.Name.Length))}",
-                            $"rId{i + 2}"));
+                            $"rId{i + 3}"));
                 }
 
                 WorkbookPart workbookPart1 = document.AddWorkbookPart();
                 OpenXMLHelper.GenerateWorkbookPart1Content(workbookPart1, worksheetNames);
 
                 WorkbookStylesPart workbookStylesPart1 =
-                    workbookPart1.AddNewPart<WorkbookStylesPart>($"rId{siteIdCount + 3}");
+                    workbookPart1.AddNewPart<WorkbookStylesPart>($"rId{siteIdCount + 4}");
                 OpenXMLHelper.GenerateWorkbookStylesPart1Content(workbookStylesPart1);
 
-                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>($"rId{siteIdCount + 2}");
+                ThemePart themePart1 = workbookPart1.AddNewPart<ThemePart>($"rId{siteIdCount + 3}");
                 OpenXMLHelper.GenerateThemePart1Content(themePart1);
+
+                #region DayOverviewSheetSetup
+
+                WorksheetPart dayOverviewWorksheetPart = workbookPart1.AddNewPart<WorksheetPart>("rId1");
+                var dayOverviewRows = new List<DayOverviewRow>();
+                for (int i = 0; i < siteIdCount; i++)
+                {
+                    var doSite = await sdkContext.Sites.FirstOrDefaultAsync(x => x.MicrotingUid == siteIds[i]);
+                    if (doSite == null) continue;
+                    var doSiteWorker = await sdkContext.SiteWorkers.FirstAsync(x => x.SiteId == doSite.Id);
+                    var doWorker = await sdkContext.Workers.FirstAsync(x => x.Id == doSiteWorker.WorkerId);
+                    perSiteCache.TryGetValue(siteIds[i], out var doCache);
+                    var doPlannings = doCache?.TimePlannings ?? new List<TimePlanningWorkingHoursModel>();
+                    var doUseOneMinute = doCache?.AssignedSite?.UseOneMinuteIntervals ?? false;
+                    foreach (var planning in doPlannings)
+                    {
+                        dayOverviewRows.Add(new DayOverviewRow
+                        {
+                            EmployeeNo = doWorker.EmployeeNo ?? string.Empty,
+                            WorkerName = doSite.Name,
+                            Date = planning.Date,
+                            Planning = planning,
+                            UseOneMinuteIntervals = doUseOneMinute
+                        });
+                    }
+                }
+                dayOverviewRows = dayOverviewRows
+                    .OrderBy(r => r.Date)
+                    .ThenBy(r => int.TryParse(r.EmployeeNo, out var n) ? n : int.MaxValue)
+                    .ThenBy(r => r.EmployeeNo)
+                    .ToList();
+                BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
+
+                #endregion
 
                 #region TotalSheetSetup
 
-                WorksheetPart totalWorksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId1");
+                WorksheetPart totalWorksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId2");
                 var seedMessages = new TimePlanningSeedMessages().Data;
 
                 var totalHeaders = new[]
@@ -3078,7 +3125,7 @@ public class TimePlanningWorkingHoursService(
                     if (site == null) continue;
                     var siteWorker = await sdkContext.SiteWorkers.FirstAsync(x => x.SiteId == site.Id);
                     var worker = await sdkContext.Workers.FirstAsync(x => x.Id == siteWorker.WorkerId);
-                    WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId{i + 2}");
+                    WorksheetPart worksheetPart1 = workbookPart1.AddNewPart<WorksheetPart>($"rId{i + 3}");
 
                     var headers = new[]
                     {
@@ -3905,6 +3952,212 @@ public class TimePlanningWorkingHoursService(
         public PayRuleSet PayRuleSet { get; set; }
         public List<TimePlanningWorkingHoursModel> TimePlannings { get; set; }
         public Dictionary<DateTime, List<PlanRegistrationPayLine>> PayLinesByDate { get; set; }
+    }
+
+    private sealed class DayOverviewRow
+    {
+        public string EmployeeNo { get; set; }
+        public string WorkerName { get; set; }
+        public DateTime Date { get; set; }
+        public TimePlanningWorkingHoursModel Planning { get; set; }
+        public bool UseOneMinuteIntervals { get; set; }
+    }
+
+    internal double? GetShiftTimeFraction(int? shift, DateTime? actualStamp, bool useOneMinuteIntervals)
+    {
+        if (useOneMinuteIntervals && actualStamp.HasValue)
+        {
+            return actualStamp.Value.TimeOfDay.TotalMinutes / 1440.0;
+        }
+        if (!shift.HasValue || shift.Value <= 0)
+        {
+            return null;
+        }
+        if (shift.Value == 289)
+        {
+            return 1.0; // 24:00 — end of day; renders as 00:00 under hh:mm (known minor edge)
+        }
+        return (shift.Value - 1) * 5 / 1440.0;
+    }
+
+    private Cell DayOverviewStringCell(int col, uint rowIdx, string value)
+    {
+        return new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(value ?? string.Empty),
+            DataType = CellValues.String
+        };
+    }
+
+    private Cell DayOverviewNumberCell(int col, uint rowIdx, double value, uint? styleIndex)
+    {
+        var cell = new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)),
+            DataType = CellValues.Number
+        };
+        if (styleIndex.HasValue)
+        {
+            cell.StyleIndex = styleIndex.Value;
+        }
+        return cell;
+    }
+
+    private Cell DayOverviewDateCell(int col, uint rowIdx, DateTime date)
+    {
+        return new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            CellValue = new CellValue(date.ToOADate().ToString(CultureInfo.InvariantCulture)),
+            DataType = CellValues.Number,
+            StyleIndex = (UInt32Value)5U // dd/mm/yyyy
+        };
+    }
+
+    private Cell DayOverviewTimeCell(int col, uint rowIdx, double? fraction)
+    {
+        var cell = new Cell
+        {
+            CellReference = $"{GetColumnLetter(col)}{rowIdx}",
+            DataType = CellValues.Number,
+            StyleIndex = (UInt32Value)3U // hh:mm
+        };
+        if (fraction.HasValue)
+        {
+            cell.CellValue = new CellValue(fraction.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        return cell;
+    }
+
+    private void BuildDayOverviewWorksheet(WorksheetPart worksheetPart, List<DayOverviewRow> rows, CultureInfo culture)
+    {
+        const int colCount = 21;
+        var headers = new[]
+        {
+            Translations.Employee_no, Translations.Worker, Translations.DayOfWeek,
+            Translations.Date, Translations.Week_number,
+            Translations.Shift_1__start, Translations.Shift_1__end, Translations.Shift_1__pause,
+            Translations.Shift_2__start, Translations.Shift_2__end, Translations.Shift_2__pause,
+            Translations.Shift_3__start, Translations.Shift_3__end, Translations.Shift_3__pause,
+            Translations.Shift_4__start, Translations.Shift_4__end, Translations.Shift_4__pause,
+            Translations.Shift_5__start, Translations.Shift_5__end, Translations.Shift_5__pause,
+            Translations.NettoHours
+        };
+
+        var worksheet = new Worksheet()
+            { MCAttributes = new MarkupCompatibilityAttributes() { Ignorable = "x14ac xr xr2 xr3" } };
+        worksheet.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        worksheet.AddNamespaceDeclaration("mc", "http://schemas.openxmlformats.org/markup-compatibility/2006");
+        worksheet.AddNamespaceDeclaration("x14ac", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac");
+        worksheet.AddNamespaceDeclaration("xr", "http://schemas.microsoft.com/office/spreadsheetml/2014/revision");
+        worksheet.AddNamespaceDeclaration("xr2", "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2");
+        worksheet.AddNamespaceDeclaration("xr3", "http://schemas.microsoft.com/office/spreadsheetml/2016/revision3");
+
+        var sheetFormatProperties = new SheetFormatProperties() { DefaultRowHeight = 15D, DyDescent = 0.25D };
+
+        var columns = new Columns();
+        columns.Append(new Column() { Min = 1U, Max = 1U, Width = 18D, CustomWidth = true });
+        columns.Append(new Column() { Min = 2U, Max = 2U, Width = 15D, CustomWidth = true });
+        columns.Append(new Column() { Min = 3U, Max = 3U, Width = 10D, CustomWidth = true });
+        columns.Append(new Column() { Min = 4U, Max = 4U, Width = 11D, CustomWidth = true });
+        columns.Append(new Column() { Min = 5U, Max = 5U, Width = 8D, CustomWidth = true });
+        columns.Append(new Column() { Min = 6U, Max = 20U, Width = 13.5D, CustomWidth = true });
+        columns.Append(new Column() { Min = 21U, Max = 21U, Width = 12D, CustomWidth = true });
+
+        var sheetData = new SheetData();
+
+        var headerRow = new Row() { RowIndex = (UInt32Value)1U };
+        for (int c = 0; c < colCount; c++)
+        {
+            headerRow.Append(new Cell
+            {
+                CellReference = $"{GetColumnLetter(c + 1)}1",
+                CellValue = new CellValue(headers[c]),
+                DataType = CellValues.String,
+                StyleIndex = (UInt32Value)1U
+            });
+        }
+        sheetData.Append(headerRow);
+
+        uint rowIndex = 2;
+        foreach (var row in rows)
+        {
+            var dataRow = new Row() { RowIndex = rowIndex };
+            int c = 1;
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.EmployeeNo));
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.WorkerName));
+            dataRow.Append(DayOverviewStringCell(c++, rowIndex, row.Date.ToString("dddd", culture)));
+            dataRow.Append(DayOverviewDateCell(c++, rowIndex, row.Date));
+            var weekNumber = culture.Calendar.GetWeekOfYear(row.Date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
+            dataRow.Append(DayOverviewNumberCell(c++, rowIndex, weekNumber, null));
+
+            var p = row.Planning;
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Start, p.Start1StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Stop, p.Stop1StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Start, p.Start2StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Stop, p.Stop2StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Start, p.Start3StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Stop, p.Stop3StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Start, p.Start4StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Stop, p.Stop4StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift4Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Start, p.Start5StartedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Stop, p.Stop5StoppedAt, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift5Pause, null, row.UseOneMinuteIntervals)));
+
+            var netto = p.NettoHoursOverrideActive ? p.NettoHoursOverride : p.NettoHours;
+            dataRow.Append(DayOverviewNumberCell(c, rowIndex, netto, (UInt32Value)4U));
+
+            sheetData.Append(dataRow);
+            rowIndex++;
+        }
+
+        uint lastRow = rowIndex - 1; // header-only when no data => 1
+        string reference = $"A1:{GetColumnLetter(colCount)}{lastRow}";
+
+        var pageMargins = new PageMargins() { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
+
+        worksheet.Append(sheetFormatProperties);
+        worksheet.Append(columns);
+        worksheet.Append(sheetData);
+        worksheet.Append(pageMargins);
+
+        var tableDefinitionPart = worksheetPart.AddNewPart<TableDefinitionPart>("rIdDayOverviewTable");
+        var table = new Table()
+        {
+            Id = (UInt32Value)1U,
+            Name = "DayOverview",
+            DisplayName = "DayOverview",
+            Reference = reference,
+            TotalsRowShown = false
+        };
+        table.Append(new AutoFilter() { Reference = reference });
+        var tableColumns = new TableColumns() { Count = (UInt32Value)(uint)colCount };
+        for (uint tc = 1; tc <= colCount; tc++)
+        {
+            tableColumns.Append(new TableColumn() { Id = (UInt32Value)tc, Name = headers[tc - 1] });
+        }
+        table.Append(tableColumns);
+        table.Append(new TableStyleInfo()
+        {
+            Name = "TableStyleMedium2",
+            ShowFirstColumn = false,
+            ShowLastColumn = false,
+            ShowRowStripes = true,
+            ShowColumnStripes = false
+        });
+        tableDefinitionPart.Table = table;
+
+        var tableParts = new TableParts() { Count = (UInt32Value)1U };
+        tableParts.Append(new TablePart() { Id = "rIdDayOverviewTable" });
+        worksheet.Append(tableParts);
+
+        worksheetPart.Worksheet = worksheet;
     }
 
     internal static List<PlanRegistrationPayLine> CalculatePayLinesForDay(

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/a/time-planning-working-hours.export.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/a/time-planning-working-hours.export.spec.ts
@@ -47,8 +47,11 @@ test.describe('Time planning plugin working hours export', () => {
     const generatedContent = fs.readFileSync(downloadPath!);
     const fixtureContent = fs.readFileSync(fixturesPath);
 
+    // The export now adds a localized "Dagsoversigt" (Day overview) sheet as the first tab,
+    // so the Dashboard data is no longer SheetNames[0]. Select the Dashboard sheet by name
+    // (the sheet this fixture represents) rather than by position.
     const wbGenerated = XLSX.read(generatedContent, { type: 'buffer' });
-    const sheetGenerated = wbGenerated.Sheets[wbGenerated.SheetNames[0]];
+    const sheetGenerated = wbGenerated.Sheets['Dashboard'];
     const jsonGenerated = XLSX.utils.sheet_to_json(sheetGenerated, { header: 1 }) as any[][];
 
     const wbFixture = XLSX.read(fixtureContent, { type: 'buffer' });


### PR DESCRIPTION
## Summary
Adds a localized **Dagsoversigt** (Day overview) worksheet as the **first tab** in both timeplanning Excel exports:
- **Single-worker** (`reports/file`): Dagsoversigt + existing Dashboard sheet
- **All-workers** (`reports/file-all-workers`): one **combined** Dagsoversigt (every worker's planning days, sorted by date then employee no.) + existing Total and per-site sheets

The sheet replicates the reference file layout: a banded Excel Table with a fixed 21-column layout — Employee no, Worker, weekday, date (`dd/mm/yyyy`), week number, all five shift blocks (start/stop/pause as real `hh:mm` time values), and net hours (`0.00`). Net hours reuse the existing override-aware computed value.

## Translation
- New resx key `DayOverview` (sheet name) added to the neutral resource + all 25 culture files. Lower-confidence translations to sanity-check: **fi-FI, ro-RO, uk-UA, el-GR**.
- Every column header reuses an existing resx key (no new header keys).

## Implementation notes
- New cell styles (`hh:mm` = 165, `dd/mm/yyyy` = 164, `0.00`) added to the shared stylesheet at new style indices (3/4/5); existing indices 0/1/2 untouched, so the other sheets are unchanged.
- A single shared `BuildDayOverviewWorksheet` builds the sheet; called exactly once per workbook (one unique `DayOverview` Excel Table).
- Known minor edge: a shift ending exactly at 24:00 (index 289) renders as `00:00` under `hh:mm`.

## Tests
- Unit test for the `GetShiftTimeFraction` time-of-day helper.
- E2E tests: single-worker first-sheet/header/table + cell styles & OADate values; all-workers combined+sorted rows and sheet order.
- Fixed an existing E2E helper (`ReadShift1Cells`) that assumed the first worksheet was the Dashboard sheet (now resolves Dashboard by name).

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)