### PR TITLE
fix(timeplanning): startup repair for corrupted pauseNId (last 7 days, 5-min sites)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/CorruptedPauseIdRepairTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/CorruptedPauseIdRepairTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.TimePlanningBase.Infrastructure.Data;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+[TestFixture]
+public class CorruptedPauseIdRepairTests : TestBaseSetup
+{
+    [SetUp]
+    public async Task SetUp()
+    {
+        await base.Setup();
+    }
+
+    [TearDown]
+    public new async Task TearDown()
+    {
+        await base.TearDown();
+    }
+
+    // ---- B0: characterize the timestamp-preferring netto writer ----------
+
+    /// <summary>
+    /// ComputeNettoSecondsFromDateTimeShifts prefers the pause DateTime delta
+    /// and ignores a corrupt absolute-tick Pause1Id. This is the writer used by
+    /// ApplyNettoFlexChainSecondPrecision (the flag-on / second-precision path).
+    /// </summary>
+    [Test]
+    public void ComputeNetto_PrefersPauseTimestamps_OverCorruptPauseId()
+    {
+        var date = new DateTime(2026, 6, 10, 0, 0, 0);
+        var pr = new PlanRegistration
+        {
+            Date = date,
+            Start1StartedAt = date.AddHours(8),
+            Stop1StoppedAt = date.AddHours(16),     // 8h work
+            Pause1StartedAt = date.AddHours(12),
+            Pause1StoppedAt = date.AddHours(12).AddMinutes(30), // 30m real pause
+            Pause1Id = 145,                          // CORRUPT absolute tick (12:00)
+        };
+
+        var netto = PlanRegistrationHelper.ComputeNettoSecondsFromDateTimeShifts(pr);
+
+        // 8h - 30m = 7h30m = 27000s, derived from timestamps not the id.
+        Assert.That(netto, Is.EqualTo(27000));
+    }
+
+    // ---- B1 + B4: repair fixes only in-window 5-min corrupted rows --------
+
+    [Test]
+    public async Task Repair_FixesOnlyInWindow5MinCorruptedRows()
+    {
+        var ctx = TimePlanningPnDbContext!;
+        var today = DateTime.UtcNow.Date;
+
+        // 5-min site (UseOneMinuteIntervals=false) and a 1-min site.
+        var fiveMinSite = await SeedAssignedSite(ctx, siteId: 100, useOneMinute: false);
+        var oneMinSite = await SeedAssignedSite(ctx, siteId: 200, useOneMinute: true);
+
+        // (a) corrupted in-window: 30m real pause, Pause1Id=145 (absolute 12:00 tick).
+        var corrupted = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-1),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
+        // (b) correct in-window: 30m pause, Pause1Id=7 ((30/5)+1).
+        var correct = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-2),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 7, work: (8, 16));
+        // (c) off-by-one in-window: Pause1Id=6 (min/5, missing +1) -> must be left alone.
+        var offByOne = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-3),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 6, work: (8, 16));
+        // (d) corrupted but out of window (> 7 days).
+        var oldRow = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-9),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
+        // (e) 1-min site, raw-minute id (30) -> not in scope.
+        var oneMin = await SeedRow(ctx, oneMinSite.SiteId, today.AddDays(-1),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 30, work: (8, 16));
+
+        await CorruptedPauseIdRepair.Run(ctx);
+
+        Assert.That((await Reload(ctx, corrupted)).Pause1Id, Is.EqualTo(7));   // fixed
+        Assert.That((await Reload(ctx, correct)).Pause1Id, Is.EqualTo(7));     // unchanged
+        Assert.That((await Reload(ctx, offByOne)).Pause1Id, Is.EqualTo(6));    // left alone
+        Assert.That((await Reload(ctx, oldRow)).Pause1Id, Is.EqualTo(145));    // out of window
+        Assert.That((await Reload(ctx, oneMin)).Pause1Id, Is.EqualTo(30));     // 1-min site
+
+        // B4: persisted netto for the repaired row is the timestamp-derived value
+        // (8h work - 30m pause = 27000s), not the corrupt tick-derived netto.
+        Assert.That((await Reload(ctx, corrupted)).NettoHoursInSeconds, Is.EqualTo(27000));
+    }
+
+    // ---- B3: idempotency ---------------------------------------------------
+
+    [Test]
+    public async Task Repair_IsIdempotent()
+    {
+        var ctx = TimePlanningPnDbContext!;
+        var site = await SeedAssignedSite(ctx, siteId: 100, useOneMinute: false);
+        var row = await SeedRow(ctx, site.SiteId, DateTime.UtcNow.Date.AddDays(-1),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
+
+        await CorruptedPauseIdRepair.Run(ctx);
+        var afterFirst = (await Reload(ctx, row)).Pause1Id;
+        await CorruptedPauseIdRepair.Run(ctx);
+        var afterSecond = (await Reload(ctx, row)).Pause1Id;
+
+        Assert.That(afterFirst, Is.EqualTo(7));
+        Assert.That(afterSecond, Is.EqualTo(7));
+    }
+
+    // ---- anomaly path never writes ----------------------------------------
+
+    /// <summary>
+    /// A corrupt absolute-tick Pause1Id with NO usable pause timestamps is an
+    /// unrepairable anomaly: the repair has no oracle to derive the true
+    /// duration from, so it must NOT guess/write. The id is left untouched
+    /// (the Sentry warning side-effect can't be asserted in this harness).
+    /// </summary>
+    [Test]
+    public async Task Repair_DoesNotWrite_WhenCorruptIdHasNoTimestamps()
+    {
+        var ctx = TimePlanningPnDbContext!;
+        var site = await SeedAssignedSite(ctx, siteId: 100, useOneMinute: false);
+
+        // In-window 5-min row: corrupt absolute tick (145) but no pause
+        // timestamps to repair from; shift span is a normal 08:00-16:00.
+        var row = await SeedRow(ctx, site.SiteId, DateTime.UtcNow.Date.AddDays(-1),
+            pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16),
+            seedPauseTimestamps: false);
+
+        await CorruptedPauseIdRepair.Run(ctx);
+
+        Assert.That((await Reload(ctx, row)).Pause1Id, Is.EqualTo(145)); // untouched
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static async Task<AssignedSiteEntity> SeedAssignedSite(
+        TimePlanningPnDbContext ctx, int siteId, bool useOneMinute)
+    {
+        var site = new AssignedSiteEntity
+        {
+            SiteId = siteId,
+            UseOneMinuteIntervals = useOneMinute,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await site.Create(ctx);
+        return site;
+    }
+
+    private static async Task<PlanRegistration> SeedRow(
+        TimePlanningPnDbContext ctx, int sdkSitId, DateTime date,
+        int pauseStart, int pauseStopMin, int pause1Id, (int Start, int Stop) work,
+        bool seedPauseTimestamps = true)
+    {
+        var pr = new PlanRegistration
+        {
+            Date = date,
+            SdkSitId = sdkSitId,
+            Start1StartedAt = date.AddHours(work.Start),
+            Stop1StoppedAt = date.AddHours(work.Stop),
+            Pause1StartedAt = seedPauseTimestamps ? date.AddHours(pauseStart) : (DateTime?)null,
+            Pause1StoppedAt = seedPauseTimestamps ? date.AddHours(pauseStart).AddMinutes(pauseStopMin) : (DateTime?)null,
+            Pause1Id = pause1Id,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await pr.Create(ctx);
+        return pr;
+    }
+
+    private static async Task<PlanRegistration> Reload(
+        TimePlanningPnDbContext ctx, PlanRegistration row)
+    {
+        return await ctx.PlanRegistrations
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == row.Id);
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/EformTimePlanningPlugin.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/EformTimePlanningPlugin.cs
@@ -200,6 +200,10 @@ public class EformTimePlanningPlugin : IEformPlugin
 
         // Seed database
         SeedDatabase(connectionString);
+
+        // One-shot, idempotent repair of pauseNId corruption (last 7 days,
+        // 5-minute sites). Safe to run on every startup.
+        RepairCorruptedPauseIds(connectionString);
     }
 
     public void Configure(IApplicationBuilder appBuilder)
@@ -906,6 +910,13 @@ public class EformTimePlanningPlugin : IEformPlugin
         }
 
         TimePlanningPluginSeed.SeedData(dbContext);
+    }
+
+    public void RepairCorruptedPauseIds(string connectionString)
+    {
+        var contextFactory = new TimePlanningPnContextFactory();
+        using var dbContext = contextFactory.CreateDbContext([connectionString]);
+        CorruptedPauseIdRepair.Run(dbContext).GetAwaiter().GetResult();
     }
 
     public PluginPermissionsManager GetPermissionsManager(string connectionString)

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.TimePlanningBase.Infrastructure.Data;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using Sentry;
+
+namespace TimePlanning.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// One-shot, idempotent repair for pauseNId corruption introduced by the
+/// mobile punch-clock sending the absolute stop-time tick instead of the
+/// pause duration on 5-minute sites. Scoped to the last 7 days and to
+/// 5-minute sites. Recomputes pauseNId from the intact pause timestamps,
+/// writing only when a row is both clearly corrupted and confidently
+/// repairable. Safe to run on every startup.
+///
+/// Netto consistency: on 5-minute (flag-off) sites the mobile save path
+/// (TimePlanningPlanningService.UpdateByCurrentUserNam) persists netto via the
+/// legacy 5-minute-tick pause math — the final writer on that path is
+/// PlanRegistrationHelper.ComputeTimeTrackingFields, which derives
+/// NettoHoursInSeconds/NettoHours as work − (pauseNId − 1) * 300 seconds. With
+/// the corrupt absolute-tick pauseNId that yields a grossly wrong (huge) break,
+/// so the persisted netto for the corrupted rows is ALSO corrupt. After fixing
+/// pauseNId we therefore re-run that exact same writer
+/// (ComputeTimeTrackingFields) on each corrected row, so the persisted netto is
+/// recomputed from the now-correct pauseNId, byte-identical to what the save
+/// path would have written. (We deliberately do NOT use
+/// ApplyNettoFlexChainSecondPrecision here: that is the flag-ON / seconds-column
+/// writer and is never invoked for flag-off sites in production; its SumFlex*
+/// seed column SumFlexEndInSeconds is not maintained on flag-off rows.) The
+/// flag-off SumFlex* doubles are recomputed on read by the working-hours
+/// overview from the corrected NettoHours, so no separate flex-chain rewrite is
+/// needed here.
+///
+/// Limitation: the repair only acts on rows whose pause timestamps are intact
+/// and overstate the decoded pauseNId by &gt; the tolerance. A corrupted row
+/// whose pause timestamps happen to have been back-filled from the corrupt id
+/// (EnsureTimestampsFromIds, only when both stamps were null on a
+/// non-detailed-pause save) will have stamps that agree with the corrupt id and
+/// is conservatively left untouched — such a row carries no independent record
+/// of the true pause duration, so it cannot be confidently repaired.
+/// </summary>
+public static class CorruptedPauseIdRepair
+{
+    // Minutes encoded per pauseNId tick on 5-minute sites; the server contract
+    // encodes/decodes pause duration as (minutes / 5) + 1.
+    private const int MinutesPerTick = 5;
+
+    // A pause longer than the real one by more than this many minutes is
+    // treated as the absolute-tick corruption. The 5-minute off-by-one
+    // (5 min short) never trips this.
+    private const int CorruptionToleranceMinutes = 15;
+
+    /// <summary>
+    /// Fallback "implausibly large" span used by the anomaly heuristic when the
+    /// shift-1 worked span is unknown. 12h (720 min).
+    /// </summary>
+    private const double UnknownSpanFallbackMinutes = 720;
+
+    public static async Task Run(TimePlanningPnDbContext dbContext)
+    {
+        var windowStart = DateTime.UtcNow.Date.AddDays(-7);
+
+        // 5-minute sites only.
+        var fiveMinuteSiteIds = await dbContext.AssignedSites
+            .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed
+                        && !s.UseOneMinuteIntervals)
+            .Select(s => s.SiteId)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        if (fiveMinuteSiteIds.Count == 0) return;
+
+        var rows = await dbContext.PlanRegistrations
+            .AsTracking()
+            .Where(p => p.WorkflowState != Constants.WorkflowStates.Removed
+                        && p.Date >= windowStart
+                        && fiveMinuteSiteIds.Contains(p.SdkSitId))
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        // Observability counters (steps 1-3). They do not influence detection
+        // or correction behaviour in any way.
+        var rowsScanned = 0;
+        var rowsCorrected = 0;
+        var slotsCorrected = 0;
+        var anomaliesFlagged = 0;
+
+        foreach (var pr in rows)
+        {
+            rowsScanned++;
+
+            // Worked span of shift 1, used only to gauge whether an
+            // unrepairable id is implausibly large (anomaly heuristic).
+            double? workedMinutes = null;
+            if (pr.Start1StartedAt is not null && pr.Stop1StoppedAt is not null
+                && pr.Stop1StoppedAt > pr.Start1StartedAt)
+            {
+                workedMinutes = (pr.Stop1StoppedAt.Value - pr.Start1StartedAt.Value).TotalMinutes;
+            }
+
+            // Evaluate every slot (no short-circuit) so each FixSlot side
+            // effect (assign) runs and every slot is inspected for anomalies.
+            var r1 = FixSlot(pr.Pause1StartedAt, pr.Pause1StoppedAt, pr.Pause1Id, v => pr.Pause1Id = v);
+            var r2 = FixSlot(pr.Pause2StartedAt, pr.Pause2StoppedAt, pr.Pause2Id, v => pr.Pause2Id = v);
+            var r3 = FixSlot(pr.Pause3StartedAt, pr.Pause3StoppedAt, pr.Pause3Id, v => pr.Pause3Id = v);
+            var r4 = FixSlot(pr.Pause4StartedAt, pr.Pause4StoppedAt, pr.Pause4Id, v => pr.Pause4Id = v);
+            var r5 = FixSlot(pr.Pause5StartedAt, pr.Pause5StoppedAt, pr.Pause5Id, v => pr.Pause5Id = v);
+
+            var slotResults = new[] { r1, r2, r3, r4, r5 };
+            var changed = false;
+
+            for (var i = 0; i < slotResults.Length; i++)
+            {
+                var slot = i + 1;
+                var result = slotResults[i];
+
+                if (result.Corrected)
+                {
+                    changed = true;
+                    slotsCorrected++;
+                    // Step 1: log on the actual write path only.
+                    Console.WriteLine($"[CorruptedPauseIdRepair] fixed PlanRegistration {pr.Id} site {pr.SdkSitId} pause{slot}: {result.OldValue} -> {result.NewValue} (actual {result.ActualMinutes:F1} min)");
+                }
+                else if (IsUnrepairableAnomaly(result, workedMinutes))
+                {
+                    anomaliesFlagged++;
+                    // Step 2: corrupt-looking but no usable timestamps to repair
+                    // from -> warn to console AND Sentry for manual review.
+                    Console.WriteLine($"[CorruptedPauseIdRepair] WARNING: PlanRegistration {pr.Id} site {pr.SdkSitId} pause{slot} id={result.OldValue} looks corrupt but has no usable timestamps to repair from; needs manual review.");
+                    SentrySdk.CaptureMessage($"CorruptedPauseIdRepair: unrepairable corrupt pauseId on PlanRegistration {pr.Id} (site {pr.SdkSitId}, pause{slot}, id={result.OldValue})", SentryLevel.Warning);
+                }
+            }
+
+            if (!changed) continue;
+
+            rowsCorrected++;
+
+            // Re-establish persisted netto from the now-correct pauseNId using
+            // the same writer the flag-off save path uses as its final step, so
+            // the stored netto matches what a normal save would have written.
+            PlanRegistrationHelper.ComputeTimeTrackingFields(pr);
+
+            await pr.Update(dbContext).ConfigureAwait(false);
+        }
+
+        // Step 3: run summary.
+        Console.WriteLine($"[CorruptedPauseIdRepair] summary: scanned {rowsScanned} rows, corrected {rowsCorrected} rows ({slotsCorrected} slots), flagged {anomaliesFlagged} anomalies.");
+    }
+
+    /// <summary>
+    /// Per-slot outcome of <see cref="FixSlot"/>. Carries enough data for the
+    /// caller to log a correction or flag an unrepairable anomaly. Purely
+    /// observational — detection/correction behaviour is unchanged.
+    /// </summary>
+    private readonly struct SlotResult
+    {
+        public bool Corrected { get; init; }
+
+        /// <summary>The slot's pauseNId as found before any correction.</summary>
+        public int OldValue { get; init; }
+
+        /// <summary>The corrected pauseNId (only meaningful when Corrected).</summary>
+        public int NewValue { get; init; }
+
+        /// <summary>Timestamp-derived pause duration in minutes, or null when
+        /// the pause timestamps were missing/unusable.</summary>
+        public double? ActualMinutes { get; init; }
+    }
+
+    /// <summary>
+    /// A slot is an unrepairable anomaly when it has a positive pauseNId but no
+    /// usable pause timestamps to repair from (ActualMinutes is null), and the
+    /// id alone is implausibly large: its decoded minutes (pauseNId-1)*5 exceed
+    /// the shift-1 worked span, or — when that span is unknown — exceed 12h.
+    /// </summary>
+    private static bool IsUnrepairableAnomaly(SlotResult result, double? workedMinutes)
+    {
+        if (result.Corrected) return false;
+        if (result.OldValue <= 0) return false;
+        // Only the rows we could NOT repair from timestamps qualify.
+        if (result.ActualMinutes is not null) return false;
+
+        var decodedMinutes = (result.OldValue - 1) * MinutesPerTick;
+        var implausibleSpan = workedMinutes ?? UnknownSpanFallbackMinutes;
+        return decodedMinutes > implausibleSpan;
+    }
+
+    // Returns the slot outcome: corrected (with old/new/actualMinutes) when the
+    // slot was clearly absolute-tick corrupted and confidently repairable,
+    // otherwise untouched. Detection and correction logic are byte-identical to
+    // the pre-logging version.
+    private static SlotResult FixSlot(DateTime? start, DateTime? stop, int currentId, Action<int> assign)
+    {
+        if (currentId <= 0 || start is null || stop is null || stop <= start)
+            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = null };
+
+        var actualMinutes = (stop.Value - start.Value).TotalMinutes;
+        var decodedMinutes = (currentId - 1) * MinutesPerTick;
+
+        // Only repair the clear absolute-tick overstatement; ignore the
+        // known 5-minute off-by-one (out of scope).
+        if (decodedMinutes - actualMinutes <= CorruptionToleranceMinutes)
+            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actualMinutes };
+
+        // Server contract: (durationMinutes / 5) + 1, matching the existing
+        // server "/5 + 1" encode (integer/truncating). actualMinutes is a
+        // double, so dividing by the int MinutesPerTick performs the same
+        // double division as the previous / 5.0 before the truncating cast.
+        var corrected = (int)(actualMinutes / MinutesPerTick) + 1;
+        if (corrected == currentId)
+            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actualMinutes };
+
+        assign(corrected);
+        return new SlotResult { Corrected = true, OldValue = currentId, NewValue = corrected, ActualMinutes = actualMinutes };
+    }
+}


