### PR TITLE
fix(timeplanning): lock-aware repair window (rolling 21st payroll cutoff)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/CorruptedPauseIdRepairTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/CorruptedPauseIdRepairTests.cs
@@ -58,26 +58,30 @@ public class CorruptedPauseIdRepairTests : TestBaseSetup
     public async Task Repair_FixesOnlyInWindow5MinCorruptedRows()
     {
         var ctx = TimePlanningPnDbContext!;
-        var today = DateTime.UtcNow.Date;
+        // Anchor window membership to the rolling payroll-lock cutoff: the day
+        // after the cutoff is in-window (repairable); the cutoff day itself is
+        // locked / out-of-window.
+        var inWindow = CorruptedPauseIdRepair.FirstUnlockedDate(DateTime.UtcNow.Date).AddDays(1);
+        var locked = CorruptedPauseIdRepair.FirstUnlockedDate(DateTime.UtcNow.Date).AddDays(-1);
 
         // 5-min site (UseOneMinuteIntervals=false) and a 1-min site.
         var fiveMinSite = await SeedAssignedSite(ctx, siteId: 100, useOneMinute: false);
         var oneMinSite = await SeedAssignedSite(ctx, siteId: 200, useOneMinute: true);
 
         // (a) corrupted in-window: 30m real pause, Pause1Id=145 (absolute 12:00 tick).
-        var corrupted = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-1),
+        var corrupted = await SeedRow(ctx, fiveMinSite.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
         // (b) correct in-window: 30m pause, Pause1Id=7 ((30/5)+1).
-        var correct = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-2),
+        var correct = await SeedRow(ctx, fiveMinSite.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 7, work: (8, 16));
         // (c) off-by-one in-window: Pause1Id=6 (min/5, missing +1) -> must be left alone.
