### PR TITLE
fix(timeplanning): seed missing settings keys so UpdateSettings doesn't NRE

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ConfigurationSeedDataTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ConfigurationSeedDataTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Data.Seed.Data;
+
+namespace TimePlanning.Pn.Test;
+
+[TestFixture]
+public class ConfigurationSeedDataTests
+{
+    [Test]
+    public void SeedData_Contains_PauseIdSelfHealEnabled()
+    {
+        var seedData = new TimePlanningConfigurationSeedData();
+
+        Assert.That(
+            seedData.Data.Any(x =>
+                x.Name == "TimePlanningBaseSettings:PauseIdSelfHealEnabled"
+                && x.Value == "true"),
+            Is.True);
+    }
+
+    [Test]
+    public void SeedData_Contains_DaysBackInTimeAllowedEditingEnabled()
+    {
+        var seedData = new TimePlanningConfigurationSeedData();
+
+        Assert.That(
+            seedData.Data.Any(x =>
+                x.Name == "TimePlanningBaseSettings:DaysBackInTimeAllowedEditingEnabled"
+                && x.Value == "0"),
+            Is.True);
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Data/Seed/Data/TimePlanningConfigurationSeedData.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Data/Seed/Data/TimePlanningConfigurationSeedData.cs
@@ -221,6 +221,16 @@ public class TimePlanningConfigurationSeedData : IPluginConfigurationSeedData
         {
             Name = $"{TimePlanningBaseSettingsName}:FirebaseServiceAccountJson",
             Value = ""
+        },
+        new PluginConfigurationValue
+        {
+            Name = $"{TimePlanningBaseSettingsName}:PauseIdSelfHealEnabled",
+            Value = "true"
+        },
+        new PluginConfigurationValue
+        {
+            Name = $"{TimePlanningBaseSettingsName}:DaysBackInTimeAllowedEditingEnabled",
+            Value = "0"
         }
     ];
 }


### PR DESCRIPTION
## Problem

PR #1609 added the `PauseIdSelfHealEnabled` property to the plugin's bound `TimePlanningBaseSettings` but did not add a corresponding seed row. The eform settings framework looks up each bound property by its `PluginConfigurationValue` row when `UpdateSettings` runs; a missing row causes a NullReferenceException on save.

The pre-existing `DaysBackInTimeAllowedEditingEnabled` property (a `string`, written by `TimeSettingService.UpdateSettings`) had the **same** unseeded gap and fails the same way.

## Fix

Seed both keys in `TimePlanningConfigurationSeedData`:

- `TimePlanningBaseSettings:PauseIdSelfHealEnabled` = `true` (bool? property, bool-parsed)
- `TimePlanningBaseSettings:DaysBackInTimeAllowedEditingEnabled` = `0` (string property, read as `== "1"` in `TimeSettingService` line ~91, so `"0"` is the disabled default)

The startup seed is idempotent, so redeploy backfills the rows for existing tenants — no EF migration needed.

Tests in `ConfigurationSeedDataTests` assert both seed rows are present.

## Notes

- Built on top of #1608/#1609 (rebased onto current `stable`).
- No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)