### PR TITLE
chore(timereg): raise web-admin force-update threshold to 4.0.26

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -268,7 +268,7 @@ public class TimePlanningPlanningService(
                     siteModel.DeviceManufacturer = user.TimeRegistrationManufacturer;
                     try
                     {
-                        siteModel.SoftwareVersionIsValid = Version.TryParse(user.TimeRegistrationSoftwareVersion, out var v1) && v1 >= new Version(3, 1, 1, 4);
+                        siteModel.SoftwareVersionIsValid = Version.TryParse(user.TimeRegistrationSoftwareVersion, out var v1) && v1 >= new Version(4,0,26);
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
Aligns the web-admin version gate (`Index`, line 271) with the mobile/gRPC gate (`IndexByCurrentUserName`, set to 4.0.26 in #1623). Both now require app version >= 4.0.26. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)