### PR TITLE
refactor(pause): stop admin path overloading ShiftNPauseNumber

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/Helpers/PauseMinutesCalculatorTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/Helpers/PauseMinutesCalculatorTests.cs
@@ -1,0 +1,142 @@
+using System;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test.Helpers;
+
+[TestFixture]
+public class PauseMinutesCalculatorTests
+{
+    // All timestamps are UTC (transport/storage rule).
+    private static readonly DateTime Start = new(2026, 6, 16, 9, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public void SinglePause_Shift1_ThirtyMinutes_ReturnsId6()
+    {
+        var planning = new PlanRegistration
+        {
+            Pause1StartedAt = Start,
+            Pause1StoppedAt = Start.AddMinutes(30),
+        };
+
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 1), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void SinglePause_Shift2_ThirtyMinutes_ReturnsId6()
+    {
+        var planning = new PlanRegistration
+        {
+            Pause20StartedAt = Start,
+            Pause20StoppedAt = Start.AddMinutes(30),
+        };
+
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 2), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void MultiplePauses_Shift1_Accumulate_30Plus20_ReturnsId10()
+    {
+        var planning = new PlanRegistration
+        {
+            Pause1StartedAt = Start,
+            Pause1StoppedAt = Start.AddMinutes(30),
+            Pause10StartedAt = Start.AddHours(2),
+            Pause10StoppedAt = Start.AddHours(2).AddMinutes(20),
+        };
+
+        // (30 + 20) / 5 = 10
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 1), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void MultiplePauses_Shift2_Accumulate_30Plus20_ReturnsId10()
+    {
+        var planning = new PlanRegistration
+        {
+            Pause20StartedAt = Start,
+            Pause20StoppedAt = Start.AddMinutes(30),
+            Pause21StartedAt = Start.AddHours(2),
+            Pause21StoppedAt = Start.AddHours(2).AddMinutes(20),
+        };
+
+        // (30 + 20) / 5 = 10
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 2), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void LastSlot_Shift1_Pause102_IsIncluded()
+    {
+        // Only the final slot of shift 1 is set; a short/wrong slot list would miss it.
+        var planning = new PlanRegistration
+        {
+            Pause102StartedAt = Start,
+            Pause102StoppedAt = Start.AddMinutes(30),
+        };
+
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 1), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void LastSlot_Shift2_Pause202_IsIncluded()
+    {
+        // Only the final slot of shift 2 is set; a short/wrong slot list would miss it.
+        var planning = new PlanRegistration
+        {
+            Pause202StartedAt = Start,
+            Pause202StoppedAt = Start.AddMinutes(30),
+        };
+
+        Assert.That(PauseMinutesCalculator.DerivePauseId(planning, 2), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void NoPauses_Shift1_ReturnsZero()
+    {
+        Assert.That(PauseMinutesCalculator.DerivePauseId(new PlanRegistration(), 1), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void NoPauses_Shift2_ReturnsZero()
+    {
+        Assert.That(PauseMinutesCalculator.DerivePauseId(new PlanRegistration(), 2), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Purity_Shift1_DoesNotMutateShift1PauseNumber()
+    {
+        var planning = new PlanRegistration
+        {
+            Shift1PauseNumber = 99,
+            Pause1StartedAt = Start,
+            Pause1StoppedAt = Start.AddMinutes(30),
+        };
+
+        PauseMinutesCalculator.DerivePauseId(planning, 1);
+
+        Assert.That(planning.Shift1PauseNumber, Is.EqualTo(99));
+    }
+
+    [Test]
+    public void Purity_Shift2_DoesNotMutateShift2PauseNumber()
+    {
+        var planning = new PlanRegistration
+        {
+            Shift2PauseNumber = 99,
+            Pause20StartedAt = Start,
+            Pause20StoppedAt = Start.AddMinutes(30),
+        };
+
+        PauseMinutesCalculator.DerivePauseId(planning, 2);
+
+        Assert.That(planning.Shift2PauseNumber, Is.EqualTo(99));
+    }
+
+    [Test]
+    public void InvalidShift_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => PauseMinutesCalculator.DerivePauseId(new PlanRegistration(), 3));
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PauseMinutesCalculator.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PauseMinutesCalculator.cs
@@ -1,0 +1,83 @@
+using System;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+
+namespace TimePlanning.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// Pure derivation of a PauseNId from the detailed pause start/stop slots of a
+/// <see cref="PlanRegistration"/>.
+///
+/// Historically the admin path accumulated total pause minutes into
+/// <c>ShiftNPauseNumber</c> only to derive <c>PauseNId = minutes / 5</c>. That
+/// overloaded the column, which the punch-clock path uses as a slot counter.
+/// This helper reproduces the exact same integer math without writing the column,
+/// so the resulting PauseNId is byte-identical to the previous behaviour.
+/// </summary>
+public static class PauseMinutesCalculator
+{
+    /// <summary>
+    /// Sums the duration (in whole minutes, truncated) of every populated pause slot
+    /// belonging to <paramref name="shift"/> and returns <c>totalMinutes / 5</c>.
+    /// Reads only; never mutates <paramref name="planning"/>.
+    /// </summary>
+    /// <param name="planning">The plan registration to read pause slots from.</param>
+    /// <param name="shift">The shift to derive the pause id for; must be 1 or 2.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="planning"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="shift"/> is not 1 or 2.</exception>
+    public static int DerivePauseId(PlanRegistration planning, int shift)
+    {
+        ArgumentNullException.ThrowIfNull(planning);
+
+        var totalMinutes = shift switch
+        {
+            // Exact slot set the admin path accumulated for shift 1 (15 slots):
+            // Pause1, Pause2, Pause10..Pause19, Pause100, Pause101, Pause102.
+            1 => SlotMinutes(planning.Pause1StartedAt, planning.Pause1StoppedAt)
+                 + SlotMinutes(planning.Pause2StartedAt, planning.Pause2StoppedAt)
+                 + SlotMinutes(planning.Pause10StartedAt, planning.Pause10StoppedAt)
+                 + SlotMinutes(planning.Pause11StartedAt, planning.Pause11StoppedAt)
+                 + SlotMinutes(planning.Pause12StartedAt, planning.Pause12StoppedAt)
+                 + SlotMinutes(planning.Pause13StartedAt, planning.Pause13StoppedAt)
+                 + SlotMinutes(planning.Pause14StartedAt, planning.Pause14StoppedAt)
+                 + SlotMinutes(planning.Pause15StartedAt, planning.Pause15StoppedAt)
+                 + SlotMinutes(planning.Pause16StartedAt, planning.Pause16StoppedAt)
+                 + SlotMinutes(planning.Pause17StartedAt, planning.Pause17StoppedAt)
+                 + SlotMinutes(planning.Pause18StartedAt, planning.Pause18StoppedAt)
+                 + SlotMinutes(planning.Pause19StartedAt, planning.Pause19StoppedAt)
+                 + SlotMinutes(planning.Pause100StartedAt, planning.Pause100StoppedAt)
+                 + SlotMinutes(planning.Pause101StartedAt, planning.Pause101StoppedAt)
+                 + SlotMinutes(planning.Pause102StartedAt, planning.Pause102StoppedAt),
+
+            // Exact slot set the admin path accumulated for shift 2 (13 slots):
+            // Pause20..Pause29, Pause200, Pause201, Pause202.
+            2 => SlotMinutes(planning.Pause20StartedAt, planning.Pause20StoppedAt)
+                 + SlotMinutes(planning.Pause21StartedAt, planning.Pause21StoppedAt)
+                 + SlotMinutes(planning.Pause22StartedAt, planning.Pause22StoppedAt)
+                 + SlotMinutes(planning.Pause23StartedAt, planning.Pause23StoppedAt)
+                 + SlotMinutes(planning.Pause24StartedAt, planning.Pause24StoppedAt)
+                 + SlotMinutes(planning.Pause25StartedAt, planning.Pause25StoppedAt)
+                 + SlotMinutes(planning.Pause26StartedAt, planning.Pause26StoppedAt)
+                 + SlotMinutes(planning.Pause27StartedAt, planning.Pause27StoppedAt)
+                 + SlotMinutes(planning.Pause28StartedAt, planning.Pause28StoppedAt)
+                 + SlotMinutes(planning.Pause29StartedAt, planning.Pause29StoppedAt)
+                 + SlotMinutes(planning.Pause200StartedAt, planning.Pause200StoppedAt)
+                 + SlotMinutes(planning.Pause201StartedAt, planning.Pause201StoppedAt)
+                 + SlotMinutes(planning.Pause202StartedAt, planning.Pause202StoppedAt),
+
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(shift), shift, "Only shift 1 and 2 are supported."),
+        };
+
+        return totalMinutes / 5;
+    }
+
+    private static int SlotMinutes(DateTime? startedAt, DateTime? stoppedAt)
+    {
+        if (startedAt == null || stoppedAt == null)
+        {
+            return 0;
+        }
+
+        return (int)(stoppedAt.Value - startedAt.Value).TotalMinutes;
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -674,181 +674,67 @@ public class TimePlanningPlanningService(
             }
             else
             {
-                planning.Shift1PauseNumber = 0;
                 planning.Pause1StartedAt = model.Pause1StartedAt;
                 planning.Pause1StoppedAt = model.Pause1StoppedAt;
-                if (planning.Pause1StartedAt != null && planning.Pause1StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber = (int)((DateTime)planning.Pause1StoppedAt - (DateTime)planning.Pause1StartedAt).TotalMinutes;
-                }
                 planning.Pause2StartedAt = model.Pause2StartedAt;
                 planning.Pause2StoppedAt = model.Pause2StoppedAt;
-                if (planning.Pause2StartedAt != null && planning.Pause2StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause2StoppedAt - (DateTime)planning.Pause2StartedAt).TotalMinutes;
-                }
                 planning.Pause10StartedAt = model.Pause10StartedAt;
                 planning.Pause10StoppedAt = model.Pause10StoppedAt;
-                if (planning.Pause10StartedAt != null && planning.Pause10StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause10StoppedAt - (DateTime)planning.Pause10StartedAt).TotalMinutes;
-                }
-
                 planning.Pause11StartedAt = model.Pause11StartedAt;
                 planning.Pause11StoppedAt = model.Pause11StoppedAt;
-                if (planning.Pause11StartedAt != null && planning.Pause11StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause11StoppedAt - (DateTime)planning.Pause11StartedAt).TotalMinutes;
-                }
                 planning.Pause12StartedAt = model.Pause12StartedAt;
                 planning.Pause12StoppedAt = model.Pause12StoppedAt;
-                if (planning.Pause12StartedAt != null && planning.Pause12StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause12StoppedAt - (DateTime)planning.Pause12StartedAt).TotalMinutes;
-                }
                 planning.Pause13StartedAt = model.Pause13StartedAt;
                 planning.Pause13StoppedAt = model.Pause13StoppedAt;
-                if (planning.Pause13StartedAt != null && planning.Pause13StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause13StoppedAt - (DateTime)planning.Pause13StartedAt).TotalMinutes;
-                }
                 planning.Pause14StartedAt = model.Pause14StartedAt;
                 planning.Pause14StoppedAt = model.Pause14StoppedAt;
-                if (planning.Pause14StartedAt != null && planning.Pause14StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause14StoppedAt - (DateTime)planning.Pause14StartedAt).TotalMinutes;
-                }
                 planning.Pause15StartedAt = model.Pause15StartedAt;
                 planning.Pause15StoppedAt = model.Pause15StoppedAt;
-                if (planning.Pause15StartedAt != null && planning.Pause15StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause15StoppedAt - (DateTime)planning.Pause15StartedAt).TotalMinutes;
-                }
                 planning.Pause16StartedAt = model.Pause16StartedAt;
                 planning.Pause16StoppedAt = model.Pause16StoppedAt;
-                if (planning.Pause16StartedAt != null && planning.Pause16StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause16StoppedAt - (DateTime)planning.Pause16StartedAt).TotalMinutes;
-                }
                 planning.Pause17StartedAt = model.Pause17StartedAt;
                 planning.Pause17StoppedAt = model.Pause17StoppedAt;
-                if (planning.Pause17StartedAt != null && planning.Pause17StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause17StoppedAt - (DateTime)planning.Pause17StartedAt).TotalMinutes;
-                }
                 planning.Pause18StartedAt = model.Pause18StartedAt;
                 planning.Pause18StoppedAt = model.Pause18StoppedAt;
