### PR TITLE
fix(timeplanning): sum all pause slots for netto, display, and Excel export

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ComputeShiftPauseSecondsTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ComputeShiftPauseSecondsTests.cs
@@ -1,0 +1,193 @@
+using System;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Regression locks for PlanRegistrationHelper.ComputeShiftPauseSeconds — the
+/// canonical per-shift pause total that must sum EVERY populated pause slot
+/// (primary Pause{N} plus the multi-pause sub-slots), not just the primary.
+///
+/// Shape is taken from production PlanRegistration 16288 (an OFF / 5-minute
+/// site) which carried 4 genuine shift-1 pauses but only deducted ~5 min of
+/// pause because the netto math read the primary Pause1 slot alone.
+///
+/// Worked oracle (all UTC, computed purely from the stored DateTimes):
+///   shift 1 (OFF, floor-to-5min clock-tick per slot):
+///     Pause1  05:21:57 -> 05:24:39  = 0  min (no 5-min boundary crossed)
+///     Pause10 05:25:06 -> 05:33:49  = 5  min (one boundary: 05:30)
+///     Pause11 05:40:46 -> 06:01:38  = 20 min (05:45,05:50,05:55,06:00)
+///     Pause12 19:09:23 -> 19:10:11  = 5  min (19:10)
+///     => shift 1 = 30 min
+///   shift 2 (OFF):
+///     Pause2  19:13:26 -> 19:16:52  = 5  min (19:15)
+///     => shift 2 = 5 min
+///   day total = 35 min.
+///
+///   shift 1 (ON, exact second deltas):
+///     162 + 523 + 1252 + 48 = 1985 s (≈ 33 min).
+/// </summary>
+[TestFixture]
+public class ComputeShiftPauseSecondsTests
+{
+    private static PlanRegistration BuildRow16288Shape()
+    {
+        var date = new DateTime(2026, 6, 19, 0, 0, 0, DateTimeKind.Utc);
+
+        return new PlanRegistration
+        {
+            Date = date,
+            // Shift boundaries so a gross work span is computable. Start1 05:00,
+            // Stop1 20:00 via 5-min IDs (Id = minutes/5 + 1): 05:00 -> 61, 20:00 -> 241.
+            Start1Id = 61,
+            Stop1Id = 241,
+            Start2Id = 61,
+            Stop2Id = 241,
+
+            // Shift 1 pauses — primary + three sub-slots (matches 16288).
+            Pause1StartedAt = new DateTime(2026, 6, 19, 5, 21, 57, DateTimeKind.Utc),
+            Pause1StoppedAt = new DateTime(2026, 6, 19, 5, 24, 39, DateTimeKind.Utc),
+            Pause10StartedAt = new DateTime(2026, 6, 19, 5, 25, 6, DateTimeKind.Utc),
+            Pause10StoppedAt = new DateTime(2026, 6, 19, 5, 33, 49, DateTimeKind.Utc),
+            Pause11StartedAt = new DateTime(2026, 6, 19, 5, 40, 46, DateTimeKind.Utc),
+            Pause11StoppedAt = new DateTime(2026, 6, 19, 6, 1, 38, DateTimeKind.Utc),
+            Pause12StartedAt = new DateTime(2026, 6, 19, 19, 9, 23, DateTimeKind.Utc),
+            Pause12StoppedAt = new DateTime(2026, 6, 19, 19, 10, 11, DateTimeKind.Utc),
+
+            // Shift 2 pause — single primary slot.
+            Pause2StartedAt = new DateTime(2026, 6, 19, 19, 13, 26, DateTimeKind.Utc),
+            Pause2StoppedAt = new DateTime(2026, 6, 19, 19, 16, 52, DateTimeKind.Utc),
+        };
+    }
+
+    [Test]
+    public void OffMode_Shift1_SumsAllSlots_FloorTo5Min_Returns30Min()
+    {
+        var reg = BuildRow16288Shape();
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 1, useOneMinuteIntervals: false);
+
+        Assert.That(result, Is.EqualTo(30 * 60),
+            "Shift 1 OFF: 0 + 5 + 20 + 5 = 30 min across Pause1/Pause10/Pause11/Pause12");
+    }
+
+    [Test]
+    public void OffMode_Shift2_SinglePrimarySlot_Returns5Min()
+    {
+        var reg = BuildRow16288Shape();
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 2, useOneMinuteIntervals: false);
+
+        Assert.That(result, Is.EqualTo(5 * 60),
+            "Shift 2 OFF: Pause2 19:13:26 -> 19:16:52 crosses 19:15 = 5 min");
+    }
+
+    [Test]
+    public void OnMode_Shift1_SumsExactSecondDeltasAcrossAllSlots_Returns1985s()
+    {
+        var reg = BuildRow16288Shape();
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 1, useOneMinuteIntervals: true);
+
+        // 162 (2m42s) + 523 (8m43s) + 1252 (20m52s) + 48 (0m48s) = 1985 s.
+        Assert.That(result, Is.EqualTo(1985),
+            "Shift 1 ON: exact second deltas 162 + 523 + 1252 + 48 = 1985 s");
+    }
+
+    [Test]
+    public void OnMode_Shift2_ExactSecondDelta_Returns206s()
+    {
+        var reg = BuildRow16288Shape();
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 2, useOneMinuteIntervals: true);
+
+        // 19:16:52 - 19:13:26 = 3m26s = 206 s.
+        Assert.That(result, Is.EqualTo(206),
+            "Shift 2 ON: Pause2 exact delta = 3m26s = 206 s");
+    }
+
+    /// <summary>
+    /// Day-total guard: the OFF-mode pause aggregation (primary + sub-slots
+    /// across both shifts) must total 35 min, matching the 16288 oracle. This
+    /// is the value that NettoHours must deduct, not the ~5 min the old
+    /// primary-slot-only math produced.
+    /// </summary>
+    [Test]
+    public void OffMode_DayTotalAcrossShifts_Returns35Min()
+    {
+        var reg = BuildRow16288Shape();
+
+        var shift1 = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 1, useOneMinuteIntervals: false);
+        var shift2 = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 2, useOneMinuteIntervals: false);
+
+        Assert.That(shift1 + shift2, Is.EqualTo(35 * 60),
+            "Day total OFF = 30 + 5 = 35 min");
+    }
+
+    /// <summary>
+    /// Fallback contract: a shift with NO timestamped pause slot falls back to
+    /// the legacy primary Pause{N}Id tick value only. Pause3Id = 4 => (4-1)*5
+    /// = 15 min = 900 s, regardless of flag.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void NoTimestampedSlot_FallsBackToLegacyPrimaryPauseId(bool useOneMinuteIntervals)
+    {
+        var reg = new PlanRegistration
+        {
+            Date = new DateTime(2026, 6, 19, 0, 0, 0, DateTimeKind.Utc),
+            Pause3Id = 4, // legacy 15-min pause: (4 - 1) * 5 = 15 min
+        };
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 3, useOneMinuteIntervals);
+
+        Assert.That(result, Is.EqualTo(15 * 60),
+            "No timestamped slot => legacy primary Pause3Id fallback = 15 min");
+    }
+
+    /// <summary>
+    /// Orphaned (incomplete) slot contract: a shift whose only pause stamp has a
+    /// start but a null stop (kiosk crash / partial edit) does NOT count as a
+    /// complete, measurable slot — so the legacy primary Pause{N}Id fallback is
+    /// honored instead of silently dropping the slot AND returning 0. With
+    /// Pause1StartedAt set, Pause1StoppedAt null and Pause1Id = 4 the result must
+    /// fall back to (4-1)*5 = 15 min = 900 s, regardless of flag.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void OrphanedStartOnlySlot_FallsBackToLegacyPrimaryPauseId(bool useOneMinuteIntervals)
+    {
+        var reg = new PlanRegistration
+        {
+            Date = new DateTime(2026, 6, 19, 0, 0, 0, DateTimeKind.Utc),
+            Pause1StartedAt = new DateTime(2026, 6, 19, 5, 21, 57, DateTimeKind.Utc),
+            Pause1StoppedAt = null, // orphaned: no stop => not a complete slot
+            Pause1Id = 4, // legacy 15-min pause: (4 - 1) * 5 = 15 min
+        };
+
+        var result = PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 1, useOneMinuteIntervals);
+
+        Assert.That(result, Is.EqualTo(15 * 60),
+            "Orphaned start-only slot is not a complete slot => legacy Pause1Id fallback = 15 min");
+    }
+
+    /// <summary>
+    /// A half-record (StartedAt set, StoppedAt null — e.g. kiosk crashed
+    /// mid-break) is not a complete, measurable slot, so it must NOT suppress
+    /// the legacy Pause{N}Id fallback. Pause1Id = 4 => (4-1)*5 = 15 min = 900 s.
+    /// </summary>
+    [Test]
+    public void PartialTimestamp_StartedAtOnly_FallsBackToLegacyPauseId()
+    {
+        var reg = new PlanRegistration {
+            Date = new DateTime(2026, 6, 19, 0, 0, 0, DateTimeKind.Utc),
+            Pause1Id = 4,  // legacy 15 min
+            Pause1StartedAt = new DateTime(2026, 6, 19, 10, 0, 0, DateTimeKind.Utc),
+            Pause1StoppedAt = null,
+        };
+        Assert.That(PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, 1, useOneMinuteIntervals: false), Is.EqualTo(900),
+            "Half-record (StartedAt only) must not suppress the legacy PauseId fallback");
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperComputationTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperComputationTests.cs
@@ -399,11 +399,11 @@ public class PlanRegistrationHelperComputationTests
 
         // Assert
         // 8 hours work - 0.5 hours pause = 7.5 hours = 27000 seconds
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800),
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000),
             "NettoHoursInSeconds should be 7.5 hours = 27000 seconds");
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0),
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5),
             "NettoHours should be 7.5");