-        var offByOne = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-3),
+        var offByOne = await SeedRow(ctx, fiveMinSite.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 6, work: (8, 16));
-        // (d) corrupted but out of window (> 7 days).
-        var oldRow = await SeedRow(ctx, fiveMinSite.SiteId, today.AddDays(-9),
+        // (d) corrupted but out of window (on/before the locked cutoff).
+        var oldRow = await SeedRow(ctx, fiveMinSite.SiteId, locked,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
         // (e) 1-min site, raw-minute id (30) -> not in scope.
-        var oneMin = await SeedRow(ctx, oneMinSite.SiteId, today.AddDays(-1),
+        var oneMin = await SeedRow(ctx, oneMinSite.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 30, work: (8, 16));
 
         await CorruptedPauseIdRepair.Run(ctx);
@@ -100,7 +104,8 @@ public class CorruptedPauseIdRepairTests : TestBaseSetup
     {
         var ctx = TimePlanningPnDbContext!;
         var site = await SeedAssignedSite(ctx, siteId: 100, useOneMinute: false);
-        var row = await SeedRow(ctx, site.SiteId, DateTime.UtcNow.Date.AddDays(-1),
+        var inWindow = CorruptedPauseIdRepair.FirstUnlockedDate(DateTime.UtcNow.Date).AddDays(1);
+        var row = await SeedRow(ctx, site.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16));
 
         await CorruptedPauseIdRepair.Run(ctx);
@@ -128,7 +133,8 @@ public class CorruptedPauseIdRepairTests : TestBaseSetup
 
         // In-window 5-min row: corrupt absolute tick (145) but no pause
         // timestamps to repair from; shift span is a normal 08:00-16:00.
-        var row = await SeedRow(ctx, site.SiteId, DateTime.UtcNow.Date.AddDays(-1),
+        var inWindow = CorruptedPauseIdRepair.FirstUnlockedDate(DateTime.UtcNow.Date).AddDays(1);
+        var row = await SeedRow(ctx, site.SiteId, inWindow,
             pauseStart: 12, pauseStopMin: 30, pause1Id: 145, work: (8, 16),
             seedPauseTimestamps: false);
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/FirstUnlockedDateTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/FirstUnlockedDateTests.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+[TestFixture]
+public class FirstUnlockedDateTests
+{
+    [Test]
+    public void Day17_UsesPreviousMonth21st_PlusOne()
+        => Assert.That(CorruptedPauseIdRepair.FirstUnlockedDate(new DateTime(2026, 6, 17)),
+            Is.EqualTo(new DateTime(2026, 5, 22)));
+
+    [Test]
+    public void Day20_StillPreviousMonth()
+        => Assert.That(CorruptedPauseIdRepair.FirstUnlockedDate(new DateTime(2026, 6, 20)),
+            Is.EqualTo(new DateTime(2026, 5, 22)));
+
+    [Test]
+    public void Day21_SwitchesToCurrentMonth()
+        => Assert.That(CorruptedPauseIdRepair.FirstUnlockedDate(new DateTime(2026, 6, 21)),
+            Is.EqualTo(new DateTime(2026, 6, 22)));
+
+    [Test]
+    public void Day25_CurrentMonth()
+        => Assert.That(CorruptedPauseIdRepair.FirstUnlockedDate(new DateTime(2026, 12, 25)),
+            Is.EqualTo(new DateTime(2026, 12, 22)));
+
+    [Test]
+    public void EarlyJanuary_RollsToPreviousDecember()
+        => Assert.That(CorruptedPauseIdRepair.FirstUnlockedDate(new DateTime(2026, 1, 10)),
+            Is.EqualTo(new DateTime(2025, 12, 22)));
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -69,7 +69,7 @@ public static class CorruptedPauseIdRepair
 
     public static async Task Run(TimePlanningPnDbContext dbContext)
     {
-        var windowStart = DateTime.UtcNow.Date.AddDays(-7);
+        var windowStart = FirstUnlockedDate(DateTime.UtcNow.Date);
 
         // 5-minute sites only.
         var fiveMinuteSiteIds = await dbContext.AssignedSites

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -51,6 +51,22 @@ public static class CorruptedPauseIdRepair
     /// </summary>
     private const double UnknownSpanFallbackMinutes = 720;
 
+    /// <summary>
+    /// Earliest registration Date the repair may modify: the day AFTER the
+    /// rolling payroll-lock cutoff. Periods lock on the 21st — on/before the
+    /// 20th the cutoff is last month's 21st; from the 21st it is this month's
+    /// 21st. The cutoff day itself is locked, so we return cutoff + 1 day.
+    /// </summary>
+    public const int PayPeriodLockDay = 21;
+
+    public static DateTime FirstUnlockedDate(DateTime today)
+    {
+        var cutoff = today.Day < PayPeriodLockDay
+            ? new DateTime(today.Year, today.Month, PayPeriodLockDay).AddMonths(-1) // last month's 21st
+            : new DateTime(today.Year, today.Month, PayPeriodLockDay);              // this month's 21st
+        return cutoff.AddDays(1);
+    }
+
     public static async Task Run(TimePlanningPnDbContext dbContext)
     {
         var windowStart = DateTime.UtcNow.Date.AddDays(-7);

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/CorruptedPauseIdRepair.cs
@@ -12,7 +12,8 @@ namespace TimePlanning.Pn.Infrastructure.Helpers;
 /// <summary>
 /// One-shot, idempotent repair for pauseNId corruption introduced by the
 /// mobile punch-clock sending the absolute stop-time tick instead of the
-/// pause duration on 5-minute sites. Scoped to the last 7 days and to
+/// pause duration on 5-minute sites. Scoped to the unlocked window (Date
+/// after the rolling payroll-lock cutoff, see FirstUnlockedDate) and to
 /// 5-minute sites. Recomputes pauseNId from the intact pause timestamps,
 /// writing only when a row is both clearly corrupted and confidently
 /// repairable. Safe to run on every startup.


### PR DESCRIPTION
## Why
CorruptedPauseIdRepair only repaired Date >= now-7days, which missed ~99% of the corruption (it spans the whole funnel-bug era, ~26 days). A 30-day sweep showed 823 corrupt rows across 38 tenants vs only 11/4 in the 7-day window.

## What
- New pure `FirstUnlockedDate(today)`: the day after the rolling payroll-lock cutoff. Periods lock on the 21st — on/before the 20th the cutoff is last month's 21st; from the 21st it's this month's 21st. The locked 21st itself is never touched (returns cutoff + 1 day).
- The repair's lower bound becomes `FirstUnlockedDate(UtcNow.Date)` instead of `AddDays(-7)`. Everything else (5-min-site filter, corruption test, netto recompute, logging, idempotency) is unchanged. No upper bound, no migration.
- Unit tests pin the day-20/21 boundary and January year-rollover; integration control rows reanchored to the cutoff (in-window repaired, the locked 21st left unchanged).

Note: this is moot until `stable` is deployed to the backend serving the affected tenants. Locked periods (Date <= the cutoff) and the legacy >30-day over-midnight corruption are intentionally left untouched.

Spec: docs/superpowers/specs/2026-06-17-lock-aware-repair-window-design.md (flutter-time repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)