-                if (planning.Pause18StartedAt != null && planning.Pause18StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause18StoppedAt - (DateTime)planning.Pause18StartedAt).TotalMinutes;
-                }
                 planning.Pause19StartedAt = model.Pause19StartedAt;
                 planning.Pause19StoppedAt = model.Pause19StoppedAt;
-                if (planning.Pause19StartedAt != null && planning.Pause19StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause19StoppedAt - (DateTime)planning.Pause19StartedAt).TotalMinutes;
-                }
                 planning.Pause100StartedAt = model.Pause100StartedAt;
                 planning.Pause100StoppedAt = model.Pause100StoppedAt;
-                if (planning.Pause100StartedAt != null && planning.Pause100StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause100StoppedAt - (DateTime)planning.Pause100StartedAt).TotalMinutes;
-                }
                 planning.Pause101StartedAt = model.Pause101StartedAt;
                 planning.Pause101StoppedAt = model.Pause101StoppedAt;
-                if (planning.Pause101StartedAt != null && planning.Pause101StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause101StoppedAt - (DateTime)planning.Pause101StartedAt).TotalMinutes;
-                }
                 planning.Pause102StartedAt = model.Pause102StartedAt;
                 planning.Pause102StoppedAt = model.Pause102StoppedAt;