-        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(28800),
+        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(27000),
             "EffectiveNetHoursInSeconds should equal NettoHoursInSeconds when no override");
     }
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperHolidayTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperHolidayTests.cs
@@ -191,9 +191,9 @@ public class PlanRegistrationHelperHolidayTests
 
         // Assert
         // 8 hours work - 0.5 hours pause = 7.5 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800)); // 7.5 * 3600
-        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(28800));
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000)); // 7.5 * 3600
+        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(27000));
     }
 
     [Test]
@@ -215,9 +215,9 @@ public class PlanRegistrationHelperHolidayTests
 
         // Assert
         // 8 hours work - 0.5 hours pause = 7.5 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800));
-        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(28800));
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000));
+        Assert.That(planRegistration.EffectiveNetHoursInSeconds, Is.EqualTo(27000));
     }
 
     [Test]
@@ -245,8 +245,8 @@ public class PlanRegistrationHelperHolidayTests
         // Shift 1: 4 hours, Shift 2: 4 hours = 8 hours total
         // Pause 1: 0.25 hours, Pause 2: 0.25 hours = 0.5 hours total
         // Net: 8 - 0.5 = 7.5 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800));
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000));
     }
 
     [Test]
@@ -304,8 +304,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 7 hours (4 + 3)
         // Pause: 0.25 hours
         // Net: 6.75 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(25200)); // 6.75 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(6.75));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(24300)); // 6.75 * 3600
         Assert.That(planRegistration.IsSaturday, Is.False);
         Assert.That(planRegistration.IsSunday, Is.False);
     }
@@ -333,8 +333,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 5 hours
         // Pause: 0.25 hours
         // Net: 4.75 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(5.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(18000)); // 4.75 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(4.75));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(17100)); // 4.75 * 3600
         Assert.That(planRegistration.IsSaturday, Is.True);
         Assert.That(planRegistration.IsSunday, Is.False);
     }
@@ -362,8 +362,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 5 hours
         // Pause: 0.5 hours
         // Net: 4.5 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(5.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(18000)); // 4.5 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(4.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(16200)); // 4.5 * 3600
         Assert.That(planRegistration.IsSaturday, Is.False);
         Assert.That(planRegistration.IsSunday, Is.True);
     }
@@ -392,8 +392,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 8 hours
         // Pause: 0.75 hours
         // Net: 7.25 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800)); // 7.25 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.25));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(26100)); // 7.25 * 3600
         Assert.That(dayCode, Is.EqualTo("HOLIDAY"));
     }
 
@@ -450,8 +450,8 @@ public class PlanRegistrationHelperHolidayTests
         // Pause: 0.5 hours
         // Net: 7.5 hours
         // Note: Hours before and after 12:00 would be split differently for payroll
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800)); // 7.5 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000)); // 7.5 * 3600
         Assert.That(dayCode, Is.EqualTo("GRUNDLOVSDAG"));
     }
 
@@ -482,8 +482,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 8 hours
         // Pause: 0.5 hours (2 x 0.25)
         // Net: 7.5 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800));
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.5));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(27000));
         Assert.That(dayCode, Is.EqualTo("HOLIDAY"));
     }
 
@@ -520,8 +520,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 10 hours (4 + 3 + 3)
         // Pause: 1.0 hours (0.25 + 0.5 + 0.25)
         // Net: 9.0 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(10.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(36000)); // 9 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(9.0));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(32400)); // 9 * 3600
     }
 
     [Test]
@@ -574,8 +574,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 8 hours
         // Pause: 1 hour
         // Net: 7 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(8.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(28800)); // 7 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(7.0));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(25200)); // 7 * 3600
         Assert.That(dayCode, Is.EqualTo("HOLIDAY"));
     }
 
@@ -608,8 +608,8 @@ public class PlanRegistrationHelperHolidayTests
         // Total work: 12 hours
         // Pause: 1.25 hours (15 + 30 + 15 + 15 min)
         // Net: 10.75 hours
-        Assert.That(planRegistration.NettoHours, Is.EqualTo(12.0));
-        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(43200)); // 10.75 * 3600
+        Assert.That(planRegistration.NettoHours, Is.EqualTo(10.75));
+        Assert.That(planRegistration.NettoHoursInSeconds, Is.EqualTo(38700)); // 10.75 * 3600
     }
 
     // Helper method to test the private GetDayCode method via reflection

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperTests.cs
@@ -1341,27 +1341,29 @@ public class PlanRegistrationHelperTests
     }
 
     /// <summary>
-    /// Flag-off parity: stamps populated and legacy Pause1Id both present.
-    /// The flag-off branch must still return only the legacy tick result
-    /// (15 here) — proves the new flag-on logic did not touch the flag-off path.
+    /// Flag-off now derives pause from the floor-to-5min clock-tick delta of the
+    /// stamps, not the legacy Pause1Id. When a COMPLETE stamp pair is present it
+    /// wins and the legacy Pause1Id is ignored. Here a 3-min pause (12:00→12:03)
+    /// stays inside a single 5-min cell, so the clock-tick delta is 0 even though
+    /// Pause1Id = 4 would have meant a legacy 15-min pause.
     /// </summary>
     [Test]
-    public void AggregatePauseMinutes_LegacyMode_StampsPopulated_StillReturnsLegacyTicks()
+    public void AggregatePauseMinutes_LegacyMode_CompleteStampWins_OverLegacyTicks()
     {
-        // Arrange — stamps describe a 3-min pause, Pause1Id = 4 is a legacy 15-min companion.
+        // Arrange — complete 3-min stamp pair, Pause1Id = 4 is a legacy 15-min companion that must be ignored.
         var someDate = new DateTime(2026, 5, 7, 0, 0, 0);
         var pr = new PlanRegistration
         {
             Pause1StartedAt = someDate.AddHours(12),
             Pause1StoppedAt = someDate.AddHours(12).AddMinutes(3),
-            Pause1Id = 4, // legacy 15 min
+            Pause1Id = 4, // legacy 15 min — ignored because a complete stamp is present
         };
 
         // Act
         var result = PlanRegistrationHelper.AggregatePauseMinutes(pr, useOneMinuteIntervals: false);
 
-        // Assert — flag-off branch ignores stamps and uses legacy ticks only.
-        Assert.That(result, Is.EqualTo(15));
+        // Assert — complete stamp wins: 12:00→12:03 floors to 12:00→12:00 = 0 min.
+        Assert.That(result, Is.EqualTo(0));
     }
 
     // ------------------------------------------------------------------

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -397,9 +397,10 @@ public static class PlanRegistrationHelper
         // Helper: compute one shift's contribution. Prefer DateTime delta when
         // both stamps are populated; otherwise fall back to the legacy 5-min
         // tick math so mixed-precision rows (some shifts precise, some not)
-        // still get a complete total.
-        long ShiftSeconds(DateTime? startAt, DateTime? stopAt, int startId, int stopId,
-            DateTime? pauseStartAt, DateTime? pauseStopAt, int pauseId)
+        // still get a complete total. Pause is the canonical per-shift total
+        // (ALL slots, not just the primary) — second-precision because this
+        // method only runs on UseOneMinuteIntervals sites.
+        long ShiftSeconds(int shift, DateTime? startAt, DateTime? stopAt, int startId, int stopId)
         {
             long workSeconds;
             if (startAt.HasValue && stopAt.HasValue && stopAt.Value > startAt.Value)
@@ -415,118 +416,45 @@ public static class PlanRegistrationHelper
                 return 0;
             }
 
