### PR TITLE
WIP: fix schedule message not shown in app (gRPC read drops MessageId)

### DIFF
--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -237,7 +237,7 @@ jobs:
           - name: b
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PictureSnapshotServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.ContentHandoverServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DanLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.DataLonFileExporterTests"
           - name: c
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.ScheduleMessageReadTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
           - name: d
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
           - name: e

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ScheduleMessageReadTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ScheduleMessageReadTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.eFormApi.BasePn.Infrastructure.Database.Entities;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+using TimePlanning.Pn.Infrastructure.Models.Planning;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningPlanningService;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Failing-test-first reproduction for the confirmed symptom: a message/status
+/// (e.g. MessageId=2 Vacation, MessageId=1 DayOff) set for an assignedSite IS
+/// persisted on PlanRegistration.MessageId and shows on the WEB, but the MOBILE
+/// APP schedule (gRPC GetPlanningsByUser) does NOT show it.
+///
+/// READ PATH under test (closest reliable seam to GetPlanningsByUser):
+///   TimePlanningPlanningsGrpcService.GetPlanningsByUser
+///     -> TimePlanningPlanningService.IndexByCurrentUserName
+///       -> PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod   <-- builds the
+///          per-day TimePlanningPlanningPrDayModel with `int? Message`.
+///
+/// IndexByCurrentUserName additionally requires real BaseDbContext.Users +
+/// sdkDbContext.Sites + Worker/SiteWorker wiring that the rest of this suite
+/// documents as the currently-[Ignore]d fixture gap (see
+/// PlanningServiceMultiShiftTests.Index_OneMinuteInterval_* and
+/// SettingsServiceExtendedTests). UpdatePlanRegistrationsInPeriod is the
+/// smallest unit that still constructs the exact day model the gRPC mapper
+/// (TimePlanningPlanningsGrpcService.MapDayToGrpc) reads `Message` from, so it
+/// is the seam exercised here — identical to how the existing
+/// Index_OneMinuteInterval_* tests pin the per-day model fields.
+///
+/// EXPECTED TO FAIL on current code if the read path drops Message. Two
+/// separate cases (with-hours day vs message-only day) so CI tells us WHICH
+/// scenario fails.
+/// </summary>
+[TestFixture]
+public class ScheduleMessageReadTests : TestBaseSetup
+{
+    private IUserService _userService;
+    private ITimePlanningLocalizationService _localizationService;
+    private IPluginDbOptions<TimePlanningBaseSettings> _options;
+
+    // MessageId values as the web write sets them (PlanRegistration.MessageId).
+    private const int MessageVacation = 2; // Vacation
+    private const int MessageDayOff = 1;   // DayOff
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+
+        _userService = Substitute.For<IUserService>();
+        _userService.UserId.Returns(1);
+        _userService.GetCurrentUserAsync().Returns(new EformUser { Id = 1 });
+
+        _localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        _localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        _options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+    }
+
+    /// <summary>
+    /// Builds the per-day models for a date range covering both seeded days,
+    /// the way IndexByCurrentUserName does for "current user".
+    /// </summary>
+    private async Task<TimePlanningPlanningModel> ReadDaysByCurrentUser(
+        AssignedSiteEntity assignedSite, SdkSite sdkSite, DateTime from, DateTime to)
+    {
+        var planningsInPeriod = await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking()
+            .Where(x => x.SdkSitId == assignedSite.SiteId)
+            .Select(x => new PlanRegistration { Id = x.Id, Date = x.Date })
+            .OrderByDescending(x => x.Date)
+            .ToListAsync();
+
+        var siteModel = new TimePlanningPlanningModel
+        {
+            SiteId = assignedSite.SiteId,
+            SiteName = sdkSite.Name,
+            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
+            PlanningPrDayModels = new List<TimePlanningPlanningPrDayModel>()
+        };
+
+        return await PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(
+            planningsInPeriod,
+            siteModel,
+            TimePlanningPnDbContext,
+            assignedSite,
+            Substitute.For<ILogger<TimePlanningPlanningService>>(),
+            sdkSite,
+            from,
+            to,
+            _options);
+    }
+
+    [Test]
+    public async Task GetPlanningsByUser_WithHoursDay_CarriesMessageId()
+    {
+        // Arrange — assigned site + sdk site wiring the read path needs.
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7100,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+        var sdkSite = new SdkSite { Name = "Test site 7100", MicrotingUid = 7100 };
+
+        // A day WITH planned hours AND MessageId=2 (Vacation). MessageId is set
+        // exactly as the web write does — directly on PlanRegistration.MessageId.
+        var date = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc); // Wednesday
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 7100,
+            Date = date,
+            PlanText = "8",
+            PlanHours = 8,
+            PlannedStartOfShift1 = 480, // 08:00
+            PlannedEndOfShift1 = 960,   // 16:00
+            MessageId = MessageVacation,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act — read the period by current user (as the app would).
+        var result = await ReadDaysByCurrentUser(
+            assignedSite, sdkSite, date.AddDays(-1), date.AddDays(1));
+
+        // Assert — the returned day model must carry the seeded MessageId.
+        var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+        Assert.That(prDay.Message, Is.EqualTo(MessageVacation),
+            "Read path dropped MessageId for a with-hours day (web shows it; app does not).");
+    }
+
+    [Test]
+    public async Task GetPlanningsByUser_MessageOnlyDay_CarriesMessageId()
+    {
+        // Arrange — assigned site + sdk site.
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7101,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+        var sdkSite = new SdkSite { Name = "Test site 7101", MicrotingUid = 7101 };
+
+        // A MESSAGE-ONLY day: no shifts/hours, only MessageId=1 (DayOff).
+        var date = new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc); // Thursday
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 7101,
+            Date = date,
+            MessageId = MessageDayOff,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act
+        var result = await ReadDaysByCurrentUser(
+            assignedSite, sdkSite, date.AddDays(-1), date.AddDays(1));
+
+        // Assert
+        var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+        Assert.That(prDay.Message, Is.EqualTo(MessageDayOff),
+            "Read path dropped MessageId for a message-only day (web shows it; app does not).");
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ScheduleMessageReadTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ScheduleMessageReadTests.cs
@@ -84,7 +84,8 @@ public class ScheduleMessageReadTests : TestBaseSetup
     /// the way IndexByCurrentUserName does for "current user".
     /// </summary>
     private async Task<TimePlanningPlanningModel> ReadDaysByCurrentUser(
-        AssignedSiteEntity assignedSite, SdkSite sdkSite, DateTime from, DateTime to)
+        AssignedSiteEntity assignedSite, SdkSite sdkSite, DateTime from, DateTime to,
+        string? messageLanguage = null)
     {
         var planningsInPeriod = await TimePlanningPnDbContext!.PlanRegistrations
             .AsNoTracking()
@@ -110,7 +111,24 @@ public class ScheduleMessageReadTests : TestBaseSetup
             sdkSite,
             from,
             to,
-            _options);
+            _options,
+            messageLanguage);
+    }
+
+    /// <summary>
+    /// Inserts a Message catalog row directly, mirroring
+    /// MessagesCodeFirst / AbsenceRequestDayUTest seeding. The test container
+    /// does not run the plugin's startup message seed, so rows the assertions
+    /// rely on are inserted explicitly in Arrange.
+    /// </summary>
+    private async Task SeedMessage(int id, string name, string daName, string enName, string deName)
+    {
+        if (await TimePlanningPnDbContext!.Messages.AnyAsync(m => m.Id == id))
+        {
+            return;
+        }
+        TimePlanningPnDbContext.Messages.Add(new Message(id, name, daName, enName, deName));
+        await TimePlanningPnDbContext.SaveChangesAsync();
     }
 
     [Test]