-                if (planning.Pause102StartedAt != null && planning.Pause102StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber += (int)((DateTime)planning.Pause102StoppedAt - (DateTime)planning.Pause102StartedAt).TotalMinutes;
-                }
 
-                planning.Pause1Id = planning.Shift1PauseNumber / 5;
+                planning.Pause1Id = PauseMinutesCalculator.DerivePauseId(planning, 1);
 
-                planning.Shift2PauseNumber = 0;
                 planning.Pause20StartedAt = model.Pause20StartedAt;
                 planning.Pause20StoppedAt = model.Pause20StoppedAt;
-                if (planning.Pause20StartedAt != null && planning.Pause20StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause20StoppedAt - (DateTime)planning.Pause20StartedAt).TotalMinutes;
-                }
                 planning.Pause21StartedAt = model.Pause21StartedAt;
                 planning.Pause21StoppedAt = model.Pause21StoppedAt;
-                if (planning.Pause21StartedAt != null && planning.Pause21StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause21StoppedAt - (DateTime)planning.Pause21StartedAt).TotalMinutes;
-                }
                 planning.Pause22StartedAt = model.Pause22StartedAt;
                 planning.Pause22StoppedAt = model.Pause22StoppedAt;
-                if (planning.Pause22StartedAt != null && planning.Pause22StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause22StoppedAt - (DateTime)planning.Pause22StartedAt).TotalMinutes;
-                }
                 planning.Pause23StartedAt = model.Pause23StartedAt;
                 planning.Pause23StoppedAt = model.Pause23StoppedAt;