-            long pauseSeconds;
-            if (pauseStartAt.HasValue && pauseStopAt.HasValue && pauseStopAt.Value > pauseStartAt.Value)
-            {
-                pauseSeconds = (long)(pauseStopAt.Value - pauseStartAt.Value).TotalSeconds;
-            }
-            else if (pauseId > 0)
-            {
-                // Legacy snap fallback: Pause1Id is stored as (minutes/5 + 1)
-                pauseSeconds = (long)(pauseId - 1) * 5 * 60;
-            }
-            else
-            {
-                pauseSeconds = 0;
-            }
+            long pauseSeconds = ComputeShiftPauseSeconds(pr, shift, useOneMinuteIntervals: true);
 
             return workSeconds - pauseSeconds;
         }
 
-        nettoSeconds += ShiftSeconds(pr.Start1StartedAt, pr.Stop1StoppedAt, pr.Start1Id, pr.Stop1Id,
-            pr.Pause1StartedAt, pr.Pause1StoppedAt, pr.Pause1Id);
-        nettoSeconds += ShiftSeconds(pr.Start2StartedAt, pr.Stop2StoppedAt, pr.Start2Id, pr.Stop2Id,
-            pr.Pause2StartedAt, pr.Pause2StoppedAt, pr.Pause2Id);
-        nettoSeconds += ShiftSeconds(pr.Start3StartedAt, pr.Stop3StoppedAt, pr.Start3Id, pr.Stop3Id,
-            pr.Pause3StartedAt, pr.Pause3StoppedAt, pr.Pause3Id);
-        nettoSeconds += ShiftSeconds(pr.Start4StartedAt, pr.Stop4StoppedAt, pr.Start4Id, pr.Stop4Id,
-            pr.Pause4StartedAt, pr.Pause4StoppedAt, pr.Pause4Id);
-        nettoSeconds += ShiftSeconds(pr.Start5StartedAt, pr.Stop5StoppedAt, pr.Start5Id, pr.Stop5Id,
-            pr.Pause5StartedAt, pr.Pause5StoppedAt, pr.Pause5Id);
+        nettoSeconds += ShiftSeconds(1, pr.Start1StartedAt, pr.Stop1StoppedAt, pr.Start1Id, pr.Stop1Id);
+        nettoSeconds += ShiftSeconds(2, pr.Start2StartedAt, pr.Stop2StoppedAt, pr.Start2Id, pr.Stop2Id);
+        nettoSeconds += ShiftSeconds(3, pr.Start3StartedAt, pr.Stop3StoppedAt, pr.Start3Id, pr.Stop3Id);
+        nettoSeconds += ShiftSeconds(4, pr.Start4StartedAt, pr.Stop4StoppedAt, pr.Start4Id, pr.Stop4Id);
+        nettoSeconds += ShiftSeconds(5, pr.Start5StartedAt, pr.Stop5StoppedAt, pr.Start5Id, pr.Stop5Id);
 
         return Math.Max(0, nettoSeconds);
     }
 
     /// <summary>
-    /// Aggregates pause minutes for a PlanRegistration.
+    /// Aggregates total pause minutes for a PlanRegistration by summing the
+    /// canonical per-shift pause (<see cref="ComputeShiftPauseSeconds"/>) across
+    /// shifts 1-5 and rounding the total down to whole minutes.
     ///
-    /// When useOneMinuteIntervals is true, sums the (Pause*StoppedAt - Pause*StartedAt)
-    /// DateTime deltas in seconds across every populated pause stamp pair — the 5 main
-    /// slots AND all sub-slots used by the multi-pause workflow (Pause10..Pause19,
-    /// Pause100..Pause102 for shift 1; Pause20..Pause29, Pause200..Pause202 for shift 2;
-    /// Pause3/4/5 single slots for shifts 3/4/5). This mirrors the frontend admin edit
-    /// dialog's computeExactPauseMinutes (workday-entity-dialog.component.ts) so the
-    /// overview's "Samlet pause" and the per-row edit dialog agree byte-for-byte.
-    /// Total seconds are rounded down to whole minutes.
-    ///
-    /// If a flag-on row has no stamp pairs populated, falls back to the legacy
-    /// 5-minute-tick formula on the 5 main slots only (sub-slots have no *Id field):
-    /// for each Pause{1..5}Id &gt; 0, contribute (Pause{N}Id * 5) - 5 minutes. This
-    /// covers older flag-on rows written before stamp-pair pauses existed.
-    ///
-    /// When useOneMinuteIntervals is false, always uses the legacy 5-minute-tick
-    /// formula on the 5 main slots. (Pause*Id stores break in 5-minute ticks plus a
-    /// +1 sentinel: Pause1Id = 1 means 0 min, Pause1Id = 4 means 15 min, etc.)
+    /// ComputeShiftPauseSeconds is the single source of truth: per shift it walks
+    /// every populated pause slot (primary Pause{N} plus the multi-pause sub-slots)
+    /// and applies the exact stamp delta when useOneMinuteIntervals is true, or the
+    /// floor-to-5-minute clock-tick delta when it is false, falling back per shift to
+    /// the legacy Pause{N}Id tick value only when that shift has no timestamped slots.
     /// </summary>
     public static int AggregatePauseMinutes(PlanRegistration pr, bool useOneMinuteIntervals)
     {
-        if (useOneMinuteIntervals)
+        // Sum the canonical per-shift pause across all 5 shifts. The canonical
+        // method walks EVERY populated slot of each shift (primary + sub-slots),
+        // applies the exact delta (flag on) or the floor-to-5-minute clock-tick
+        // delta (flag off), and falls back per-shift to the legacy Pause{N}Id
+        // tick value only when that shift has no timestamped slots.
+        long totalSeconds = 0;
+        for (var shift = 1; shift <= 5; shift++)
         {
-            long totalSeconds = 0;
-            var hasAnyStamp = false;
-
-            // Walk every pause stamp pair (31 total — mirrors the frontend's
-            // computeExactPauseMinutes via the shared EnumeratePauseStampPairs
-            // source of truth that GetPauseIntervals also consumes). Track
-            // whether ANY stamp was observed independently of the duration sum,
-            // so a populated-but-zero-duration pause (start == stop) doesn't
-            // wrongly trigger the legacy-tick fallback.
-            foreach (var (startedAt, stoppedAt) in EnumeratePauseStampPairs(pr))
-            {
-                if (startedAt.HasValue || stoppedAt.HasValue)
-                {
-                    hasAnyStamp = true;
-                }
-                if (startedAt.HasValue && stoppedAt.HasValue && startedAt.Value < stoppedAt.Value)
-                {
-                    totalSeconds += (long)(stoppedAt.Value - startedAt.Value).TotalSeconds;
-                }
-            }
-
-            if (!hasAnyStamp)
-            {
-                // Older flag-on rows without any stamp data may still carry
-                // legacy 5-minute-tick IDs in the 5 main pause slots.
-                return LegacyTickMinutesAcrossMainSlots(pr);
-            }
-
-            return (int)(totalSeconds / 60); // round down to whole minutes
+            totalSeconds += ComputeShiftPauseSeconds(pr, shift, useOneMinuteIntervals);
         }
 
-        // Flag-off branch: legacy 5-minute-tick path.
-        return LegacyTickMinutesAcrossMainSlots(pr);
-    }
-
-    /// <summary>
-    /// Sums the legacy 5-minute-tick pause IDs across the 5 main slots only.
-    /// Sub-slots have no *Id field, so they cannot contribute legacy ticks.
-    /// </summary>
-    private static int LegacyTickMinutesAcrossMainSlots(PlanRegistration pr)
-    {
-        var totalMinutes = 0;
-        if (pr.Pause1Id > 0) totalMinutes += (pr.Pause1Id * 5) - 5;
-        if (pr.Pause2Id > 0) totalMinutes += (pr.Pause2Id * 5) - 5;
-        if (pr.Pause3Id > 0) totalMinutes += (pr.Pause3Id * 5) - 5;
-        if (pr.Pause4Id > 0) totalMinutes += (pr.Pause4Id * 5) - 5;
-        if (pr.Pause5Id > 0) totalMinutes += (pr.Pause5Id * 5) - 5;
-        return totalMinutes;
-    }
-
-    private static long PauseSpanSeconds(DateTime? startedAt, DateTime? stoppedAt)
-    {
-        if (startedAt == null || stoppedAt == null) return 0;
-        var span = stoppedAt.Value - startedAt.Value;
-        return span.TotalSeconds > 0 ? (long)span.TotalSeconds : 0;
+        return (int)(totalSeconds / 60); // round down to whole minutes
     }
 
     /// <summary>