### PR DESCRIPTION
## Problem
The mobile punch-clock had been sending the absolute stop-time tick as `pauseNId` on pause-stop for 5-minute sites instead of the pause duration. The server decodes `pauseNId` as `(pauseNId-1)*5` minutes, so corrupted ids (e.g. 145) became ~12h breaks and drove netto hours negative. Verified on real rows 17003/17024/19545 (ids 116/115/115 → ~9.5h decoded vs ~30min real pause; persisted NettoHours ≈ -0.92h).

The app-side fix (stops new corruption) is in the flutter-time repo. This PR repairs the already-corrupted historical rows.

## Fix
New idempotent, corrupted-rows-only startup repair (`CorruptedPauseIdRepair`), mirroring the existing `SeedDatabase` startup idiom, scoped to the last 7 days and to 5-minute sites (`UseOneMinuteIntervals == false`):
- Oracle = the intact pause timestamps. A slot is corrupt when `(pauseNId-1)*5 - actualMinutes > 15` (catches the absolute-tick overstatement; ignores the known 5-min off-by-one).
- Corrected value `(int)(actualMinutes/5)+1`, matching the server's `/5+1` encode. Writes only on change (idempotent).
- After correcting a row, re-runs the real production netto writer `ComputeTimeTrackingFields` so persisted `NettoHours`/`NettoHoursInSeconds` are restored (verified this is the flag-off save path's final netto writer).
- Logs each correction to console and flags corrupt-but-unrepairable rows (no usable timestamps) to console + Sentry for manual review.

No schema change / no migration (pure data update via the DbContext). No base-package edits.

## Tests (NUnit + Testcontainers MariaDB)
Control matrix: corrupted-in-window FIXED, correct UNCHANGED, off-by-one LEFT ALONE, out-of-window UNCHANGED, 1-minute-site UNCHANGED; idempotency; netto recompute assertion; and no-write-when-corrupt-id-has-no-timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)