-                if (planning.Pause23StartedAt != null && planning.Pause23StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause23StoppedAt - (DateTime)planning.Pause23StartedAt).TotalMinutes;
-                }
                 planning.Pause24StartedAt = model.Pause24StartedAt;
                 planning.Pause24StoppedAt = model.Pause24StoppedAt;
-                if (planning.Pause24StartedAt != null && planning.Pause24StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause24StoppedAt - (DateTime)planning.Pause24StartedAt).TotalMinutes;
-                }
                 planning.Pause25StartedAt = model.Pause25StartedAt;
                 planning.Pause25StoppedAt = model.Pause25StoppedAt;
-                if (planning.Pause25StartedAt != null && planning.Pause25StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause25StoppedAt - (DateTime)planning.Pause25StartedAt).TotalMinutes;
-                }
                 planning.Pause26StartedAt = model.Pause26StartedAt;
                 planning.Pause26StoppedAt = model.Pause26StoppedAt;
-                if (planning.Pause26StartedAt != null && planning.Pause26StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause26StoppedAt - (DateTime)planning.Pause26StartedAt).TotalMinutes;
-                }
                 planning.Pause27StartedAt = model.Pause27StartedAt;
                 planning.Pause27StoppedAt = model.Pause27StoppedAt;
-                if (planning.Pause27StartedAt != null && planning.Pause27StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause27StoppedAt - (DateTime)planning.Pause27StartedAt).TotalMinutes;
-                }
                 planning.Pause28StartedAt = model.Pause28StartedAt;
                 planning.Pause28StoppedAt = model.Pause28StoppedAt;