@@ -2085,44 +2013,168 @@ public static class PlanRegistrationHelper
     /// </summary>
     private static IEnumerable<(DateTime? StartedAt, DateTime? StoppedAt)> EnumeratePauseStampPairs(PlanRegistration pr)
     {
-        // Main pause intervals 1-5
-        yield return (pr.Pause1StartedAt, pr.Pause1StoppedAt);
-        yield return (pr.Pause2StartedAt, pr.Pause2StoppedAt);
-        yield return (pr.Pause3StartedAt, pr.Pause3StoppedAt);
-        yield return (pr.Pause4StartedAt, pr.Pause4StoppedAt);
-        yield return (pr.Pause5StartedAt, pr.Pause5StoppedAt);
+        // Delegate to the per-shift enumerator so there is ONE authoritative
+        // list of the 31 pause columns. The pairs are regrouped by shift
+        // (shift 1: Pause1,10-19,100-102; shift 2: Pause2,20-29,200-202;
+        // shifts 3-5: Pause3/4/5) rather than the old flat 1-5/10-29/100-102/
+        // 200-202 order, but the only consumer (GetPauseIntervals →
+        // CalculateTotalSeconds) sums durations and is order-independent.
+        for (var shift = 1; shift <= 5; shift++)
+        {
+            foreach (var pair in EnumerateShiftPauseStampPairs(pr, shift))
+            {
+                yield return pair;
+            }
+        }
+    }
 
-        // Extended pause intervals 10-29
-        yield return (pr.Pause10StartedAt, pr.Pause10StoppedAt);
-        yield return (pr.Pause11StartedAt, pr.Pause11StoppedAt);
-        yield return (pr.Pause12StartedAt, pr.Pause12StoppedAt);
-        yield return (pr.Pause13StartedAt, pr.Pause13StoppedAt);
-        yield return (pr.Pause14StartedAt, pr.Pause14StoppedAt);
-        yield return (pr.Pause15StartedAt, pr.Pause15StoppedAt);
-        yield return (pr.Pause16StartedAt, pr.Pause16StoppedAt);
-        yield return (pr.Pause17StartedAt, pr.Pause17StoppedAt);
-        yield return (pr.Pause18StartedAt, pr.Pause18StoppedAt);
-        yield return (pr.Pause19StartedAt, pr.Pause19StoppedAt);
-        yield return (pr.Pause20StartedAt, pr.Pause20StoppedAt);
-        yield return (pr.Pause21StartedAt, pr.Pause21StoppedAt);
-        yield return (pr.Pause22StartedAt, pr.Pause22StoppedAt);
-        yield return (pr.Pause23StartedAt, pr.Pause23StoppedAt);
-        yield return (pr.Pause24StartedAt, pr.Pause24StoppedAt);
-        yield return (pr.Pause25StartedAt, pr.Pause25StoppedAt);
-        yield return (pr.Pause26StartedAt, pr.Pause26StoppedAt);
-        yield return (pr.Pause27StartedAt, pr.Pause27StoppedAt);
-        yield return (pr.Pause28StartedAt, pr.Pause28StoppedAt);
-        yield return (pr.Pause29StartedAt, pr.Pause29StoppedAt);
+    /// <summary>
+    /// Enumerates the pause stamp pairs that belong to ONE shift.
+    /// A shift can carry pauses in several slot columns:
+    ///   shift 1 → Pause1 (primary), Pause10..Pause19, Pause100..Pause102
+    ///   shift 2 → Pause2 (primary), Pause20..Pause29, Pause200..Pause202
+    ///   shift 3 → Pause3 (single slot)
+    ///   shift 4 → Pause4 (single slot)
+    ///   shift 5 → Pause5 (single slot)
+    /// The primary slot is always yielded first so callers that need the
+    /// "primary only" semantics (e.g. legacy-fallback) can take the first pair.
+    /// </summary>
+    private static IEnumerable<(DateTime? StartedAt, DateTime? StoppedAt)> EnumerateShiftPauseStampPairs(PlanRegistration pr, int shift)
+    {
+        switch (shift)
+        {
+            case 1:
+                yield return (pr.Pause1StartedAt, pr.Pause1StoppedAt);
+                yield return (pr.Pause10StartedAt, pr.Pause10StoppedAt);
+                yield return (pr.Pause11StartedAt, pr.Pause11StoppedAt);
+                yield return (pr.Pause12StartedAt, pr.Pause12StoppedAt);
+                yield return (pr.Pause13StartedAt, pr.Pause13StoppedAt);
+                yield return (pr.Pause14StartedAt, pr.Pause14StoppedAt);
+                yield return (pr.Pause15StartedAt, pr.Pause15StoppedAt);
+                yield return (pr.Pause16StartedAt, pr.Pause16StoppedAt);
+                yield return (pr.Pause17StartedAt, pr.Pause17StoppedAt);
+                yield return (pr.Pause18StartedAt, pr.Pause18StoppedAt);
+                yield return (pr.Pause19StartedAt, pr.Pause19StoppedAt);
+                yield return (pr.Pause100StartedAt, pr.Pause100StoppedAt);
+                yield return (pr.Pause101StartedAt, pr.Pause101StoppedAt);
+                yield return (pr.Pause102StartedAt, pr.Pause102StoppedAt);
+                break;
+            case 2:
+                yield return (pr.Pause2StartedAt, pr.Pause2StoppedAt);
+                yield return (pr.Pause20StartedAt, pr.Pause20StoppedAt);
+                yield return (pr.Pause21StartedAt, pr.Pause21StoppedAt);
+                yield return (pr.Pause22StartedAt, pr.Pause22StoppedAt);
+                yield return (pr.Pause23StartedAt, pr.Pause23StoppedAt);
+                yield return (pr.Pause24StartedAt, pr.Pause24StoppedAt);
+                yield return (pr.Pause25StartedAt, pr.Pause25StoppedAt);
+                yield return (pr.Pause26StartedAt, pr.Pause26StoppedAt);
+                yield return (pr.Pause27StartedAt, pr.Pause27StoppedAt);
+                yield return (pr.Pause28StartedAt, pr.Pause28StoppedAt);
+                yield return (pr.Pause29StartedAt, pr.Pause29StoppedAt);
+                yield return (pr.Pause200StartedAt, pr.Pause200StoppedAt);
+                yield return (pr.Pause201StartedAt, pr.Pause201StoppedAt);
+                yield return (pr.Pause202StartedAt, pr.Pause202StoppedAt);
+                break;
+            case 3:
+                yield return (pr.Pause3StartedAt, pr.Pause3StoppedAt);
+                break;
+            case 4:
+                yield return (pr.Pause4StartedAt, pr.Pause4StoppedAt);
+                break;
+            case 5:
+                yield return (pr.Pause5StartedAt, pr.Pause5StoppedAt);
+                break;
+        }
+    }
 
-        // Additional pause intervals 100-102
-        yield return (pr.Pause100StartedAt, pr.Pause100StoppedAt);
-        yield return (pr.Pause101StartedAt, pr.Pause101StoppedAt);
-        yield return (pr.Pause102StartedAt, pr.Pause102StoppedAt);
+    /// <summary>
+    /// The legacy 5-minute-tick integer pause field for a shift's primary slot.
+    /// Pause{N}Id stores break in 5-minute ticks plus a +1 sentinel
+    /// (Pause1Id = 1 means 0 min, Pause1Id = 4 means 15 min, etc.).
+    /// </summary>
+    private static int PrimaryPauseId(PlanRegistration pr, int shift) => shift switch
+    {
+        1 => pr.Pause1Id,
+        2 => pr.Pause2Id,
+        3 => pr.Pause3Id,
+        4 => pr.Pause4Id,
+        5 => pr.Pause5Id,
+        _ => 0
+    };
 