@@ -186,5 +204,115 @@ public class ScheduleMessageReadTests : TestBaseSetup
         var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
         Assert.That(prDay.Message, Is.EqualTo(MessageDayOff),
             "Read path dropped MessageId for a message-only day (web shows it; app does not).");
+    }
+
+    [Test]
+    public async Task GetPlanningsByUser_MappedMessage_ResolvesDanishLabel()
+    {
+        // Arrange — a normal, app-mapped id (2 = Vacation) in a Danish site.
+        await SeedMessage(MessageVacation, "Vacation", "Ferie", "Vacation", "Ferien");
+
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7200,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+        var sdkSite = new SdkSite { Name = "Test site 7200", MicrotingUid = 7200 };
+
+        var date = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 7200,
+            Date = date,
+            MessageId = MessageVacation,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act — read with the site language "da".
+        var result = await ReadDaysByCurrentUser(
+            assignedSite, sdkSite, date.AddDays(-1), date.AddDays(1), "da");
+
+        // Assert — the day model carries the localized label, not just the int.
+        var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+        Assert.That(prDay.MessageLabel, Is.EqualTo("Ferie"),
+            "MessageLabel not resolved for a mapped id in Danish.");
+    }
+
+    [Test]
+    public async Task GetPlanningsByUser_AppUnmappedMessage_StillResolvesLabel()
+    {
+        // Arrange — an id the mobile app does NOT hard-code (the previously
+        // invisible case). It must still resolve to its localized label.
+        const int unmappedId = 42;
+        await SeedMessage(unmappedId, "Time off in lieu", "Afspadsering", "Time off in lieu", "Freizeitausgleich");
+
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7201,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+        var sdkSite = new SdkSite { Name = "Test site 7201", MicrotingUid = 7201 };
+
+        var date = new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 7201,
+            Date = date,
+            MessageId = unmappedId,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act
+        var result = await ReadDaysByCurrentUser(
+            assignedSite, sdkSite, date.AddDays(-1), date.AddDays(1), "da");
+
+        // Assert — label resolved even though the app has no constant for it.
+        var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+        Assert.That(prDay.MessageLabel, Is.EqualTo("Afspadsering"),
+            "MessageLabel not resolved for an app-unmapped id (the symptom being fixed).");
+    }
+
+    [Test]
+    public async Task GetPlanningsByUser_NoMessage_HasNoLabel()
+    {
+        // Arrange — a day with no MessageId at all.
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7202,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+        var sdkSite = new SdkSite { Name = "Test site 7202", MicrotingUid = 7202 };
+
+        var date = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 7202,
+            Date = date,
+            PlanText = "8",
+            PlanHours = 8,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        // Act
+        var result = await ReadDaysByCurrentUser(
+            assignedSite, sdkSite, date.AddDays(-1), date.AddDays(1), "da");
+
+        // Assert — null MessageId yields no label.
+        var prDay = result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+        Assert.That(prDay.Message, Is.Null);
+        Assert.That(prDay.MessageLabel, Is.Null.Or.Empty,
+            "MessageLabel should be null/empty when there is no MessageId.");
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -623,11 +623,15 @@ public static class PlanRegistrationHelper
         Site site,
         DateTime midnightOfDateFrom,
         DateTime midnightOfDateTo,
-        IPluginDbOptions<TimePlanningBaseSettings> options
+        IPluginDbOptions<TimePlanningBaseSettings> options,
+        string? messageLanguage = null
         )
     {
         var tainted = false;
         var settingsDayOfPayment = options.Value.DayOfPayment == 0 ? 20 : options.Value.DayOfPayment;
+        // Load the message catalog once (no N+1) so each day can resolve its
+        // localized label without re-querying per row.
+        var messagesById = await dbContext.Messages.AsNoTracking().ToDictionaryAsync(m => m.Id);
         var toDay = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, 0, 0, 0);
         // var dayOfPayment = toDay.Day >= settingsDayOfPayment
         //     ? new DateTime(DateTime.Now.Year, DateTime.Now.Month, settingsDayOfPayment, 0, 0, 0)