-                if (planning.Pause28StartedAt != null && planning.Pause28StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause28StoppedAt - (DateTime)planning.Pause28StartedAt).TotalMinutes;
-                }
                 planning.Pause29StartedAt = model.Pause29StartedAt;
                 planning.Pause29StoppedAt = model.Pause29StoppedAt;
-                if (planning.Pause29StartedAt != null && planning.Pause29StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause29StoppedAt - (DateTime)planning.Pause29StartedAt).TotalMinutes;
-                }
                 planning.Pause200StartedAt = model.Pause200StartedAt;
                 planning.Pause200StoppedAt = model.Pause200StoppedAt;
-                if (planning.Pause200StartedAt != null && planning.Pause200StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause200StoppedAt - (DateTime)planning.Pause200StartedAt).TotalMinutes;
-                }
                 planning.Pause201StartedAt = model.Pause201StartedAt;
                 planning.Pause201StoppedAt = model.Pause201StoppedAt;
-                if (planning.Pause201StartedAt != null && planning.Pause201StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause201StoppedAt - (DateTime)planning.Pause201StartedAt).TotalMinutes;
-                }
                 planning.Pause202StartedAt = model.Pause202StartedAt;
                 planning.Pause202StoppedAt = model.Pause202StoppedAt;
-                if (planning.Pause202StartedAt != null && planning.Pause202StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber += (int)((DateTime)planning.Pause202StoppedAt - (DateTime)planning.Pause202StartedAt).TotalMinutes;
-                }
-                planning.Pause2Id = planning.Shift2PauseNumber / 5;
+
+                planning.Pause2Id = PauseMinutesCalculator.DerivePauseId(planning, 2);
 
                 planning.Pause3StartedAt = model.Pause3StartedAt;
                 planning.Pause3StoppedAt = model.Pause3StoppedAt;
@@ -1305,235 +1191,67 @@ public class TimePlanningPlanningService(
             }
             else
             {
-                planning.Shift1PauseNumber = 0;
                 planning.Pause1StartedAt = model.Pause1StartedAt;
                 planning.Pause1StoppedAt = model.Pause1StoppedAt;
-                if (planning.Pause1StartedAt != null && planning.Pause1StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber =
-                        (int)((DateTime)planning.Pause1StoppedAt - (DateTime)planning.Pause1StartedAt).TotalMinutes;
-                }
-
                 planning.Pause2StartedAt = model.Pause2StartedAt;
                 planning.Pause2StoppedAt = model.Pause2StoppedAt;
-                if (planning.Pause2StartedAt != null && planning.Pause2StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause2StoppedAt - (DateTime)planning.Pause2StartedAt).TotalMinutes;
-                }
-
                 planning.Pause10StartedAt = model.Pause10StartedAt;
                 planning.Pause10StoppedAt = model.Pause10StoppedAt;
-                if (planning.Pause10StartedAt != null && planning.Pause10StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause10StoppedAt - (DateTime)planning.Pause10StartedAt).TotalMinutes;
-                }
-
                 planning.Pause11StartedAt = model.Pause11StartedAt;
                 planning.Pause11StoppedAt = model.Pause11StoppedAt;
-                if (planning.Pause11StartedAt != null && planning.Pause11StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause11StoppedAt - (DateTime)planning.Pause11StartedAt).TotalMinutes;
-                }
-
                 planning.Pause12StartedAt = model.Pause12StartedAt;
                 planning.Pause12StoppedAt = model.Pause12StoppedAt;
-                if (planning.Pause12StartedAt != null && planning.Pause12StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause12StoppedAt - (DateTime)planning.Pause12StartedAt).TotalMinutes;
-                }
-
                 planning.Pause13StartedAt = model.Pause13StartedAt;
                 planning.Pause13StoppedAt = model.Pause13StoppedAt;
-                if (planning.Pause13StartedAt != null && planning.Pause13StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause13StoppedAt - (DateTime)planning.Pause13StartedAt).TotalMinutes;
-                }
-
                 planning.Pause14StartedAt = model.Pause14StartedAt;
                 planning.Pause14StoppedAt = model.Pause14StoppedAt;
-                if (planning.Pause14StartedAt != null && planning.Pause14StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause14StoppedAt - (DateTime)planning.Pause14StartedAt).TotalMinutes;
-                }
-
                 planning.Pause15StartedAt = model.Pause15StartedAt;
                 planning.Pause15StoppedAt = model.Pause15StoppedAt;