-        // Additional pause intervals 200-202
-        yield return (pr.Pause200StartedAt, pr.Pause200StoppedAt);
-        yield return (pr.Pause201StartedAt, pr.Pause201StoppedAt);
-        yield return (pr.Pause202StartedAt, pr.Pause202StoppedAt);
+    private static readonly long FiveMinuteTicks = TimeSpan.FromMinutes(5).Ticks;
+
+    /// <summary>
+    /// Floors a DateTime down to its absolute 5-minute grid boundary on the
+    /// timeline (NOT relative to the day) so the result is over-midnight safe.
+    /// </summary>
+    private static DateTime FloorTo5Min(DateTime dt)
+        => new DateTime(dt.Ticks - (dt.Ticks % FiveMinuteTicks), dt.Kind);
+
+    /// <summary>
+    /// Canonical per-shift pause total in SECONDS — the single source of truth
+    /// for every netto and display pause computation.
+    ///
+    /// Sums the contribution of EVERY populated pause slot that belongs to the
+    /// shift (primary Pause{N} plus its sub-slots, see
+    /// <see cref="EnumerateShiftPauseStampPairs"/>), where each slot contributes:
+    ///   • <paramref name="useOneMinuteIntervals"/> == true  → the exact
+    ///     (StoppedAt - StartedAt) delta in seconds (full precision).
+    ///   • <paramref name="useOneMinuteIntervals"/> == false → the clock-tick
+    ///     delta: floor BOTH endpoints to the absolute 5-minute grid and
+    ///     difference them — floor(stop) - floor(start), a whole number of
+    ///     5-minute units. A pause that stays inside one 5-min cell contributes
+    ///     0; it adds 5 min for each 5-minute boundary it crosses.
+    ///
+    /// Fallback: when the shift has NO slot with both timestamps present (e.g.
+    /// legacy admin-entered rows that only carry the integer field), falls back
+    /// to the legacy 5-minute-tick value of the shift's primary slot only:
+    /// (Pause{N}Id > 0 ? Pause{N}Id - 1 : 0) * 5 * 60 seconds.
+    /// </summary>
+    public static int ComputeShiftPauseSeconds(PlanRegistration r, int shift, bool useOneMinuteIntervals)
+    {
+        long totalSeconds = 0;
+        var hasTimestampedSlot = false;
+
+        foreach (var (startedAt, stoppedAt) in EnumerateShiftPauseStampPairs(r, shift))
+        {
+            // A slot only counts as "measured" — and thus suppresses the
+            // legacy-tick fallback — when BOTH endpoints are present, i.e. it is
+            // a complete, measurable interval. A deliberately zero-duration
+            // (start == stop) or invalid (stop < start) but COMPLETE pause still
+            // counts: the worker stamped a real (if zero) pause, so the intended
+            // contribution is 0 and the legacy field must not resurface.
+            // An orphaned slot (only one endpoint — e.g. kiosk crash or partial
+            // edit) is NOT a complete slot, so it does not suppress the fallback;
+            // the row correctly falls back to the legacy Pause{N}Id tick value.
+            if (startedAt.HasValue && stoppedAt.HasValue)
+            {
+                hasTimestampedSlot = true;
+            }
+
+            if (!startedAt.HasValue || !stoppedAt.HasValue || stoppedAt.Value <= startedAt.Value)
+            {
+                continue;
+            }
+
+            if (useOneMinuteIntervals)
+            {
+                totalSeconds += (long)(stoppedAt.Value - startedAt.Value).TotalSeconds;
+            }
+            else
+            {
+                var tickDelta = FloorTo5Min(stoppedAt.Value) - FloorTo5Min(startedAt.Value);
+                totalSeconds += (long)tickDelta.TotalSeconds;
+            }
+        }
+
+        if (!hasTimestampedSlot)
+        {
+            var pauseId = PrimaryPauseId(r, shift);
+            return pauseId > 0 ? (pauseId - 1) * 5 * 60 : 0;
+        }
+
+        return (int)totalSeconds;
     }
 
     /// <summary>
@@ -2218,16 +2270,18 @@ public static class PlanRegistrationHelper
         var workIntervals = GetWorkIntervals(planRegistration);
         var totalWorkSeconds = CalculateTotalSeconds(workIntervals);
 
-        // Calculate pause intervals and total pause seconds
-        // var pauseIntervals = GetPauseIntervals(planRegistration);
-        // var totalPauseSeconds = CalculateTotalSeconds(pauseIntervals);
-        long totalPauseSeconds = 0;;
-        // Sum pauses from Pause1Id to Pause5Id only for now (as we don't have timestamps for others) and these are equal to 5 min increments
-        totalPauseSeconds += (planRegistration.Pause1Id > 0 ? planRegistration.Pause1Id - 1 : 0) * 300;
-        totalPauseSeconds += (planRegistration.Pause2Id > 0 ? planRegistration.Pause2Id - 1 : 0) * 300;
-        totalPauseSeconds += (planRegistration.Pause3Id > 0 ? planRegistration.Pause3Id - 1 : 0) * 300;
-        totalPauseSeconds += (planRegistration.Pause4Id > 0 ? planRegistration.Pause4Id - 1 : 0) * 300;
-        totalPauseSeconds += (planRegistration.Pause5Id > 0 ? planRegistration.Pause5Id - 1 : 0) * 300;
+        // Calculate total pause seconds via the canonical per-shift method so
+        // ALL populated pause slots (primary Pause{N} plus the multi-pause
+        // sub-slots Pause10/11/.., Pause20/21/..) are deducted, not just the
+        // legacy primary Pause{N}Id. This is the 5-minute (flag-off) grid path:
+        // each timestamped slot contributes its floor-to-5min clock-tick delta,
+        // falling back per-shift to the legacy Pause{N}Id tick value only when a
+        // shift has no timestamped pause slots.
+        long totalPauseSeconds = 0;
+        for (var shift = 1; shift <= 5; shift++)
+        {
+            totalPauseSeconds += ComputeShiftPauseSeconds(planRegistration, shift, useOneMinuteIntervals: false);
+        }
 
         // Net work seconds = total work - total pause (cannot be negative)
         var netWorkSeconds = Math.Max(0, totalWorkSeconds - totalPauseSeconds);

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningWorkingHoursModel.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningWorkingHoursModel.cs
@@ -50,6 +50,17 @@ public class TimePlanningWorkingHoursModel
     public int? Shift5Start { get; set; }
     public int? Shift5Pause { get; set; }
     public int? Shift5Stop { get; set; }
+
+    /// <summary>
+    /// Total pause minutes for shift 1 / shift 2, computed via
+    /// <c>PlanRegistrationHelper.ComputeShiftPauseSeconds</c> so they sum EVERY
+    /// populated pause slot (primary Pause{N} plus the multi-pause sub-slots),
+    /// honoring the site's UseOneMinuteIntervals flag. The Excel export renders
+    /// these instead of the legacy <c>Shift{N}Pause</c> (Pause{N}Id-only) value,
+    /// which ignored sub-slots and under-reported multi-pause days.
+    /// </summary>
+    public int Shift1PauseMinutes { get; set; }
+    public int Shift2PauseMinutes { get; set; }
     public double NettoHours { get; set; }
     public double FlexHours { get; set; }
     public double SumFlexStart { get; set; }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -184,6 +184,92 @@ public class TimePlanningWorkingHoursService(
                 })
                 .ToListAsync();
 
