### PR TITLE
feat(timeplanning): carry OverMidnight per-site flag (proto + gRPC)

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/AssignedSite.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/AssignedSite.cs
@@ -56,6 +56,7 @@ public class AssignedSite
     public int SaturdayBreakMinutesUpperLimit { get; set; }
     public int SundayBreakMinutesUpperLimit { get; set; }
     public bool UseOneMinuteIntervals { get; set; }
+    public bool OverMidnight { get; set; }
     public bool AllowAcceptOfPlannedHours { get; set; }
     public bool AllowEditOfRegistrations { get; set; }
     public bool AllowPersonalTimeRegistration { get; set; }
@@ -228,6 +229,7 @@ public class AssignedSite
             SaturdayBreakMinutesUpperLimit = model.SaturdayBreakMinutesUpperLimit,
             SundayBreakMinutesUpperLimit = model.SundayBreakMinutesUpperLimit,
             UseOneMinuteIntervals = model.UseOneMinuteIntervals,
+            OverMidnight = model.OverMidnight,
             AllowAcceptOfPlannedHours = model.AllowAcceptOfPlannedHours,
             AllowEditOfRegistrations = model.AllowEditOfRegistrations,
             AllowPersonalTimeRegistration = model.AllowPersonalTimeRegistration,

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/Site.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Settings/Site.cs
@@ -29,4 +29,5 @@ public class Site
     public DateTime ResignedAtDate { get; set; }
     public string? PhoneNumber { get; set; }
     public bool UseOneMinuteIntervals { get; set; }
+    public bool OverMidnight { get; set; }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/settings.proto
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/settings.proto
@@ -210,6 +210,7 @@ message AssignedSite {
   AutoBreakSettings auto_break_settings = 161;
 
   bool enforce_end_of_shift_before_allow_registration = 162;
+  bool over_midnight = 163;
 }
 
 // Matches C# Site model
@@ -237,6 +238,7 @@ message Site {
   google.protobuf.Timestamp resigned_at_date = 21;
   string phone_number = 22;
   bool use_one_minute_intervals = 23;
+  bool over_midnight = 24;
 }
 
 // Response wrappers matching C# OperationDataResult<T>

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningSettingsGrpcService.cs
@@ -86,6 +86,7 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
                 SaturdayBreakMinutesUpperLimit = m.SaturdayBreakMinutesUpperLimit,
                 SundayBreakMinutesUpperLimit = m.SundayBreakMinutesUpperLimit,
                 UseOneMinuteIntervals = m.UseOneMinuteIntervals,
+                OverMidnight = m.OverMidnight,
                 AllowAcceptOfPlannedHours = m.AllowAcceptOfPlannedHours,
                 AllowEditOfRegistrations = m.AllowEditOfRegistrations,
                 AllowPersonalTimeRegistration = m.AllowPersonalTimeRegistration,
@@ -267,6 +268,7 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
                         DateTime.SpecifyKind(site.ResignedAtDate, DateTimeKind.Utc)),
                     PhoneNumber = site.PhoneNumber ?? "",
                     UseOneMinuteIntervals = site.UseOneMinuteIntervals,
+                    OverMidnight = site.OverMidnight,
                 };
                 response.Model.Add(grpcSite);
             }
@@ -320,6 +322,7 @@ public class TimePlanningSettingsGrpcService : TimePlanningSettingsService.TimeP
                         DateTime.SpecifyKind(site.ResignedAtDate, DateTimeKind.Utc)),
                     PhoneNumber = site.PhoneNumber ?? "",
                     UseOneMinuteIntervals = site.UseOneMinuteIntervals,
+                    OverMidnight = site.OverMidnight,
                 };
                 response.Model.Add(grpcSite);
             }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -312,7 +312,8 @@ public class TimeSettingService(
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
                             SnapshotEnabled = assignedSite.SnapshotEnabled,
-                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
+                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
+                            OverMidnight = assignedSite.OverMidnight
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users
@@ -619,7 +620,8 @@ public class TimeSettingService(
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
                             SnapshotEnabled = assignedSite.SnapshotEnabled,
-                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
+                            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
+                            OverMidnight = assignedSite.OverMidnight
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users
@@ -895,6 +897,7 @@ public class TimeSettingService(
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
                             UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
+                            OverMidnight = assignedSite.OverMidnight,
                         };
                         var workerEmail = (worker.Email ?? "").Trim().ToLower();
                         var user = baseDbContext == null || string.IsNullOrEmpty(workerEmail) ? null : await baseDbContext.Users

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
@@ -33,7 +33,7 @@
       <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.35" />
       <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.29" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.51" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.52" />
       <PackageReference Include="Sentry" Version="6.6.0" />
       <PackageReference Include="FirebaseAdmin" Version="3.5.0" />
       <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />


### PR DESCRIPTION
Phase B of the per-site OverMidnight feature. Carries the new `AssignedSite.OverMidnight` flag (added in Microting.TimePlanningBase 10.0.52) through the plugin contracts:

- bump `Microting.TimePlanningBase` → 10.0.52
- `OverMidnight` on the `AssignedSite` model (+ implicit operator) and the coworker `Site` model
- `over_midnight` proto field on `AssignedSite` (163) and `Site` (24)
- gRPC mapping on the assigned-site response and both coworker-site loops
- `OverMidnight = assignedSite.OverMidnight` in the three `new Site{}` assemblers in TimeSettingService (kiosk / active / resigned) so the coworker contract isn't silently false

Server only carries the flag; the behavior change is client-side (flutter-time Phase C). Default false.

Spec: flutter-time/docs/superpowers/specs/2026-06-17-over-midnight-per-site-flag-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)