### PR TITLE
chore(timereg): force mobile update below v4.0.26

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -472,7 +472,7 @@ public class TimePlanningPlanningService(
 
         try
         {
-            siteModel.SoftwareVersionIsValid = Version.TryParse(currentUser.TimeRegistrationSoftwareVersion, out var v2) && v2 >= new Version(4,0,0,0);
+            siteModel.SoftwareVersionIsValid = Version.TryParse(currentUser.TimeRegistrationSoftwareVersion, out var v2) && v2 >= new Version(4,0,26);
         }
         catch (Exception)
         {


### PR DESCRIPTION
Raises the **mobile** force-update minimum so flutter-time clients below **4.0.26** are forced to update.

- `TimePlanningPlanningService.IndexByCurrentUserName` (gRPC `GetPlanningsByUser`): threshold `new Version(4,0,0,0)` → `new Version(4,0,26)`. Clients with app version `< 4.0.26` get `software_version_is_valid = false` → flutter-time shows the UpdateNeeded screen.
- Web-admin threshold (`Index`, `3.1.1.4`) left unchanged (intended split).

Semantics verified: `4.0.25` → force; `4.0.26`/`4.0.27` → valid; unparseable/missing → force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)