+            // Populate the canonical per-shift total pause minutes (all slots, not
+            // just the primary Pause{N}Id) for the Excel export. ComputeShiftPauseSeconds
+            // is not EF-translatable, so materialize the pause columns for these same
+            // rows in ONE batched query (keyed by Id) and compute in memory — no N+1.
+            if (timePlannings.Count > 0)
+            {
+                var pauseRows = await timePlanningRequest
+                    .Select(x => new PlanRegistration
+                    {
+                        Id = x.Id,
+                        Pause1Id = x.Pause1Id,
+                        Pause2Id = x.Pause2Id,
+                        Pause1StartedAt = x.Pause1StartedAt,
+                        Pause1StoppedAt = x.Pause1StoppedAt,
+                        Pause10StartedAt = x.Pause10StartedAt,
+                        Pause10StoppedAt = x.Pause10StoppedAt,
+                        Pause11StartedAt = x.Pause11StartedAt,
+                        Pause11StoppedAt = x.Pause11StoppedAt,
+                        Pause12StartedAt = x.Pause12StartedAt,
+                        Pause12StoppedAt = x.Pause12StoppedAt,
+                        Pause13StartedAt = x.Pause13StartedAt,
+                        Pause13StoppedAt = x.Pause13StoppedAt,
+                        Pause14StartedAt = x.Pause14StartedAt,
+                        Pause14StoppedAt = x.Pause14StoppedAt,
+                        Pause15StartedAt = x.Pause15StartedAt,
+                        Pause15StoppedAt = x.Pause15StoppedAt,
+                        Pause16StartedAt = x.Pause16StartedAt,
+                        Pause16StoppedAt = x.Pause16StoppedAt,
+                        Pause17StartedAt = x.Pause17StartedAt,
+                        Pause17StoppedAt = x.Pause17StoppedAt,
+                        Pause18StartedAt = x.Pause18StartedAt,
+                        Pause18StoppedAt = x.Pause18StoppedAt,
+                        Pause19StartedAt = x.Pause19StartedAt,
+                        Pause19StoppedAt = x.Pause19StoppedAt,
+                        Pause100StartedAt = x.Pause100StartedAt,
+                        Pause100StoppedAt = x.Pause100StoppedAt,
+                        Pause101StartedAt = x.Pause101StartedAt,
+                        Pause101StoppedAt = x.Pause101StoppedAt,
+                        Pause102StartedAt = x.Pause102StartedAt,
+                        Pause102StoppedAt = x.Pause102StoppedAt,
+                        Pause2StartedAt = x.Pause2StartedAt,
+                        Pause2StoppedAt = x.Pause2StoppedAt,
+                        Pause20StartedAt = x.Pause20StartedAt,
+                        Pause20StoppedAt = x.Pause20StoppedAt,
+                        Pause21StartedAt = x.Pause21StartedAt,
+                        Pause21StoppedAt = x.Pause21StoppedAt,
+                        Pause22StartedAt = x.Pause22StartedAt,
+                        Pause22StoppedAt = x.Pause22StoppedAt,
+                        Pause23StartedAt = x.Pause23StartedAt,
+                        Pause23StoppedAt = x.Pause23StoppedAt,
+                        Pause24StartedAt = x.Pause24StartedAt,
+                        Pause24StoppedAt = x.Pause24StoppedAt,
+                        Pause25StartedAt = x.Pause25StartedAt,
+                        Pause25StoppedAt = x.Pause25StoppedAt,
+                        Pause26StartedAt = x.Pause26StartedAt,
+                        Pause26StoppedAt = x.Pause26StoppedAt,
+                        Pause27StartedAt = x.Pause27StartedAt,
+                        Pause27StoppedAt = x.Pause27StoppedAt,
+                        Pause28StartedAt = x.Pause28StartedAt,
+                        Pause28StoppedAt = x.Pause28StoppedAt,
+                        Pause29StartedAt = x.Pause29StartedAt,
+                        Pause29StoppedAt = x.Pause29StoppedAt,
+                        Pause200StartedAt = x.Pause200StartedAt,
+                        Pause200StoppedAt = x.Pause200StoppedAt,
+                        Pause201StartedAt = x.Pause201StartedAt,
+                        Pause201StoppedAt = x.Pause201StoppedAt,
+                        Pause202StartedAt = x.Pause202StartedAt,
+                        Pause202StoppedAt = x.Pause202StoppedAt,
+                    })
+                    .ToListAsync();
+
+                var pauseRowsById = pauseRows.ToDictionary(x => x.Id);
+                foreach (var tp in timePlannings)
+                {
+                    if (tp.Id is not { } id || !pauseRowsById.TryGetValue(id, out var pauseRow))
+                    {
+                        continue;
+                    }
+
+                    tp.Shift1PauseMinutes =
+                        PlanRegistrationHelper.ComputeShiftPauseSeconds(pauseRow, 1, useOneMinuteIntervals) / 60;
+                    tp.Shift2PauseMinutes =
+                        PlanRegistrationHelper.ComputeShiftPauseSeconds(pauseRow, 2, useOneMinuteIntervals) / 60;
+                }
+            }
+
             var totalDays = (int)(model.DateTo - model.DateFrom).TotalDays + 1;
 
             var lastPlanning = dbContext.PlanRegistrations
@@ -216,6 +302,16 @@ public class TimePlanningWorkingHoursService(
                         Shift2Start = lastPlanning?.Start2Id,
                         Shift2Stop = lastPlanning?.Stop2Id,
                         Shift2Pause = lastPlanning?.Pause2Id,
+                        // Canonical all-slots pause totals (not the legacy single Pause{N}Id)
+                        // for the carried-over previous-day row. lastPlanning is a fully
+                        // materialized PlanRegistration already in scope, so this reuses
+                        // ComputeShiftPauseSeconds with no extra query (no N+1).
+                        Shift1PauseMinutes = lastPlanning != null
+                            ? PlanRegistrationHelper.ComputeShiftPauseSeconds(lastPlanning, 1, useOneMinuteIntervals) / 60
+                            : 0,
+                        Shift2PauseMinutes = lastPlanning != null
+                            ? PlanRegistrationHelper.ComputeShiftPauseSeconds(lastPlanning, 2, useOneMinuteIntervals) / 60
+                            : 0,
                         Shift3Start = lastPlanning?.Start3Id,
                         Shift3Stop = lastPlanning?.Stop3Id,
                         Shift3Pause = lastPlanning?.Pause3Id,
@@ -956,6 +1052,50 @@ public class TimePlanningWorkingHoursService(
         Heal(pr.Pause5StartedAt, pr.Pause5StoppedAt, pr.Pause5Id, 5, v => pr.Pause5Id = v);
     }
 
+    /// <summary>
+    /// Flag-OFF netto computation (5-minute sites): work span in 5-minute ticks
+    /// per shift minus the canonical all-slots shift pause (floor-to-5min clock
+    /// tick), summed across shifts 1..5. Returns netto MINUTES. Mirrors the
+    /// per-call inline blocks in the personal/kiosk create/update paths.
+    /// </summary>
+    private static double ComputeFlagOffNettoMinutes(PlanRegistration pr)
+    {
+        const int minutesMultiplier = 5;
+        double nettoMinutes = 0;
+
+        if (pr.Stop1Id >= pr.Start1Id && pr.Stop1Id != 0)
+        {
+            nettoMinutes += (pr.Stop1Id - pr.Start1Id) * minutesMultiplier;
+            nettoMinutes -= PlanRegistrationHelper.ComputeShiftPauseSeconds(pr, 1, useOneMinuteIntervals: false) / 60.0;
+        }
+
+        if (pr.Stop2Id >= pr.Start2Id && pr.Stop2Id != 0)
+        {
+            nettoMinutes += (pr.Stop2Id - pr.Start2Id) * minutesMultiplier;
+            nettoMinutes -= PlanRegistrationHelper.ComputeShiftPauseSeconds(pr, 2, useOneMinuteIntervals: false) / 60.0;
+        }
+
+        if (pr.Stop3Id >= pr.Start3Id && pr.Stop3Id != 0)
+        {
+            nettoMinutes += (pr.Stop3Id - pr.Start3Id) * minutesMultiplier;
+            nettoMinutes -= PlanRegistrationHelper.ComputeShiftPauseSeconds(pr, 3, useOneMinuteIntervals: false) / 60.0;
+        }
+
+        if (pr.Stop4Id >= pr.Start4Id && pr.Stop4Id != 0)
+        {
+            nettoMinutes += (pr.Stop4Id - pr.Start4Id) * minutesMultiplier;
+            nettoMinutes -= PlanRegistrationHelper.ComputeShiftPauseSeconds(pr, 4, useOneMinuteIntervals: false) / 60.0;
+        }
+
+        if (pr.Stop5Id >= pr.Start5Id && pr.Stop5Id != 0)
+        {
+            nettoMinutes += (pr.Stop5Id - pr.Start5Id) * minutesMultiplier;
+            nettoMinutes -= PlanRegistrationHelper.ComputeShiftPauseSeconds(pr, 5, useOneMinuteIntervals: false) / 60.0;
+        }
+
+        return nettoMinutes;
+    }
+
     public async Task<OperationResult> UpdateWorkingHour(TimePlanningWorkingHoursUpdateModel model)
     {
         Console.WriteLine($"[DEBUG-GRPC-UPDATE] === UpdateWorkingHour (PERSONAL mode, 1-param) entered ===");
@@ -1281,8 +1421,6 @@ public class TimePlanningWorkingHoursService(
                 Shift2PauseNumber = model.Shift2PauseNumber,
             };
 
-            var minutesMultiplier = 5;
-            double nettoMinutes = 0;
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
 
@@ -1290,37 +1428,7 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
-            if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
-            {
-                nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
-                nettoMinutes -= planRegistration.Pause1Id > 0 ? planRegistration.Pause1Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop2Id >= planRegistration.Start2Id && planRegistration.Stop2Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop2Id - planRegistration.Start2Id;
-                nettoMinutes -= planRegistration.Pause2Id > 0 ? planRegistration.Pause2Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop3Id >= planRegistration.Start3Id && planRegistration.Stop3Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop3Id - planRegistration.Start3Id;
-                nettoMinutes -= planRegistration.Pause3Id > 0 ? planRegistration.Pause3Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop4Id >= planRegistration.Start4Id && planRegistration.Stop4Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop4Id - planRegistration.Start4Id;
-                nettoMinutes -= planRegistration.Pause4Id > 0 ? planRegistration.Pause4Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop5Id >= planRegistration.Start5Id && planRegistration.Stop5Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop5Id - planRegistration.Start5Id;
-                nettoMinutes -= planRegistration.Pause5Id > 0 ? planRegistration.Pause5Id - 1 : 0;
-            }
-
-            nettoMinutes *= minutesMultiplier;
+            double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
             var preTimePlanning =
@@ -1606,8 +1714,6 @@ public class TimePlanningWorkingHoursService(
             planRegistration.Shift1PauseNumber = model.Shift1PauseNumber;
             planRegistration.Shift2PauseNumber = model.Shift2PauseNumber;
 
-            var minutesMultiplier = 5;
-            double nettoMinutes = 0;
 
             planRegistration = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planRegistration);
 
@@ -1615,37 +1721,7 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
-            if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
-            {
-                nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
-                nettoMinutes -= planRegistration.Pause1Id > 0 ? planRegistration.Pause1Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop2Id >= planRegistration.Start2Id && planRegistration.Stop2Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop2Id - planRegistration.Start2Id;
-                nettoMinutes -= planRegistration.Pause2Id > 0 ? planRegistration.Pause2Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop3Id >= planRegistration.Start3Id && planRegistration.Stop3Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop3Id - planRegistration.Start3Id;
-                nettoMinutes -= planRegistration.Pause3Id > 0 ? planRegistration.Pause3Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop4Id >= planRegistration.Start4Id && planRegistration.Stop4Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop4Id - planRegistration.Start4Id;
-                nettoMinutes -= planRegistration.Pause4Id > 0 ? planRegistration.Pause4Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop5Id >= planRegistration.Start5Id && planRegistration.Stop5Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop5Id - planRegistration.Start5Id;
-                nettoMinutes -= planRegistration.Pause5Id > 0 ? planRegistration.Pause5Id - 1 : 0;
-            }
-
-            nettoMinutes *= minutesMultiplier;
+            double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
             var preTimePlanning =
@@ -1986,8 +2062,6 @@ public class TimePlanningWorkingHoursService(
                 Shift2PauseNumber = model.Shift2PauseNumber,
             };
 
-            var minutesMultiplier = 5;
-            double nettoMinutes = 0;
 
             var assignedSite = await dbContext.AssignedSites
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -1999,37 +2073,7 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
-            if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
-            {
-                nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
-                nettoMinutes -= planRegistration.Pause1Id > 0 ? planRegistration.Pause1Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop2Id >= planRegistration.Start2Id && planRegistration.Stop2Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop2Id - planRegistration.Start2Id;
-                nettoMinutes -= planRegistration.Pause2Id > 0 ? planRegistration.Pause2Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop3Id >= planRegistration.Start3Id && planRegistration.Stop3Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop3Id - planRegistration.Start3Id;
-                nettoMinutes -= planRegistration.Pause3Id > 0 ? planRegistration.Pause3Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop4Id >= planRegistration.Start4Id && planRegistration.Stop4Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop4Id - planRegistration.Start4Id;
-                nettoMinutes -= planRegistration.Pause4Id > 0 ? planRegistration.Pause4Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop5Id >= planRegistration.Start5Id && planRegistration.Stop5Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop5Id - planRegistration.Start5Id;
-                nettoMinutes -= planRegistration.Pause5Id > 0 ? planRegistration.Pause5Id - 1 : 0;
-            }
-
-            nettoMinutes *= minutesMultiplier;
+            double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
             var preTimePlanning =
@@ -2300,8 +2344,6 @@ public class TimePlanningWorkingHoursService(
             planRegistration.Shift1PauseNumber = model.Shift1PauseNumber;
             planRegistration.Shift2PauseNumber = model.Shift2PauseNumber;
 
-            var minutesMultiplier = 5;
-            double nettoMinutes = 0;
 
             var assignedSite = await dbContext.AssignedSites
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -2313,37 +2355,7 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
-            if (planRegistration.Stop1Id >= planRegistration.Start1Id && planRegistration.Stop1Id != 0)
-            {
-                nettoMinutes = planRegistration.Stop1Id - planRegistration.Start1Id;
-                nettoMinutes -= planRegistration.Pause1Id > 0 ? planRegistration.Pause1Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop2Id >= planRegistration.Start2Id && planRegistration.Stop2Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop2Id - planRegistration.Start2Id;
-                nettoMinutes -= planRegistration.Pause2Id > 0 ? planRegistration.Pause2Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop3Id >= planRegistration.Start3Id && planRegistration.Stop3Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop3Id - planRegistration.Start3Id;
-                nettoMinutes -= planRegistration.Pause3Id > 0 ? planRegistration.Pause3Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop4Id >= planRegistration.Start4Id && planRegistration.Stop4Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop4Id - planRegistration.Start4Id;
-                nettoMinutes -= planRegistration.Pause4Id > 0 ? planRegistration.Pause4Id - 1 : 0;
-            }
-
-            if (planRegistration.Stop5Id >= planRegistration.Start5Id && planRegistration.Stop5Id != 0)
-            {
-                nettoMinutes = nettoMinutes + planRegistration.Stop5Id - planRegistration.Start5Id;
-                nettoMinutes -= planRegistration.Pause5Id > 0 ? planRegistration.Pause5Id - 1 : 0;
-            }
-
-            nettoMinutes *= minutesMultiplier;
+            double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
             var preTimePlanning =
@@ -2750,10 +2762,10 @@ public class TimePlanningWorkingHoursService(
             // pass actualStamp=null and fall through to the existing 2-arg lookup.
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift1Start, planning.Start1StartedAt, useOneMinuteIntervals)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift1Stop, planning.Stop1StoppedAt, useOneMinuteIntervals)));
-            dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift1Pause, null, useOneMinuteIntervals)));
+            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift1PauseMinutes)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift2Start, planning.Start2StartedAt, useOneMinuteIntervals)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift2Stop, planning.Stop2StoppedAt, useOneMinuteIntervals)));
-            dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift2Pause, null, useOneMinuteIntervals)));
+            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift2PauseMinutes)));
             dataRow.Append(CreateNumericCell(planning.NettoHoursOverrideActive ? planning.NettoHoursOverride : planning.NettoHours));
             dataRow.Append(CreateNumericCell(planning.FlexHours));
             dataRow.Append(CreateNumericCell(planning.SumFlexEnd));