-                if (planning.Pause15StartedAt != null && planning.Pause15StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause15StoppedAt - (DateTime)planning.Pause15StartedAt).TotalMinutes;
-                }
-
                 planning.Pause16StartedAt = model.Pause16StartedAt;
                 planning.Pause16StoppedAt = model.Pause16StoppedAt;
-                if (planning.Pause16StartedAt != null && planning.Pause16StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause16StoppedAt - (DateTime)planning.Pause16StartedAt).TotalMinutes;
-                }
-
                 planning.Pause17StartedAt = model.Pause17StartedAt;
                 planning.Pause17StoppedAt = model.Pause17StoppedAt;
-                if (planning.Pause17StartedAt != null && planning.Pause17StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause17StoppedAt - (DateTime)planning.Pause17StartedAt).TotalMinutes;
-                }
-
                 planning.Pause18StartedAt = model.Pause18StartedAt;
                 planning.Pause18StoppedAt = model.Pause18StoppedAt;
-                if (planning.Pause18StartedAt != null && planning.Pause18StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause18StoppedAt - (DateTime)planning.Pause18StartedAt).TotalMinutes;
-                }
-
                 planning.Pause19StartedAt = model.Pause19StartedAt;
                 planning.Pause19StoppedAt = model.Pause19StoppedAt;
-                if (planning.Pause19StartedAt != null && planning.Pause19StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause19StoppedAt - (DateTime)planning.Pause19StartedAt).TotalMinutes;
-                }
-
                 planning.Pause100StartedAt = model.Pause100StartedAt;
                 planning.Pause100StoppedAt = model.Pause100StoppedAt;
-                if (planning.Pause100StartedAt != null && planning.Pause100StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause100StoppedAt - (DateTime)planning.Pause100StartedAt).TotalMinutes;
-                }
-
                 planning.Pause101StartedAt = model.Pause101StartedAt;
                 planning.Pause101StoppedAt = model.Pause101StoppedAt;
-                if (planning.Pause101StartedAt != null && planning.Pause101StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause101StoppedAt - (DateTime)planning.Pause101StartedAt).TotalMinutes;
-                }
-
                 planning.Pause102StartedAt = model.Pause102StartedAt;
                 planning.Pause102StoppedAt = model.Pause102StoppedAt;
-                if (planning.Pause102StartedAt != null && planning.Pause102StoppedAt != null)
-                {
-                    planning.Shift1PauseNumber +=
-                        (int)((DateTime)planning.Pause102StoppedAt - (DateTime)planning.Pause102StartedAt).TotalMinutes;
-                }
 
-                planning.Pause1Id = planning.Shift1PauseNumber / 5;
+                planning.Pause1Id = PauseMinutesCalculator.DerivePauseId(planning, 1);
 
-                planning.Shift2PauseNumber = 0;
                 planning.Pause20StartedAt = model.Pause20StartedAt;
                 planning.Pause20StoppedAt = model.Pause20StoppedAt;
-                if (planning.Pause20StartedAt != null && planning.Pause20StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause20StoppedAt - (DateTime)planning.Pause20StartedAt).TotalMinutes;
-                }
-
                 planning.Pause21StartedAt = model.Pause21StartedAt;
                 planning.Pause21StoppedAt = model.Pause21StoppedAt;
-                if (planning.Pause21StartedAt != null && planning.Pause21StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause21StoppedAt - (DateTime)planning.Pause21StartedAt).TotalMinutes;
-                }
-
                 planning.Pause22StartedAt = model.Pause22StartedAt;
                 planning.Pause22StoppedAt = model.Pause22StoppedAt;
-                if (planning.Pause22StartedAt != null && planning.Pause22StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause22StoppedAt - (DateTime)planning.Pause22StartedAt).TotalMinutes;
-                }
-
                 planning.Pause23StartedAt = model.Pause23StartedAt;
                 planning.Pause23StoppedAt = model.Pause23StoppedAt;
-                if (planning.Pause23StartedAt != null && planning.Pause23StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause23StoppedAt - (DateTime)planning.Pause23StartedAt).TotalMinutes;
-                }
-
                 planning.Pause24StartedAt = model.Pause24StartedAt;
                 planning.Pause24StoppedAt = model.Pause24StoppedAt;