@@ -1128,6 +1132,19 @@ public static class PlanRegistrationHelper
                 }
             }
 
+            string? messageLabel = null;
+            if (planRegistration.MessageId.HasValue
+                && messagesById.TryGetValue(planRegistration.MessageId.Value, out var msg))
+            {
+                messageLabel = messageLanguage switch
+                {
+                    "da" => string.IsNullOrEmpty(msg.DaName) ? msg.Name : msg.DaName,
+                    "de" => string.IsNullOrEmpty(msg.DeName) ? msg.Name : msg.DeName,
+                    "en" => string.IsNullOrEmpty(msg.EnName) ? msg.Name : msg.EnName,
+                    _    => msg.Name,
+                };
+            }
+
             var planningModel = new TimePlanningPlanningPrDayModel
             {
                 Id = planRegistration.Id,
@@ -1136,6 +1153,7 @@ public static class PlanRegistrationHelper
                 PlanText = planRegistration.PlanText,
                 PlanHours = planRegistration.PlanHours,
                 Message = planRegistration.MessageId,
+                MessageLabel = messageLabel,
                 SiteId = dbAssignedSite.SiteId,
                 WeekDay =
                     planRegistration.Date.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)planRegistration.Date.DayOfWeek,

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Planning/TimePlanningPlanningPrDayModel.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/Planning/TimePlanningPlanningPrDayModel.cs
@@ -39,6 +39,7 @@ public class TimePlanningPlanningPrDayModel
     public double Difference { get; set; }
     public double PauseMinutes { get; set; }
     public int? Message { get; set; }