@@ -2830,6 +2842,33 @@ public class TimePlanningWorkingHoursService(
         };
     }
 
+
+    /// <summary>
+    /// Formats a total pause duration in minutes as <c>HH:mm</c> (the Dashboard
+    /// sheet's pause-cell format). Source is the canonical all-slots pause total
+    /// (<c>Shift{N}PauseMinutes</c>), not the legacy single-slot Pause{N}Id.
+    /// </summary>
+    internal static string FormatPauseMinutesAsTime(int minutes)
+    {
+        if (minutes <= 0)
+        {
+            return "";
+        }
+        return $"{minutes / 60:00}:{minutes % 60:00}";
+    }
+
+    /// <summary>
+    /// The day-fraction (minutes / 1440) of a total pause duration for the
+    /// Dagsoversigt tab, mirroring <see cref="GetShiftTimeFraction"/>'s output.
+    /// </summary>
+    internal static double? PauseMinutesAsDayFraction(int minutes)
+    {
+        if (minutes <= 0)
+        {
+            return null;
+        }
+        return minutes / 1440.0;
+    }
 
     internal string GetShiftTime(PlanRegistration plr, int? shift)
     {
@@ -4206,10 +4245,10 @@ public class TimePlanningWorkingHoursService(
             var p = row.Planning;
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Start, p.Start1StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Stop, p.Stop1StoppedAt, row.UseOneMinuteIntervals)));
-            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift1PauseMinutes)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Start, p.Start2StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Stop, p.Stop2StoppedAt, row.UseOneMinuteIntervals)));
-            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Pause, null, row.UseOneMinuteIntervals)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift2PauseMinutes)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Start, p.Start3StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Stop, p.Stop3StoppedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Pause, null, row.UseOneMinuteIntervals)));

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -2762,10 +2762,10 @@ public class TimePlanningWorkingHoursService(
             // pass actualStamp=null and fall through to the existing 2-arg lookup.
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift1Start, planning.Start1StartedAt, useOneMinuteIntervals)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift1Stop, planning.Stop1StoppedAt, useOneMinuteIntervals)));
-            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift1PauseMinutes)));
+            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift1PauseMinutes, planning.Shift1Pause)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift2Start, planning.Start2StartedAt, useOneMinuteIntervals)));
             dataRow.Append(CreateCell(GetShiftTime(plr, planning.Shift2Stop, planning.Stop2StoppedAt, useOneMinuteIntervals)));
-            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift2PauseMinutes)));
+            dataRow.Append(CreateCell(FormatPauseMinutesAsTime(planning.Shift2PauseMinutes, planning.Shift2Pause)));
             dataRow.Append(CreateNumericCell(planning.NettoHoursOverrideActive ? planning.NettoHoursOverride : planning.NettoHours));
             dataRow.Append(CreateNumericCell(planning.FlexHours));
             dataRow.Append(CreateNumericCell(planning.SumFlexEnd));