-                if (planning.Pause24StartedAt != null && planning.Pause24StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause24StoppedAt - (DateTime)planning.Pause24StartedAt).TotalMinutes;
-                }
-
                 planning.Pause25StartedAt = model.Pause25StartedAt;
                 planning.Pause25StoppedAt = model.Pause25StoppedAt;
-                if (planning.Pause25StartedAt != null && planning.Pause25StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause25StoppedAt - (DateTime)planning.Pause25StartedAt).TotalMinutes;
-                }
-
                 planning.Pause26StartedAt = model.Pause26StartedAt;
                 planning.Pause26StoppedAt = model.Pause26StoppedAt;
-                if (planning.Pause26StartedAt != null && planning.Pause26StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause26StoppedAt - (DateTime)planning.Pause26StartedAt).TotalMinutes;
-                }
-
                 planning.Pause27StartedAt = model.Pause27StartedAt;
                 planning.Pause27StoppedAt = model.Pause27StoppedAt;
-                if (planning.Pause27StartedAt != null && planning.Pause27StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause27StoppedAt - (DateTime)planning.Pause27StartedAt).TotalMinutes;
-                }
-
                 planning.Pause28StartedAt = model.Pause28StartedAt;
                 planning.Pause28StoppedAt = model.Pause28StoppedAt;
-                if (planning.Pause28StartedAt != null && planning.Pause28StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause28StoppedAt - (DateTime)planning.Pause28StartedAt).TotalMinutes;
-                }
-
                 planning.Pause29StartedAt = model.Pause29StartedAt;
                 planning.Pause29StoppedAt = model.Pause29StoppedAt;
-                if (planning.Pause29StartedAt != null && planning.Pause29StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause29StoppedAt - (DateTime)planning.Pause29StartedAt).TotalMinutes;
-                }
-
                 planning.Pause200StartedAt = model.Pause200StartedAt;
                 planning.Pause200StoppedAt = model.Pause200StoppedAt;
-                if (planning.Pause200StartedAt != null && planning.Pause200StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause200StoppedAt - (DateTime)planning.Pause200StartedAt).TotalMinutes;
-                }
-
                 planning.Pause201StartedAt = model.Pause201StartedAt;
                 planning.Pause201StoppedAt = model.Pause201StoppedAt;
-                if (planning.Pause201StartedAt != null && planning.Pause201StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause201StoppedAt - (DateTime)planning.Pause201StartedAt).TotalMinutes;
-                }
-
                 planning.Pause202StartedAt = model.Pause202StartedAt;
                 planning.Pause202StoppedAt = model.Pause202StoppedAt;
-                if (planning.Pause202StartedAt != null && planning.Pause202StoppedAt != null)
-                {
-                    planning.Shift2PauseNumber +=
-                        (int)((DateTime)planning.Pause202StoppedAt - (DateTime)planning.Pause202StartedAt).TotalMinutes;
-                }
 
-                planning.Pause2Id = planning.Shift2PauseNumber / 5;
+                planning.Pause2Id = PauseMinutesCalculator.DerivePauseId(planning, 2);
 
                 planning.Pause3StartedAt = model.Pause3StartedAt;
                 planning.Pause3StoppedAt = model.Pause3StoppedAt;


### PR DESCRIPTION
## What & why

`ShiftNPauseNumber` (Shift1PauseNumber / Shift2PauseNumber) carried a **dual meaning** depending on which write path touched it:

- **Admin planning path** stored the **total pause minutes** in the column, purely so it could later derive `PauseNId = minutes / 5`.
- **Punch-clock path** uses the very same column as a **slot counter**.

This overload made the column's semantics ambiguous and dependent on the writer.

## The fix

- Extracted the derivation into a pure helper, `PauseMinutesCalculator.DerivePauseId`.
- The admin path **no longer writes** `ShiftNPauseNumber` — it just derives `PauseNId` via the helper.
- `PauseNId` output is **byte-identical** to before: same slot handling, same int-minutes value, then the same `/ 5` truncation.

## Safety

- Verified **no consumer reads the column as minutes** — the admin path was the only writer using that meaning, and nothing downstream depends on it.
- **No schema change.**
- Adds unit tests for `PauseMinutesCalculator.DerivePauseId`; **CI runs the new unit tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)