### PR TITLE
fix(timereg): serve gps/snapshot from global settings

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationVersionHistoryTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationVersionHistoryTests.cs
@@ -44,6 +44,14 @@ public class PlanRegistrationVersionHistoryTests : TestBaseSetup
         _localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
 
         _options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        // GetVersionHistory now reads GPS/Snapshot from the global (per-customer) settings
+        // via options.Value (matching TimeSettingService), not from the per-site AssignedSite.
+        // Each test overrides _options.Value as needed; default both off here.
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
         _dbContextHelper = Substitute.For<ITimePlanningDbContextHelper>();
         _dbContextHelper.GetDbContext().Returns(TimePlanningPnDbContext);
 
@@ -73,6 +81,13 @@ public class PlanRegistrationVersionHistoryTests : TestBaseSetup
     public async Task GetVersionHistory_ReturnsEmptyList_WhenNoVersionsExist()
     {
         // Arrange
+        // GPS/Snapshot now come from the global settings, not the per-site AssignedSite.
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            GpsEnabled = "1",
+            SnapshotEnabled = "1"
+        });
+
         var assignedSite = new AssignedSiteEntity
         {
             SiteId = 1,
@@ -170,6 +185,13 @@ public class PlanRegistrationVersionHistoryTests : TestBaseSetup
     public async Task GetVersionHistory_IncludesGpsCoordinates_WhenGpsEnabledAndCoordinatesExist()
     {
         // Arrange
+        // GPS inclusion is now driven by the global GpsEnabled setting, not the per-site flag.
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            GpsEnabled = "1",
+            SnapshotEnabled = "0"
+        });
+
         var assignedSite = new AssignedSiteEntity
         {
             SiteId = 1,
@@ -218,6 +240,13 @@ public class PlanRegistrationVersionHistoryTests : TestBaseSetup
     public async Task GetVersionHistory_ExcludesGpsCoordinates_WhenGpsDisabled()
     {
         // Arrange
+        // GPS exclusion is now driven by the global GpsEnabled setting, not the per-site flag.
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
         var assignedSite = new AssignedSiteEntity
         {
             SiteId = 1,

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/SettingsServiceTests.cs
@@ -64,6 +64,14 @@ public class SettingsServiceTests : TestBaseSetup
     [Test]
     public async Task GetAssignedSite_ReturnsAssignedSite_WithGpsAndSnapshotFlags()
     {
+        // Business-logic change: on the PERSONAL path GPS follows the GLOBAL
+        // (per-customer) setting, never the per-site AssignedSite column, and Snapshot is
+        // ALWAYS off (snapshot is kiosk-only; never taken in personal registration). The
+        // per-site column below is set to the OPPOSITE of the global to prove the served
+        // GPS value follows the global. Global defaults from SetUp are GpsEnabled="0" and
+        // SnapshotEnabled="0", so GpsEnabled is served false (global) and SnapshotEnabled
+        // is served false (always-off in personal mode) even though the per-site column
+        // has GpsEnabled=true.
         // Arrange
         var assignedSite = new AssignedSiteEntity
         {
@@ -91,7 +99,61 @@ public class SettingsServiceTests : TestBaseSetup
         Assert.That(result.Success, Is.True);
         Assert.That(result.Model, Is.Not.Null);
         Assert.That(result.Model.SiteId, Is.EqualTo(1));
+        // GPS served from GLOBAL ("0" from SetUp), not from the per-site column.
+        Assert.That(result.Model.GpsEnabled, Is.False);
+        // Snapshot is always off on the personal path (kiosk-only).
+        Assert.That(result.Model.SnapshotEnabled, Is.False);
+    }
+
+    [Test]
+    public async Task GetAssignedSite_PersonalServesGlobalGps_ButSnapshotAlwaysOff()
+    {
+        // Spec change: on the PERSONAL path (GetAssignedSite) GPS follows the GLOBAL
+        // (per-customer) setting, never the per-site AssignedSite column, while Snapshot is
+        // ALWAYS off because snapshot is kiosk-only and is never taken in personal
+        // registration. Here global snapshot is "1" but the served value must still be
+        // false. The per-site column is the OPPOSITE of the global to prove GPS follows
+        // the global:
+        //   global   -> GpsEnabled=true (served true),  SnapshotEnabled=true (served FALSE: always-off)
+        //   per-site -> GpsEnabled=false, SnapshotEnabled=false
+        // Arrange
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "1",
+            SnapshotEnabled = "1"
+        });
+
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 7,
+            GpsEnabled = false,
+            SnapshotEnabled = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var core = await _coreService.GetCore();
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+        var site = new Microting.eForm.Infrastructure.Data.Entities.Site
+        {
+            Name = "Test Site Global",
+            MicrotingUid = 7
+        };
+        await site.Create(sdkDbContext);
+
+        // Act
+        var result = await _settingsService.GetAssignedSite(7);
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.That(result.Model.SiteId, Is.EqualTo(7));
+        // GPS served from GLOBAL ("1"), opposite of the per-site column (false).
         Assert.That(result.Model.GpsEnabled, Is.True);
+        // Snapshot is always off on the personal path, even though global is "1".
         Assert.That(result.Model.SnapshotEnabled, Is.False);
     }
 
@@ -424,8 +486,13 @@ public class SettingsServiceTests : TestBaseSetup
     }
 
     [Test]
-    public async Task UpdateSettings_UpdatesAllAssignedSites_WithGpsAndSnapshotSettings()
+    public async Task UpdateSettings_DoesNotFanGpsAndSnapshotOutToAssignedSites()
     {
+        // Business-logic change: GPS/Snapshot now live ONLY in the GLOBAL settings and are
+        // served from there on every serve path. UpdateSettings no longer fans these values
+        // out to the per-site AssignedSite columns (that loop was removed), so the per-site
+        // columns below must stay at their original false even though the settings model
+        // sets GpsEnabled=true and SnapshotEnabled=true.
         // Arrange
         var assignedSite1 = new AssignedSiteEntity
         {
@@ -493,13 +560,15 @@ public class SettingsServiceTests : TestBaseSetup
         var updatedSite2 = await TimePlanningPnDbContext.AssignedSites
             .FirstOrDefaultAsync(x => x.Id == assignedSite2.Id);
 
+        // Per-site columns are intentionally left untouched (loop removed); GPS/Snapshot
+        // are served from the GLOBAL settings, not from these columns.
         Assert.That(updatedSite1, Is.Not.Null);
-        Assert.That(updatedSite1.GpsEnabled, Is.True);
-        Assert.That(updatedSite1.SnapshotEnabled, Is.True);
+        Assert.That(updatedSite1.GpsEnabled, Is.False);
+        Assert.That(updatedSite1.SnapshotEnabled, Is.False);
 
         Assert.That(updatedSite2, Is.Not.Null);
-        Assert.That(updatedSite2.GpsEnabled, Is.True);
-        Assert.That(updatedSite2.SnapshotEnabled, Is.True);
+        Assert.That(updatedSite2.GpsEnabled, Is.False);
+        Assert.That(updatedSite2.SnapshotEnabled, Is.False);
     }
 
     #region Manager and Tags Tests

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -1832,14 +1832,11 @@ public class TimePlanningPlanningService(
                     localizationService.GetString("PlanRegistrationNotFound"));
             }
 
-            // Get the assigned site to check GPS and Snapshot settings
-            var assignedSite = await dbContext.AssignedSites
-                .Where(x => x.SiteId == planRegistration.SdkSitId)
-                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                .FirstOrDefaultAsync().ConfigureAwait(false);
-
-            var gpsEnabled = assignedSite?.GpsEnabled ?? false;
-            var snapshotEnabled = assignedSite?.SnapshotEnabled ?? false;
+            // GPS/Snapshot always come from the TimePlanning GLOBAL (per-customer) settings,
+            // never from the per-site AssignedSite column, matching the serve paths in
+            // TimeSettingService.
+            var gpsEnabled = options.Value.GpsEnabled == "1";
+            var snapshotEnabled = options.Value.SnapshotEnabled == "1";
 
             // Get all versions for this plan registration, ordered by version descending (newest first)
             var versions = await dbContext.PlanRegistrationVersions

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -167,17 +167,9 @@ public class TimeSettingService(
                 settings.SnapshotEnabled = timePlanningSettingsModel.SnapshotEnabled ? "1" : "0";
             }, dbContext, userService.UserId);
 