@@ -2844,13 +2844,26 @@ public class TimePlanningWorkingHoursService(
 
 
     /// <summary>
+    /// A shift pause cell is blank only when the shift has no pause at all: the
+    /// canonical all-slots total is zero AND the legacy single-slot Pause{N}Id is
+    /// absent (id &lt;= 0). A present-but-zero pause (legacy id 1 -&gt; 0 min) still
+    /// renders, preserving the old "00:00"/0.0 output; a real/multi pause
+    /// (minutes &gt; 0) always renders regardless of the legacy id.
+    /// </summary>
+    private static bool IsShiftPauseBlank(int minutes, int? legacyPauseId)
+    {
+        return minutes == 0 && (legacyPauseId ?? 0) <= 0;
+    }
+
+    /// <summary>
     /// Formats a total pause duration in minutes as <c>HH:mm</c> (the Dashboard
     /// sheet's pause-cell format). Source is the canonical all-slots pause total
-    /// (<c>Shift{N}PauseMinutes</c>), not the legacy single-slot Pause{N}Id.
+    /// (<c>Shift{N}PauseMinutes</c>); the legacy single-slot Pause{N}Id is used
+    /// only to decide blank-vs-present-zero (see <see cref="IsShiftPauseBlank"/>).
     /// </summary>
-    internal static string FormatPauseMinutesAsTime(int minutes)
+    internal static string FormatPauseMinutesAsTime(int minutes, int? legacyPauseId)
     {
-        if (minutes <= 0)
+        if (IsShiftPauseBlank(minutes, legacyPauseId))
         {
             return "";
         }
@@ -2860,10 +2873,11 @@ public class TimePlanningWorkingHoursService(
     /// <summary>
     /// The day-fraction (minutes / 1440) of a total pause duration for the
     /// Dagsoversigt tab, mirroring <see cref="GetShiftTimeFraction"/>'s output.
+    /// The legacy single-slot Pause{N}Id only decides blank-vs-present-zero.
     /// </summary>
-    internal static double? PauseMinutesAsDayFraction(int minutes)
+    internal static double? PauseMinutesAsDayFraction(int minutes, int? legacyPauseId)
     {
-        if (minutes <= 0)
+        if (IsShiftPauseBlank(minutes, legacyPauseId))
         {
             return null;
         }
@@ -4245,10 +4259,10 @@ public class TimePlanningWorkingHoursService(
             var p = row.Planning;
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Start, p.Start1StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift1Stop, p.Stop1StoppedAt, row.UseOneMinuteIntervals)));
-            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift1PauseMinutes)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift1PauseMinutes, p.Shift1Pause)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Start, p.Start2StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift2Stop, p.Stop2StoppedAt, row.UseOneMinuteIntervals)));
-            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift2PauseMinutes)));
+            dataRow.Append(DayOverviewTimeCell(c++, rowIndex, PauseMinutesAsDayFraction(p.Shift2PauseMinutes, p.Shift2Pause)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Start, p.Start3StartedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Stop, p.Stop3StoppedAt, row.UseOneMinuteIntervals)));
             dataRow.Append(DayOverviewTimeCell(c++, rowIndex, GetShiftTimeFraction(p.Shift3Pause, null, row.UseOneMinuteIntervals)));

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.ts
@@ -158,11 +158,13 @@ export class WorkdayEntityDialogComponent implements OnInit, OnDestroy {
 
     const start1StartedAt = this.datePipe.transform(this.data.planningPrDayModels.start1StartedAt, 'HH:mm', 'UTC');
     const stop1StoppedAt = this.datePipe.transform(this.data.planningPrDayModels.stop1StoppedAt, 'HH:mm', 'UTC');
-    const pause1Id = this.convertMinutesToTime(this.data.planningPrDayModels.pause1Id * 5);
+    const pause1Minutes = this.computeFiveMinutePauseMinutes(1);
+    const pause1Id = this.convertMinutesToTime(pause1Minutes ?? this.data.planningPrDayModels.pause1Id * 5);
 
     const start2StartedAt = this.datePipe.transform(this.data.planningPrDayModels.start2StartedAt, 'HH:mm', 'UTC');
     const stop2StoppedAt = this.datePipe.transform(this.data.planningPrDayModels.stop2StoppedAt, 'HH:mm', 'UTC');
-    const pause2Id = this.convertMinutesToTime(this.data.planningPrDayModels.pause2Id * 5);
+    const pause2Minutes = this.computeFiveMinutePauseMinutes(2);
+    const pause2Id = this.convertMinutesToTime(pause2Minutes ?? this.data.planningPrDayModels.pause2Id * 5);
 
     const start3StartedAt = this.datePipe.transform(this.data.planningPrDayModels.start3StartedAt, 'HH:mm', 'UTC');
     const stop3StoppedAt = this.datePipe.transform(this.data.planningPrDayModels.stop3StoppedAt, 'HH:mm', 'UTC');
@@ -1085,6 +1087,31 @@ export class WorkdayEntityDialogComponent implements OnInit, OnDestroy {
       }
     }
     return Math.round(totalSeconds / 60);
+  }
+
+  // Sum every Pause*StartedAt/Pause*StoppedAt pair attached to the given shift
+  // using the 5-minute clock-tick rule that mirrors the C# backend under
+  // UseOneMinuteIntervals=false: each endpoint is floored DOWN to its absolute
+  // 5-minute boundary, then differenced per slot (floor(stop) - floor(start),
+  // NOT floor(stop - start)), and summed. A pause inside a single 5-minute cell
+  // contributes 0; each crossed 5-minute boundary adds 5. Returns whole
+  // 5-minute units, or null when the shift has no slot with both endpoints
+  // present (so the caller can fall back to the legacy pause{N}Id value).
+  private computeFiveMinutePauseMinutes(shift: number): number | null {
+    const fiveMinMs = 300000;
+    const floorTo5MinMs = (ms: number) => Math.floor(ms / fiveMinMs) * fiveMinMs;
+    let totalMs = 0;
+    let hasPair = false;
+    for (const [start, stop] of this.getPauseTimestampPairs(shift)) {
+      if (start && stop) {
+        hasPair = true;
+        totalMs += floorTo5MinMs(new Date(stop).getTime()) - floorTo5MinMs(new Date(start).getTime());
+      }
+    }
+    if (!hasPair) {
+      return null;
+    }
+    return totalMs / 60000;
   }
 
   private getPauseTimestampPairs(shift: number): Array<[string | null, string | null]> {


### PR DESCRIPTION
## Problem

Per-shift pause was computed from **only the primary pause slot** (`Pause1`/`Pause2`). When a worker takes multiple breaks in one shift, the extra pauses are stored in sub-slots (`Pause10..19`/`Pause100..102` for shift 1, `Pause20..29`/`Pause200..202` for shift 2) — and those were silently ignored.

Concrete case (PlanRegistration 16288, tenant 855): shift 1 has 4 real pauses totalling **30 min**, but:
- **NettoHours** deducted only ~5 min → worker over-credited ~28 min
- the **admin workday dialog** showed 5 min
- the **Excel export** showed 5 min

The app's "today" view already summed all slots (showed 30), which is what surfaced the discrepancy.

## Fix

New single source of truth `PlanRegistrationHelper.ComputeShiftPauseSeconds(reg, shift, useOneMinuteIntervals)`:
- **OFF (5-min sites):** per-slot 5-min clock-tick delta `floor(stop) - floor(start)`, summed over all slots
- **ON (one-minute sites):** exact `(stop - start)`, summed over all slots
- **Fallback:** legacy `Pause{N}Id` integer only when a shift has no timestamped slot. A half-record (StartedAt without StoppedAt) does not suppress the fallback.

Rule confirmed with product owner: total pause = every recorded pause start/stop; for 16288 → shift 1 = 30, shift 2 = 5, day = 35 min.

Re-wired every consumer:
- Netto: `ComputeNettoSecondsFromDateTimeShifts`, `ComputeTimeTrackingFields`, and the four inline working-hours netto blocks (extracted into one `ComputeFlagOffNettoMinutes`)
- Display: `AggregatePauseMinutes`
- Excel export (shifts 1 & 2): `Index()` projection + `FillDataRow` + Dagsoversigt
- Admin workday dialog OFF-path (Angular)

## Scope / notes

- **Forward-only** — no historical data repair (a read-only feasibility check exists separately; ~97% of recent flag-known rows are deterministically recoverable if a repair is later approved).
- Existing tests that encoded the old single-slot behaviour are updated to the corrected netto values (each corrected value matches the netto the test's own comment documented); new `ComputeShiftPauseSecondsTests` added.
- **Out of scope, separate ticket:** `PauseMinutesCalculator` (admin detailed-pause-edit save path) diverges from the canonical method — it attributes `Pause2` to shift 1 and rounds by `floor(duration)`. It only writes the legacy fallback ints, so impact is mostly latent.
- Shifts 3-5 have no sub-slots in the schema, so they are unaffected by under-counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)