### PR TITLE
fix(timeplanning): self-heal corrupt pauseNId on save (temporary guard)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdCorrectionTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdCorrectionTests.cs
@@ -1,0 +1,45 @@
+using System;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+[TestFixture]
+public class PauseIdCorrectionTests
+{
+    private static readonly DateTime Start = new(2026, 6, 16, 9, 0, 0);
+
+    [Test]
+    public void Corrupt_AbsoluteTick_IsCorrectedToDuration()
+    {
+        // 28-minute real pause, but id=116 (absolute 09:35 tick) decodes to 575 min.
+        var stop = Start.AddMinutes(28);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, stop, 116), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void CorrectValue_ReturnsNull()
+    {
+        // 30-min pause, id=7 = (30/5)+1 is already correct.
+        var stop = Start.AddMinutes(30);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, stop, 7), Is.Null);
+    }
+
+    [Test]
+    public void OffByOne_IsLeftAlone()
+    {
+        // 30-min pause, id=6 = 30/5 (missing +1) understates -> not corrected.
+        var stop = Start.AddMinutes(30);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, stop, 6), Is.Null);
+    }
+
+    [Test]
+    public void ZeroOrMissing_ReturnsNull()
+    {
+        var stop = Start.AddMinutes(30);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, stop, 0), Is.Null);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(null, stop, 116), Is.Null);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, null, 116), Is.Null);
+        Assert.That(PauseIdCorrection.CorrectedPauseId(Start, Start, 116), Is.Null);
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdSelfHealGuardTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdSelfHealGuardTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.UpdateCreate;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using RegistrationDeviceEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.RegistrationDevice;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Integration coverage for the on-save pauseNId self-heal guard
+/// (<c>TimePlanningWorkingHoursService.SelfHealCorruptPauseIds</c>) exercised
+/// end-to-end through the kiosk gRPC write path
+/// (<c>UpdateWorkingHour(int? sdkSiteId, model, token)</c>) against a real
+/// Testcontainers MariaDB.
+///
+/// The kiosk and personal save paths share the identical guard call placed
+/// immediately before the inline 5-minute-tick netto math, so the kiosk path is
+/// used to drive every scenario: it requires only <c>userService.UserId</c> and
+/// the plugin <c>dbContext</c> (no SDK core / JWT), which the integration harness
+/// provides. A corrupt <c>Shift1Pause</c> (absolute stop-tick) plus truthful
+/// <c>Pause1StartedAt/StoppedAt</c> must be persisted as the timestamp-derived
+/// duration id, healing netto in the same save.
+/// </summary>
+[TestFixture]
+public class PauseIdSelfHealGuardTests : TestBaseSetup
+{
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+    }
+
+    private TimePlanningWorkingHoursService BuildService(bool? pauseIdSelfHealEnabled)
+    {
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+
+        var localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        var coreService = Substitute.For<IEFormCoreService>();
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0",
+            PauseIdSelfHealEnabled = pauseIdSelfHealEnabled,
+        });
+
+        // The kiosk path only references userService.UserId and dbContext from the
+        // constructor graph; baseDbContext / coreHelper are never dereferenced here.
+        return new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            TimePlanningPnDbContext!,
+            userService,
+            localizationService,
+            baseDbContext: null!,
+            options,
+            coreService);
+    }
+
+    private async Task SeedSiteAsync(int siteId, bool useOneMinuteIntervals)
+    {
+        await new AssignedSiteEntity
+        {
+            SiteId = siteId,
+            UseOneMinuteIntervals = useOneMinuteIntervals,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+    }
+
+    private async Task SeedDeviceAsync(string token, string otp)
+    {
+        await new RegistrationDeviceEntity
+        {
+            Token = token,
+            Name = "Kiosk Device",
+            OtpCode = otp,
+            SoftwareVersion = "1.0.0",
+            Manufacturer = "Test",
+            Model = "Test",
+            OsVersion = "1.0",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+    }
+
+    // A worked shift of 96 5-minute ticks (108 -> 204, i.e. 09:00 -> 17:00).
+    // The inline netto math is (Stop1Id - Start1Id) - (Pause1Id - 1), then * 5.
+    // With the corrupt id (116) netto is grossly negative; with the corrected id
+    // (6) netto is sane and positive.
+    private static TimePlanningWorkingHoursUpdateModel BuildModel(
+        DateTime date, int pauseId, int pauseMinutes)
+    {
+        var pauseStart = date.AddHours(12);
+        var pauseStop = pauseStart.AddMinutes(pauseMinutes);
+        return new TimePlanningWorkingHoursUpdateModel
+        {
+            Date = date,
+            Shift1Start = 108,
+            Shift1Stop = 204,
+            Shift1Pause = pauseId,
+            Start1StartedAt = $"{date:yyyy-MM-dd}T09:00:00",
+            Stop1StoppedAt = $"{date:yyyy-MM-dd}T17:00:00",
+            Pause1StartedAt = pauseStart.ToString("yyyy-MM-ddTHH:mm:ss"),
+            Pause1StoppedAt = pauseStop.ToString("yyyy-MM-ddTHH:mm:ss"),
+            CommentWorker = "",
+            OsVersion = "1.0",
+            Model = "Test",
+            Manufacturer = "Test",
+            SoftwareVersion = "1.0.0",
+        };
+    }
+
+    private async Task<Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration>
+        PersistedRowAsync(int siteId, DateTime date)
+    {
+        return await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking()
+            .Where(x => x.SdkSitId == siteId && x.Date == date)
+            .OrderByDescending(x => x.Id)
+            .FirstAsync();
+    }
+
+    [Test]
+    public async Task Corrupt_5MinSite_IsHealedOnSave()
+    {
+        const int siteId = 9601;
+        var token = "selfheal-corrupt";
+        var date = new DateTime(2026, 6, 16, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: false);
+        await SeedDeviceAsync(token, "10001");
+
+        // 28-min real pause, corrupt absolute-tick id 116 -> corrected to 6.
+        var model = BuildModel(date, pauseId: 116, pauseMinutes: 28);
+        var service = BuildService(pauseIdSelfHealEnabled: null);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.Multiple(() =>
+        {
+            Assert.That(pr.Pause1Id, Is.EqualTo(6), "corrupt absolute-tick id must be healed to (28/5)+1");
+            Assert.That(pr.NettoHours, Is.GreaterThan(0), "netto must be sane (positive) after healing");
+        });
+    }
+
+    [Test]
+    public async Task Correct_Value_Unchanged()
+    {
+        const int siteId = 9602;
+        var token = "selfheal-correct";
+        var date = new DateTime(2026, 6, 16, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: false);
+        await SeedDeviceAsync(token, "10002");
+
+        // 30-min pause, already-correct id 7 = (30/5)+1.
+        var model = BuildModel(date, pauseId: 7, pauseMinutes: 30);
+        var service = BuildService(pauseIdSelfHealEnabled: null);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.That(pr.Pause1Id, Is.EqualTo(7), "correct id must be left unchanged");
+    }
+
+    [Test]
+    public async Task OffByOne_Unchanged()
+    {
+        const int siteId = 9603;
+        var token = "selfheal-offbyone";
+        var date = new DateTime(2026, 6, 16, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: false);
+        await SeedDeviceAsync(token, "10003");
+
+        // 30-min pause, id 6 = 30/5 (missing +1) understates -> not corrected.
+        var model = BuildModel(date, pauseId: 6, pauseMinutes: 30);
+        var service = BuildService(pauseIdSelfHealEnabled: null);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.That(pr.Pause1Id, Is.EqualTo(6), "off-by-one must be left unchanged");
+    }
+
+    [Test]
+    public async Task OneMinuteSite_Unchanged()
+    {
+        const int siteId = 9604;
+        var token = "selfheal-1min";
+        var date = new DateTime(2026, 6, 16, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: true);
+        await SeedDeviceAsync(token, "10004");
+
+        // 1-minute sites are never affected; the guard must skip them.
+        var model = BuildModel(date, pauseId: 116, pauseMinutes: 28);
+        var service = BuildService(pauseIdSelfHealEnabled: null);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.That(pr.Pause1Id, Is.EqualTo(116), "guard must skip 1-minute sites");
+    }
+
+    [Test]
+    public async Task FlagDisabled_NotHealed()
+    {
+        const int siteId = 9605;
+        var token = "selfheal-flagoff";
+        var date = new DateTime(2026, 6, 16, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: false);
+        await SeedDeviceAsync(token, "10005");
+
+        var model = BuildModel(date, pauseId: 116, pauseMinutes: 28);
+        // Kill switch off -> the corrupt id must be persisted as-is.
+        var service = BuildService(pauseIdSelfHealEnabled: false);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.That(pr.Pause1Id, Is.EqualTo(116), "flag off -> guard must not heal");
+    }
+
+    [Test]
+    public async Task Kiosk_Path_IsHealed()
+    {
+        const int siteId = 9606;
+        var token = "selfheal-kiosk";
+        var date = new DateTime(2026, 6, 17, 0, 0, 0);
+        await SeedSiteAsync(siteId, useOneMinuteIntervals: false);
+        await SeedDeviceAsync(token, "10006");
+
+        // Explicit kiosk-path heal of a corrupt absolute-tick id.
+        var model = BuildModel(date, pauseId: 116, pauseMinutes: 28);
+        var service = BuildService(pauseIdSelfHealEnabled: null);
+
+        var result = await service.UpdateWorkingHour(sdkSiteId: siteId, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await PersistedRowAsync(siteId, date);
+        Assert.Multiple(() =>
+        {
+            Assert.That(pr.Pause1Id, Is.EqualTo(6), "kiosk save must heal the corrupt id");
+            Assert.That(pr.NettoHours, Is.GreaterThan(0), "kiosk netto must be sane after healing");
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdSelfHealGuardTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PauseIdSelfHealGuardTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -45,15 +45,6 @@ namespace TimePlanning.Pn.Infrastructure.Helpers;
 /// </summary>
 public static class CorruptedPauseIdRepair
 {
-    // Minutes encoded per pauseNId tick on 5-minute sites; the server contract
-    // encodes/decodes pause duration as (minutes / 5) + 1.
-    private const int MinutesPerTick = 5;
-
-    // A pause longer than the real one by more than this many minutes is
-    // treated as the absolute-tick corruption. The 5-minute off-by-one
-    // (5 min short) never trips this.
-    private const int CorruptionToleranceMinutes = 15;
-
     /// <summary>
     /// Fallback "implausibly large" span used by the anomaly heuristic when the
     /// shift-1 worked span is unknown. 12h (720 min).
@@ -184,7 +175,7 @@ public static class CorruptedPauseIdRepair
         // Only the rows we could NOT repair from timestamps qualify.
         if (result.ActualMinutes is not null) return false;
 
-        var decodedMinutes = (result.OldValue - 1) * MinutesPerTick;
+        var decodedMinutes = (result.OldValue - 1) * PauseIdCorrection.MinutesPerTick;
         var implausibleSpan = workedMinutes ?? UnknownSpanFallbackMinutes;
         return decodedMinutes > implausibleSpan;
     }
@@ -195,26 +186,28 @@ public static class CorruptedPauseIdRepair
     // the pre-logging version.
     private static SlotResult FixSlot(DateTime? start, DateTime? stop, int currentId, Action<int> assign)
     {
-        if (currentId <= 0 || start is null || stop is null || stop <= start)
-            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = null };
+        // Delegate the detect+correct decision to the shared single-source-of-truth
+        // helper, so the batch repair and the on-save guard apply byte-identical
+        // rules. The corrected value and the >15 min tolerance are unchanged.
+        var corrected = PauseIdCorrection.CorrectedPauseId(start, stop, currentId);
+        if (corrected is null)
+        {
+            // Preserve the actualMinutes value used by the anomaly heuristic /
+            // logging when the timestamps exist.
+            double? actual = (start.HasValue && stop.HasValue && stop.Value > start.Value)
+                ? (stop.Value - start.Value).TotalMinutes
+                : (double?)null;
+            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actual };
+        }
 
-        var actualMinutes = (stop.Value - start.Value).TotalMinutes;
-        var decodedMinutes = (currentId - 1) * MinutesPerTick;
-
-        // Only repair the clear absolute-tick overstatement; ignore the
-        // known 5-minute off-by-one (out of scope).
-        if (decodedMinutes - actualMinutes <= CorruptionToleranceMinutes)
-            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actualMinutes };
-
-        // Server contract: (durationMinutes / 5) + 1, matching the existing
-        // server "/5 + 1" encode (integer/truncating). actualMinutes is a
-        // double, so dividing by the int MinutesPerTick performs the same
-        // double division as the previous / 5.0 before the truncating cast.
-        var corrected = (int)(actualMinutes / MinutesPerTick) + 1;
-        if (corrected == currentId)
-            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actualMinutes };
-
-        assign(corrected);
-        return new SlotResult { Corrected = true, OldValue = currentId, NewValue = corrected, ActualMinutes = actualMinutes };
+        var actualMinutes = (stop!.Value - start!.Value).TotalMinutes;
+        assign(corrected.Value);
+        return new SlotResult
+        {
+            Corrected = true,
+            OldValue = currentId,
+            NewValue = corrected.Value,
+            ActualMinutes = actualMinutes,
+        };
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -186,21 +186,19 @@ public static class CorruptedPauseIdRepair
     // the pre-logging version.
     private static SlotResult FixSlot(DateTime? start, DateTime? stop, int currentId, Action<int> assign)
     {
+        // actualMinutes drives the anomaly heuristic / logging; it is only
+        // meaningful when the timestamps exist and are ordered, otherwise null.
+        double? actualMinutes = (start.HasValue && stop.HasValue && stop.Value > start.Value)
+            ? (stop.Value - start.Value).TotalMinutes
+            : null;
+
         // Delegate the detect+correct decision to the shared single-source-of-truth
         // helper, so the batch repair and the on-save guard apply byte-identical
         // rules. The corrected value and the >15 min tolerance are unchanged.
         var corrected = PauseIdCorrection.CorrectedPauseId(start, stop, currentId);
         if (corrected is null)
-        {
-            // Preserve the actualMinutes value used by the anomaly heuristic /
-            // logging when the timestamps exist.
-            double? actual = (start.HasValue && stop.HasValue && stop.Value > start.Value)
-                ? (stop.Value - start.Value).TotalMinutes
-                : (double?)null;
-            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actual };
-        }
+            return new SlotResult { Corrected = false, OldValue = currentId, ActualMinutes = actualMinutes };
 
-        var actualMinutes = (stop!.Value - start!.Value).TotalMinutes;
         assign(corrected.Value);
         return new SlotResult
         {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PauseIdCorrection.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PauseIdCorrection.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace TimePlanning.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// Single source of truth for detecting the absolute-stop-tick pauseNId
+/// corruption (5-minute sites) and computing the corrected duration id.
+/// Used by both the startup batch repair (CorruptedPauseIdRepair) and the
+/// on-save guard (TimePlanningWorkingHoursService.SelfHealCorruptPauseIds).
+/// </summary>
+public static class PauseIdCorrection
+{
+    public const int MinutesPerTick = 5;
+    public const int CorruptionToleranceMinutes = 15;
+
+    /// <summary>
+    /// Returns the corrected pauseNId when the slot carries the absolute-tick
+    /// corruption (decoded break overstates the real pause, from the
+    /// timestamps, by more than the tolerance), otherwise null (correct,
+    /// off-by-one, zero, or no usable timestamps — leave as-is).
+    /// </summary>
+    public static int? CorrectedPauseId(DateTime? start, DateTime? stop, int currentId)
+    {
+        if (currentId <= 0 || start is null || stop is null || stop <= start)
+            return null;
+
+        var actualMinutes = (stop.Value - start.Value).TotalMinutes;
+        var decodedMinutes = (currentId - 1) * MinutesPerTick;
+        if (decodedMinutes - actualMinutes <= CorruptionToleranceMinutes)
+            return null;
+
+        var corrected = (int)(actualMinutes / (double)MinutesPerTick) + 1;
+        return corrected == currentId ? null : corrected;
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/TimePlanningBaseSettings.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/TimePlanningBaseSettings.cs
@@ -68,4 +68,9 @@ public class TimePlanningBaseSettings
     public int DaysBackInTimeAllowedEditing { get; set; } = 2;
     public string GpsEnabled { get; set; }
     public string SnapshotEnabled { get; set; }
+
+    // Temporary kill switch for the on-save pauseNId self-heal guard. Null/true =
+    // enabled (default). Set false once all mobile apps are on a fixed version,
+    // then remove the guard. See spec 2026-06-16-pauseid-selfheal-guard-design.md.
+    public bool? PauseIdSelfHealEnabled { get; set; }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -931,7 +931,9 @@ public class TimePlanningWorkingHoursService(
     /// with the batch repair via <see cref="PauseIdCorrection"/>. Skips 1-minute
     /// sites and obeys the <c>PauseIdSelfHealEnabled</c> kill switch (default on).
     /// </summary>
-    private void SelfHealCorruptPauseIds(PlanRegistration pr, AssignedSite? site)
+    private void SelfHealCorruptPauseIds(
+        PlanRegistration pr,
+        Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite? site)
     {
         if (site is null || site.UseOneMinuteIntervals) return;       // 5-minute sites only
         if (!(options.Value.PauseIdSelfHealEnabled ?? true)) return;  // kill switch, default on

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -923,6 +923,37 @@ public class TimePlanningWorkingHoursService(
             result);
     }
 
+    /// <summary>
+    /// Temporary, default-on, server-side guard: corrects a corrupt incoming
+    /// pauseNId (the absolute-stop-tick bug on 5-minute sites) from the truthful
+    /// pause timestamps before the inline netto math, so the row self-heals
+    /// regardless of the client's app version. Shares the detect+correct rule
+    /// with the batch repair via <see cref="PauseIdCorrection"/>. Skips 1-minute
+    /// sites and obeys the <c>PauseIdSelfHealEnabled</c> kill switch (default on).
+    /// </summary>
+    private void SelfHealCorruptPauseIds(PlanRegistration pr, AssignedSite? site)
+    {
+        if (site is null || site.UseOneMinuteIntervals) return;       // 5-minute sites only
+        if (!(options.Value.PauseIdSelfHealEnabled ?? true)) return;  // kill switch, default on
+
+        void Heal(DateTime? start, DateTime? stop, int current, int slot, Action<int> assign)
+        {
+            var corrected = PauseIdCorrection.CorrectedPauseId(start, stop, current);
+            if (corrected is null) return;
+            assign(corrected.Value);
+            var msg = $"[PauseIdSelfHeal] site {pr.SdkSitId} {pr.Date:yyyy-MM-dd} "
+                    + $"pause{slot}: {current} -> {corrected.Value}";
+            Console.WriteLine(msg);
+            SentrySdk.CaptureMessage(msg, SentryLevel.Warning);
+        }
+
+        Heal(pr.Pause1StartedAt, pr.Pause1StoppedAt, pr.Pause1Id, 1, v => pr.Pause1Id = v);
+        Heal(pr.Pause2StartedAt, pr.Pause2StoppedAt, pr.Pause2Id, 2, v => pr.Pause2Id = v);
+        Heal(pr.Pause3StartedAt, pr.Pause3StoppedAt, pr.Pause3Id, 3, v => pr.Pause3Id = v);
+        Heal(pr.Pause4StartedAt, pr.Pause4StoppedAt, pr.Pause4Id, 4, v => pr.Pause4Id = v);
+        Heal(pr.Pause5StartedAt, pr.Pause5StoppedAt, pr.Pause5Id, 5, v => pr.Pause5Id = v);
+    }
+
     public async Task<OperationResult> UpdateWorkingHour(TimePlanningWorkingHoursUpdateModel model)
     {
         Console.WriteLine($"[DEBUG-GRPC-UPDATE] === UpdateWorkingHour (PERSONAL mode, 1-param) entered ===");
@@ -1253,6 +1284,10 @@ public class TimePlanningWorkingHoursService(
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
 
+            // Self-heal a corrupt incoming pauseNId from the truthful pause
+            // timestamps before the inline netto math (5-min sites, flag on).
+            SelfHealCorruptPauseIds(planRegistration, assignedSite);
+
             if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
             {
                 nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
@@ -1573,6 +1608,10 @@ public class TimePlanningWorkingHoursService(
             double nettoMinutes = 0;
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
+
+            // Self-heal a corrupt incoming pauseNId from the truthful pause
+            // timestamps before the inline netto math (5-min sites, flag on).
+            SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
             if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
             {
@@ -1954,6 +1993,10 @@ public class TimePlanningWorkingHoursService(
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
 
+            // Self-heal a corrupt incoming pauseNId from the truthful pause
+            // timestamps before the inline netto math (5-min sites, flag on).
+            SelfHealCorruptPauseIds(planRegistration, assignedSite);
+
             if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
             {
                 nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
@@ -2263,6 +2306,10 @@ public class TimePlanningWorkingHoursService(
                 .FirstOrDefaultAsync(x => x.SiteId == sdkSiteId!.Value);
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
+
+            // Self-heal a corrupt incoming pauseNId from the truthful pause
+            // timestamps before the inline netto math (5-min sites, flag on).
+            SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
             if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
             {


### PR DESCRIPTION
## Why
Some deployed mobile app versions still send the absolute stop-time tick as pauseNId (5-minute sites) instead of the duration, which the server decodes as a huge break and negative netto. The startup batch repair (already on stable) heals history but only at restart; this adds an on-save guard so new saves self-heal regardless of app version, until all customers upgrade.

## What
- Shared `PauseIdCorrection.CorrectedPauseId` helper = single source of the detect+correct rule; `CorruptedPauseIdRepair` refactored to use it (behavior-identical).
- `SelfHealCorruptPauseIds` guard in `TimePlanningWorkingHoursService.UpdateWorkingHour` (personal + kiosk write sites), 5-minute sites only, runs after pauseNId+timestamps are set and before the inline netto math, so the corrected id flows into a correct netto. Each correction logs to console + Sentry.
- Default-on kill switch `PauseIdSelfHealEnabled` on the plugin settings (no migration); set false + remove the guard once all apps are upgraded.
- Tests: `PauseIdCorrectionTests` (unit) + `PauseIdSelfHealGuardTests` (Testcontainers: corrupt-healed, correct/off-by-one/1-min/flag-off unchanged, kiosk).

Spec: docs/superpowers/specs/2026-06-16-pauseid-selfheal-guard-design.md (flutter-time repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)