-            // Update all assigned sites with the new GPS and Snapshot settings
-            var assignedSites = await dbContext.AssignedSites
-                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                .ToListAsync();
-
-            foreach (var assignedSite in assignedSites)
-            {
-                assignedSite.GpsEnabled = timePlanningSettingsModel.GpsEnabled;
-                assignedSite.SnapshotEnabled = timePlanningSettingsModel.SnapshotEnabled;
-                await assignedSite.Update(dbContext);
-            }
+            // GPS/Snapshot are now served from the GLOBAL settings written above; the
+            // per-site AssignedSite columns are no longer read on any serve path, so the
+            // old loop that fanned these values out to every AssignedSite was removed.
 
             await GoogleSheetHelper.PushToGoogleSheet(await core.GetCore(), dbContext, logger);
 
@@ -219,6 +211,11 @@ public class TimeSettingService(
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .Where(x => x.Resigned != true)
                 .ToListAsync();
+
+            // GPS/Snapshot are sourced from the TimePlanning GLOBAL (per-customer) settings,
+            // never from the per-site AssignedSite column, so newly-created sites always
+            // honour the customer-wide camera/GPS policy regardless of their per-site default.
+            var snapshotEnabledGlobal = options.Value.SnapshotEnabled == "1";
 
             var sites = new List<Site>();
             foreach (var assignedSite in assignedSites)
@@ -311,7 +308,7 @@ public class TimeSettingService(
                             FifthShiftActive = assignedSite.FifthShiftActive,
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
-                            SnapshotEnabled = assignedSite.SnapshotEnabled,
+                            SnapshotEnabled = snapshotEnabledGlobal,
                             UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
                             OverMidnight = assignedSite.OverMidnight
                         };
@@ -528,6 +525,11 @@ public class TimeSettingService(
         List<Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite> assignedSites,
         Microting.eForm.Infrastructure.MicrotingDbContext sdkDbContext)
     {
+        // GPS/Snapshot are sourced from the TimePlanning GLOBAL (per-customer) settings,
+        // never from the per-site AssignedSite column, so newly-created sites always
+        // honour the customer-wide camera/GPS policy regardless of their per-site default.
+        var snapshotEnabledGlobal = options.Value.SnapshotEnabled == "1";
+
         var sites = new List<Site>();
         foreach (var assignedSite in assignedSites)
         {
@@ -619,7 +621,7 @@ public class TimeSettingService(
                             FifthShiftActive = assignedSite.FifthShiftActive,
                             Resigned = assignedSite.Resigned,
                             ResignedAtDate = assignedSite.ResignedAtDate,
-                            SnapshotEnabled = assignedSite.SnapshotEnabled,
+                            SnapshotEnabled = snapshotEnabledGlobal,
                             UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
                             OverMidnight = assignedSite.OverMidnight
                         };
@@ -673,6 +675,12 @@ public class TimeSettingService(
         dbAssignedSite.GlobalAutoBreakCalculationActive = globalAutoBreakCalculationActive;
         dbAssignedSite.SiteName = site.Name;
 
+        // GPS comes from the TimePlanning GLOBAL (per-customer) settings, never from the
+        // per-site AssignedSite column.
+        dbAssignedSite.GpsEnabled = options.Value.GpsEnabled == "1";
+        // Snapshot is kiosk-only; always off for personal registration
+        dbAssignedSite.SnapshotEnabled = false;
+
         return new OperationDataResult<Infrastructure.Models.Settings.AssignedSite>(true, dbAssignedSite);
 
     }
@@ -707,6 +715,13 @@ public class TimeSettingService(
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.SiteId == sdkSite.MicrotingUid);
         dbAssignedSite.DayOfPayment = options.Value.DayOfPayment;
+
+        // GPS comes from the TimePlanning GLOBAL (per-customer) settings, never from the
+        // per-site AssignedSite column. This is the personal-mode gRPC path
+        // (GetAssignedSite -> GetAssignedSiteByCurrentUserName).
+        dbAssignedSite.GpsEnabled = options.Value.GpsEnabled == "1";
+        // Snapshot is kiosk-only; always off for personal registration
+        dbAssignedSite.SnapshotEnabled = false;
 
         return new OperationDataResult<Infrastructure.Models.Settings.AssignedSite>(true, dbAssignedSite);
     }


### PR DESCRIPTION
GpsEnabled/SnapshotEnabled are served to the app from the TimePlanning **global** settings instead of the per-site `AssignedSite` column, so they can't drift. Fixes the kiosk bug where newly-created sites had per-site `SnapshotEnabled=false` and never took pictures.

Behavior matrix:
- **kiosk**: `SnapshotEnabled` = global; GPS not served on the kiosk `Site` model (always off)
- **personal**: `GpsEnabled` = global; `SnapshotEnabled` always off (snapshot is kiosk-only)

Also removes the `UpdateSettings` per-site fan-out loop (the global value is the source of truth; the global write is kept) and updates `GetVersionHistory` to read global. No proto/schema change — the app already reads these fields. Per-site DB columns left in place, now unused for serving.

Pairs with backendconfiguration #1021 (removes the now-pointless per-site GpsEnabled writes); land this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)