+    public string? MessageLabel { get; set; }
     public bool WorkDayStarted { get; set; }
     public bool WorkDayEnded { get; set; }
     public bool PlanHoursMatched { get; set; }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/plannings.proto
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/plannings.proto
@@ -156,6 +156,9 @@ message PlanningPrDayModel {
 
   double netto_hours_override = 135;
   bool netto_hours_override_active = 136;
+  // Localized label for `message` (resolved via the site's default language).
+  // Additive: `message` (int as string) stays unchanged.
+  string message_label = 137;
 }
 
 message GetPlanningsByUserRequest {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
@@ -199,6 +199,7 @@ public class TimePlanningPlanningsGrpcService
             FlexHours = m.Difference,
             PaidOutFlex = m.PaidOutFlex,
             Message = m.Message?.ToString() ?? "",
+            MessageLabel = m.MessageLabel ?? "",
             SumFlexStart = m.SumFlexStart,
             SumFlexEnd = m.SumFlexEnd,
             Comment = m.WorkerComment ?? "",

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -571,6 +571,14 @@ public class TimePlanningPlanningService(
                 .ToListAsync().ConfigureAwait(false);
         }
 
+        // Resolve the site's default language so message ids can be turned into
+        // localized labels. LanguageCode is stored as e.g. "da" / "en-US" /
+        // "de-DE"; normalize to the 2-letter prefix the label switch expects.
+        var siteLanguage = await sdkDbContext.Languages
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == site.LanguageId);
+        var messageLanguage = siteLanguage?.LanguageCode?.Split('-')[0].ToLowerInvariant();
+
         siteModel = await PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(
             planningsInPeriod,
             siteModel,
@@ -580,7 +588,8 @@ public class TimePlanningPlanningService(
             site,
             midnightOfDateFrom,
             midnightOfDateTo,
-            options);
+            options,
+            messageLanguage);
 
         siteModel.PlanningPrDayModels = model.IsSortDsc
             ? siteModel.PlanningPrDayModels.OrderByDescending(x => x.Date).ToList()


### PR DESCRIPTION
**WIP — failing-test-first.**

This PR adds ONLY a failing test (no fix yet) to nail the root cause of the confirmed symptom:

> A message/status (e.g. MessageId=2 Vacation, MessageId=1 DayOff) set for an assignedSite IS persisted on `PlanRegistration.MessageId` and shows on the WEB, but the MOBILE APP schedule (gRPC `GetPlanningsByUser`) does NOT show it.

The test exercises the app READ path:
`GetPlanningsByUser` → `IndexByCurrentUserName` → `PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod` (the seam that builds the per-day `TimePlanningPlanningPrDayModel` with `int? Message`).

Two separate cases so CI tells us WHICH scenario fails:
- `GetPlanningsByUser_WithHoursDay_CarriesMessageId` — planned hours + MessageId=2
- `GetPlanningsByUser_MessageOnlyDay_CarriesMessageId` — message-only, MessageId=1

Expected to be RED. Do not merge. No fix included yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)