### PR TITLE
fix(handover): treat double PlanHours as content when PlanHoursInSeconds=0

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
@@ -186,6 +186,53 @@ public class ContentHandoverServiceTests : TestBaseSetup
     }
 
     [Test]
+    public async Task CreateAsync_CreatesHandoverRequest_WhenSourceHasOnlyDoublePlanHours()
+    {
+        // Regression: rows created by Google import / PlanText parsing set only the
+        // double PlanHours and leave PlanHoursInSeconds at 0. Such a source row HAS
+        // content and the handover must proceed (it was previously rejected because
+        // the content gate only inspected PlanHoursInSeconds).
+        var date = new DateTime(2024, 1, 1);
+        var sourcePR = new PlanRegistration
+        {
+            Date = date,
+            SdkSitId = 1,
+            PlanHours = 8, // double set
+            PlanHoursInSeconds = 0, // seconds NOT set (import/parse path)
+            PlanText = null,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await sourcePR.Create(TimePlanningPnDbContext);
+
+        var targetPR = new PlanRegistration
+        {
+            Date = date,
+            SdkSitId = 2,
+            PlanHoursInSeconds = 0,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await targetPR.Create(TimePlanningPnDbContext);
+
+        var model = new ContentHandoverRequestCreateModel
+        {
+            ToSdkSitId = 2,
+            RequestComment = "Need to transfer imported plan"
+        };
+
+        // Act
+        var result = await _contentHandoverService.CreateAsync(sourcePR.Id, model);
+
+        // Assert
+        Assert.That(result.Success, Is.True, $"Expected success but got error: {result.Message}");
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.Count, Is.EqualTo(1));
+        Assert.That(result.Model[0].Status, Is.EqualTo("Pending"));
+        Assert.That(result.Model[0].ShiftIndex, Is.Null);
+    }
+
+    [Test]
     public async Task AcceptAsync_MovesContent_FromSourceToTarget()
     {
         // Arrange

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
@@ -322,7 +322,7 @@ public class ContentHandoverService : IContentHandoverService
             {
                 // Legacy full-day create.
                 // Validate source has content
-                var hasPlanHours = fromPR.PlanHoursInSeconds > 0;
+                var hasPlanHours = fromPR.PlanHoursInSeconds > 0 || fromPR.PlanHours > 0;
                 var hasPlanText = !string.IsNullOrWhiteSpace(fromPR.PlanText);
                 if (!hasPlanHours && !hasPlanText)
                 {


### PR DESCRIPTION
## Problem
`ContentHandoverService`'s source-content gate used `hasPlanHours = fromPR.PlanHoursInSeconds > 0`. Google-import (`GoogleSheetHelper`) and PlanText parsing (`PlanTextHelper`) set only the `double PlanHours` and leave `PlanHoursInSeconds = 0`, so a source row with planned hours but no `PlanText` was incorrectly rejected as "no content" and the handover was blocked.

## Fix
`var hasPlanHours = fromPR.PlanHoursInSeconds > 0 || fromPR.PlanHours > 0;`

Same root cause as the one-minute flex fix (PR #1616) — only the double plan field is populated by import/parse — different consumer. A completeness sweep confirmed this is the only content-gate keyed on the scalar plan-hours value; copy/clear logic handles both fields symmetrically.

## Test
`CreateAsync_CreatesHandoverRequest_WhenSourceHasOnlyDoublePlanHours` (DB-backed): source `PlanHours=8, PlanHoursInSeconds=0, PlanText=null` -> handover succeeds. Fails on old code (`SourcePlanRegistrationHasNoContent`), passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
