### PR TITLE
fix(planning): scope 5-min-label timepicker CSS to the minute face

### DIFF
--- a/docs/superpowers/specs/2026-06-25-timepicker-hours-dial-scope-fix-design.md
+++ b/docs/superpowers/specs/2026-06-25-timepicker-hours-dial-scope-fix-design.md
@@ -1,0 +1,65 @@
+# Timepicker hours-dial regression — scoped 5-minute-label fix
+
+**Date:** 2026-06-25
+**Status:** design approved, pending implementation
+**Branch:** `fix/timepicker-hours-dial-scope` off `stable`
+**Fixes:** regression introduced by #1625 (`feat(planning): show only 5-min labels on one-minute timepicker`), live on `stable`.
+
+## Problem
+
+In one-minute mode the workday-entity dialog's `ngx-material-timepicker` (v13.1.1) **HOURS** dial shows only hours 1, 6, 11 — the rest are hidden. The 5-minute-minute-label feature's CSS leaks onto the hours face.
+
+### Root cause
+
+The feature thins minute labels with:
+
+```scss
+.timepicker.timepicker--hide-non-multiples-of-5 .clock-face__number--outer:not(:nth-child(5n+1)) > span { visibility: hidden; }
+```
+
+applied via `[timepickerClass]` on the persistent overlay root `.timepicker`. Both the **hours** outer ring (12 cells) and the **minutes** ring (60 cells) use the same class `clock-face__number--outer`, and the root `.timepicker` is present on both faces. On the 12-cell hours dial, `:nth-child(5n+1)` keeps positions 1/6/11 → hours 1, 6, 11; all other hours are hidden via `visibility:hidden`. It only works for minutes by coincidence of count (60 cells → minutes 0,5,…,55). The 24h inner ring uses `clock-face__number--inner`, so it is unaffected.
+
+The library has no `minutesGap`-style hook that separates *labels* from *selection* (gap=5 would also snap selection to 5-minute steps), so CSS thinning is the correct strategy — it just must be scoped to the minute face. The library renders only the **active** face into the DOM (`*ngSwitchCase`), so the minute face is identifiable by having more than 12 outer cells.
+
+## Requirements
+
+- **Hours dial:** every hour visible and selectable (full 1–12 outer ring + 00/13–23 inner ring) — stock Material behavior, untouched.
+- **Minute dial:** only labels for multiples of 5 (0,5,10,…,55) shown; **every** minute still selectable (1-minute precision preserved).
+- Applies only when the tenant is in one-minute mode (the existing `[timepickerClass]` binding gate is unchanged).
+
+## Design
+
+### 1. Scope the selector to the minute face (`:has()`)
+
+Gate the thinning behind a `:has()` that matches only the minute face — keyed on the minute face having a 13th outer cell, which the hours outer ring never has:
+
+```scss
+.timepicker.timepicker--hide-non-multiples-of-5
+  .clock-face:has(.clock-face__number--outer:nth-child(13))
+  .clock-face__number--outer:not(:nth-child(5n+1)) > span { visibility: hidden; }
+```
+
+The exact ancestor element (`.clock-face` vs the numbers' direct container) and the `:has()` predicate will be confirmed against the live rendered DOM during implementation; the count-based `:nth-child(13)` predicate is format-independent (the hours outer ring is always 12 cells in both 12h and 24h formats). `:has()` is supported in all current evergreen browsers — acceptable for this internal admin app. The CI test (below) validates the chosen selector against both dials, so a wrong guess cannot ship.
+
+### 2. Move the rule to the global stylesheet
+
+Move the rule out of `time-plannings-table.component.scss` (which only reaches the body-appended overlay via `ViewEncapsulation.None` — fragile, silently breaks if encapsulation changes) into the eform-client **global stylesheet** that already holds global timepicker/overlay overrides, per the original feature spec.
+
+### 3. Harden the Playwright test
+
+The current test (`b1m/dashboard-edit-a.spec.ts`) clicks an hour *first*, then asserts label visibility — so it never inspects the hours dial while open, which is why it missed the regression. Update it to:
+
+1. Open the picker (starts on the **hours** dial) and assert **all 12** hour outer-ring labels are visible (`toBeVisible` for each).
+2. Click an hour to move to the minute dial; assert only multiples of 5 are visible and a non-multiple (e.g. minute 23) is hidden.
+3. Confirm a non-multiple minute is still **selectable** (round-trips to a value like `09:23`).
+
+## Out of scope (YAGNI)
+
+- No library fork, no TypeScript, no change to selection behavior.
+- The six `[timepickerClass]` bindings stay as-is.
+- The stale `feat/planning-timepicker-5min-labels` branch is abandoned (its content shipped via #1625).
+
+## Verification
+
+- Playwright spec asserts both dials (hours intact + minutes thinned + non-5 minute selectable).
+- Manual: open the workday dialog on a one-minute tenant, confirm the hours dial shows every hour and the minute dial shows only 0/5/…/55.

--- a/docs/superpowers/specs/2026-06-25-timepicker-hours-dial-scope-fix-design.md
+++ b/docs/superpowers/specs/2026-06-25-timepicker-hours-dial-scope-fix-design.md
@@ -41,9 +41,9 @@ Gate the thinning behind a `:has()` that matches only the minute face — keyed 
 
 The exact ancestor element (`.clock-face` vs the numbers' direct container) and the `:has()` predicate will be confirmed against the live rendered DOM during implementation; the count-based `:nth-child(13)` predicate is format-independent (the hours outer ring is always 12 cells in both 12h and 24h formats). `:has()` is supported in all current evergreen browsers — acceptable for this internal admin app. The CI test (below) validates the chosen selector against both dials, so a wrong guess cannot ship.
 
-### 2. Move the rule to the global stylesheet
+### 2. Rule location — kept in the component (as built)
 
-Move the rule out of `time-plannings-table.component.scss` (which only reaches the body-appended overlay via `ViewEncapsulation.None` — fragile, silently breaks if encapsulation changes) into the eform-client **global stylesheet** that already holds global timepicker/overlay overrides, per the original feature spec.
+The original feature spec wanted the rule in a global stylesheet. On investigation that is not appropriate here: the **plugin** repo owns no global stylesheet — the angular.json global styles (`src/scss/styles.scss`, `theme.scss`) live in the **host** repo (`eform-angular-frontend`), and `devinstall.sh` only ships the plugin module dir + DLL + e2e tests, never host globals. Moving the rule there would disconnect it from the plugin's release pipeline. So the rule stays in `time-plannings-table.component.scss`, which is emitted globally via `ViewEncapsulation.None` (the existing mechanism that already reaches the body-appended overlay), with a comment documenting both the minute-face scoping and this ownership rationale.
 
 ### 3. Harden the Playwright test
 

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/b1m/dashboard-edit-a.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/b1m/dashboard-edit-a.spec.ts
@@ -196,6 +196,21 @@ test.describe('Dashboard edit values (b1m, flag-on, 1-minute granularity)', () =
     const h: number = 9;
     const hourFace = page.locator('.clock-face');
     await hourFace.first().waitFor({ state: 'visible', timeout: 5000 });
+
+    // Regression guard for the hours dial: the picker opens on the HOURS face,
+    // whose outer ring also uses .clock-face__number--outer. The 5-min-label
+    // thinning rule is scoped to the minute face only, so EVERY one of the 12
+    // hour labels (1..12) must stay visible here. (Bug #1625 hid hours 2,3,4,7,
+    // 8,9,12 because :nth-child(5n+1) kept only 1/6/11 on the 12-cell dial.)
+    // Shared across both faces (only the active face is in the DOM at a time).
+    const outerLabelSelector =
+      '.timepicker.timepicker--hide-non-multiples-of-5 .clock-face__number--outer > span';
+    const hourLabels = page.locator(outerLabelSelector);
+    await expect(hourLabels).toHaveCount(12);
+    for (let i = 0; i < 12; i++) {
+      await expect(hourLabels.nth(i), `hour label ${i + 1} should be visible`).toBeVisible();
+    }
+
     const hourAngle = (h % 12) * 30;
     const hourR = (h === 0 || h > 12) ? 60 : 100;
     const hourRad = hourAngle * Math.PI / 180;
@@ -211,8 +226,7 @@ test.describe('Dashboard edit values (b1m, flag-on, 1-minute granularity)', () =
     // clock face; non-multiple-of-5 labels are hidden (visibility:hidden) by the
     // .timepicker--hide-non-multiples-of-5 rule. The items remain in the DOM so
     // selection still works — only the label <span> is hidden.
-    const minuteLabels = page.locator(
-      '.timepicker.timepicker--hide-non-multiples-of-5 .clock-face__number--outer > span');
+    const minuteLabels = page.locator(outerLabelSelector);
     await expect(minuteLabels.nth(0)).toBeVisible();   // minute 0
     await expect(minuteLabels.nth(5)).toBeVisible();   // minute 5
     await expect(minuteLabels.nth(1)).toBeHidden();    // minute 1 label hidden

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-plannings-table/time-plannings-table.component.scss
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-plannings-table/time-plannings-table.component.scss
@@ -63,16 +63,31 @@
 }
 
 /* Planning workday picker in one-minute mode (minutesGap=1, all 60 minutes
-   selectable): show only the 5-minute marks. Marker class is set via
-   [timepickerClass] only on the flag-on pickers, so other timepickers and the
-   minutesGap=5 pickers are unaffected. visibility:hidden keeps each minute's
-   click target + layout, so any minute is still selectable.
+   selectable): show only the 5-minute marks on the MINUTE dial. Marker class is
+   set via [timepickerClass] only on the flag-on pickers, so other timepickers
+   and the minutesGap=5 pickers are unaffected. visibility:hidden keeps each
+   minute's click target + layout, so any minute is still selectable.
+
+   Scoping: ngx-material-timepicker v13.1.1 reuses the class
+   .clock-face__number--outer for BOTH the hours outer ring (12 cells) and the
+   minutes ring (60 cells), and the .timepicker overlay root persists across
+   faces. Without scoping, :nth-child(5n+1) on the 12-cell hours dial would keep
+   only hours 1/6/11 and hide the rest. We gate the thinning behind a :has()
+   that matches only the minute face: the minute face's .clock-face__container
+   has a 13th .clock-face__number--outer child (60 cells), while the hours
+   face's container has at most 12 outer cells (its 13th child, when present in
+   24h format, is .clock-face__inner, never a --outer). The library renders only
+   the active face into the DOM, so this predicate cleanly isolates the minute
+   face in both 12h and 24h formats.
 
    This rule lives here (rather than a host global stylesheet, which the plugin
-   does not own) because this component already uses ViewEncapsulation.None, so
-   its styles are emitted globally and reach the ngx-material-timepicker overlay
-   that is appended to <body> from the workday-entity dialog this table opens. */
-.timepicker.timepicker--hide-non-multiples-of-5 .clock-face__number--outer:not(:nth-child(5n+1)) > span {
+   does not own and which devinstall.sh never overwrites) because this component
+   already uses ViewEncapsulation.None, so its styles are emitted globally and
+   reach the ngx-material-timepicker overlay that is appended to <body> from the
+   workday-entity dialog this table opens. */
+.timepicker.timepicker--hide-non-multiples-of-5
+  .clock-face__container:has(.clock-face__number--outer:nth-child(13))
+  .clock-face__number--outer:not(:nth-child(5n+1)) > span {
   visibility: hidden;
 }
 


### PR DESCRIPTION
## Problem

The one-minute 5-min-label timepicker feature (#1625, live on `stable`) breaks the **hours** dial: it shows only hours **1, 6, 11**, hiding the rest.

## Root cause

The thinning rule
```scss
.timepicker--hide-non-multiples-of-5 .clock-face__number--outer:not(:nth-child(5n+1)) > span { visibility: hidden; }
```
keys on `.clock-face__number--outer` — but `ngx-material-timepicker` v13.1.1 uses that **same class for both the 12-cell hours ring and the 60-cell minute ring**, and the `.timepicker--hide-non-multiples-of-5` class sits on the persistent overlay root present on both faces. On the 12-cell hours dial, `:nth-child(5n+1)` keeps positions 1/6/11 → hours 1, 6, 11. It only works on minutes by coincidence of count. The CI test missed it because it asserted label visibility *after* clicking an hour (already on the minute face).

## Fix

- **Scope to the minute face:** gate the selector behind `.clock-face__container:has(.clock-face__number--outer:nth-child(13))`. The minute container has a 13th `--outer` cell; the hours container never does (its 13th child in 24h mode is `.clock-face__inner`, a different class), so the rule can no longer match the hours dial. Verified against the compiled v13.1.1 template; minute behavior is byte-identical; every minute stays selectable (`visibility:hidden` keeps click targets).
- **Harden the test:** assert all 12 hour labels are visible while the hours dial is open (before clicking) — the gap that let #1625 pass CI — keeping the existing minute-dial assertions.

Kept in the `ViewEncapsulation.None` component SCSS (not a global stylesheet): the plugin repo owns no global stylesheet — globals live in the host repo, which `devinstall.sh` doesn't ship.

`:has()` is supported in all current evergreen browsers (incl. Firefox ESR 128+) — fine for this internal admin app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)