### PR TITLE
feat(assigned-site): one-way Use 1-minute intervals

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningSettingService/TimeSettingService.cs
@@ -962,7 +962,7 @@ public class TimeSettingService(
         dbAssignedSite.AllowPersonalTimeRegistration = site.AllowPersonalTimeRegistration;
         dbAssignedSite.AllowAcceptOfPlannedHours = site.AllowAcceptOfPlannedHours;
         dbAssignedSite.Resigned = site.Resigned;
-        dbAssignedSite.UseOneMinuteIntervals = site.UseOneMinuteIntervals;
+        dbAssignedSite.UseOneMinuteIntervals = dbAssignedSite.UseOneMinuteIntervals || site.UseOneMinuteIntervals;
         dbAssignedSite.UsePunchClock = site.UsePunchClock;
         dbAssignedSite.UseDetailedPauseEditing = site.UseDetailedPauseEditing;
         dbAssignedSite.AutoBreakCalculationActive = site.AutoBreakCalculationActive;

--- a/eform-client/playwright/e2e/plugins/time-planning-pn/b/dashboard-edit-multishift.spec.ts
+++ b/eform-client/playwright/e2e/plugins/time-planning-pn/b/dashboard-edit-multishift.spec.ts
@@ -293,14 +293,30 @@ test.describe('Dashboard — multi-shift (3-5) round-trip regression guard', () 
    * Regression guard for the "Use 1-minute intervals" first-user toggle in
    * the Advanced settings section. The flag rides on AssignedSite end-to-end
    * (entity → DTO → write mapping → angular model) and is persisted by
-   * TimeSettingService.UpdateAssignedSite. This test only verifies the UI
-   * plumbing — the toggle is dormant (no business-logic consumers yet).
+   * TimeSettingService.UpdateAssignedSite.
+   *
+   * The toggle is now ONE-WAY:
+   *   - `assigned-site-dialog.component.ts` initializes the FormControl as
+   *     `{ value, disabled: value === true }` — once the loaded value is
+   *     true, the control is born disabled and can never be unchecked via
+   *     the UI again.
+   *   - `TimeSettingService.UpdateAssignedSite` ORs the incoming flag with
+   *     the stored one (`dbAssignedSite.UseOneMinuteIntervals =
+   *     dbAssignedSite.UseOneMinuteIntervals || site.UseOneMinuteIntervals`),
+   *     so the backend can't flip it back to false either.
+   *   - The checkbox carries an always-visible description line
+   *     ('Once enabled, 1-minute intervals cannot be turned off') warning
+   *     about this.
+   *
+   * This test locks that one-way contract for both the CI-fresh-seed case
+   * (checkbox starts unchecked+enabled) and the rerun case (a prior run, or
+   * seed data, already flipped it on — checkbox starts checked+disabled).
    *
    * Gating: !data.resigned && (selectCurrentUserIsFirstUser$ | async).
    * The CI seed logs in as admin@admin.com (LoginConstants.username), which
    * is the first-user, so the toggle is visible in this test context.
    */
-  test('first-user can toggle Use 1-minute intervals; persists across save+reopen', async ({ page }) => {
+  test('Use 1-minute intervals is one-way: ticking persists and locks the control', async ({ page }) => {
     await page.locator('mat-nested-tree-node').filter({ hasText: 'Timeregistrering' }).click();
     const indexPromise = page.waitForResponse(r =>
       r.url().includes('/api/time-planning-pn/plannings/index') && r.request().method() === 'POST');
@@ -328,14 +344,20 @@ test.describe('Dashboard — multi-shift (3-5) round-trip regression guard', () 
     const cb = page.locator('#useOneMinuteIntervals input[type="checkbox"]');
     await expect(cb).toBeAttached({ timeout: 30000 });
 
-    // Capture the starting state, flip it, save, re-open, assert it persisted.
-    const wasChecked = await cb.isChecked();
-    await page.locator('#useOneMinuteIntervals').click({ force: true });
-    if (wasChecked) {
-      await expect(cb).not.toBeChecked();
-    } else {
-      await expect(cb).toBeChecked();
+    if (await cb.isChecked()) {
+      // Rerun path: the flag was already flipped on (by a previous run of
+      // this test, or by seed data). The control must be locked — never
+      // force-click a disabled control, that would mask the very bug this
+      // test guards against.
+      await expect(cb).toBeDisabled();
+      await page.locator('#cancelButton').click();
+      return;
     }
+
+    // First-run path: checkbox starts unchecked and enabled.
+    await expect(cb).toBeEnabled();
+    await page.locator('#useOneMinuteIntervals').click({ force: true });
+    await expect(cb).toBeChecked();
 
     const assignSitePromise = page.waitForResponse(
       r => r.url().includes('/api/time-planning-pn/settings/assigned-site') && r.request().method() === 'PUT',
@@ -345,10 +367,10 @@ test.describe('Dashboard — multi-shift (3-5) round-trip regression guard', () 
     await waitForSpinner(page);
     await expect(page.locator('mat-dialog-container')).toHaveCount(0, { timeout: 15000 });
 
-    // Re-open and assert the new value round-tripped. Await the
-    // post-save GET so the freshly-persisted toggle is bound before we
-    // assert (prior failure: line 305 `toBeChecked` saw the pre-bind
-    // unchecked state in a 5s window).
+    // Re-open and assert the value round-tripped AND the control is now
+    // locked. Await the post-save GET so the freshly-persisted toggle is
+    // bound before we assert (prior failure mode: asserting inside the
+    // default 5s window can race the post-open data bind).
     const getAssignedSitePromise2 = page.waitForResponse(
       r => r.url().includes('/api/time-planning-pn/settings/assigned-sites')
         && r.url().includes('siteId=')
@@ -360,11 +382,8 @@ test.describe('Dashboard — multi-shift (3-5) round-trip regression guard', () 
 
     const cbReopened = page.locator('#useOneMinuteIntervals input[type="checkbox"]');
     await expect(cbReopened).toBeAttached({ timeout: 30000 });
-    if (wasChecked) {
-      await expect(cbReopened).not.toBeChecked({ timeout: 15000 });
-    } else {
-      await expect(cbReopened).toBeChecked({ timeout: 15000 });
-    }
+    await expect(cbReopened).toBeChecked({ timeout: 15000 });
+    await expect(cbReopened).toBeDisabled({ timeout: 15000 });
 
     await page.locator('#cancelButton').click();
   });

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.html
@@ -232,6 +232,7 @@
           <div>
             <div>{{ 'Use 1-minute intervals' | translate }}</div>
             <small class="checkbox-description">{{ 'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.' | translate }}</small>
+            <small class="checkbox-description">{{ 'Once enabled, 1-minute intervals cannot be turned off' | translate }}</small>
           </div>
         </mat-checkbox>
       </div>

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
@@ -169,7 +169,10 @@ export class AssignedSiteDialogComponent implements DoCheck, OnInit {
     this.assignedSiteForm = this.fb.group({
       useGoogleSheetAsDefault: new FormControl(this.data.useGoogleSheetAsDefault),
       useOnlyPlanHours: new FormControl(this.data.useOnlyPlanHours),
-      useOneMinuteIntervals: new FormControl(this.data.useOneMinuteIntervals ?? false),
+      useOneMinuteIntervals: new FormControl({
+        value: this.data.useOneMinuteIntervals ?? false,
+        disabled: this.data.useOneMinuteIntervals === true
+      }),
       autoBreakCalculationActive: new FormControl(this.data.autoBreakCalculationActive),
       allowPersonalTimeRegistration: new FormControl(this.data.allowPersonalTimeRegistration),
       allowEditOfRegistrations: new FormControl(this.data.allowEditOfRegistrations),

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/bgBG.ts
@@ -399,4 +399,5 @@ export const bgBG = {
   'Use 1-minute intervals': 'Използвайте интервали от 1 минута',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Активирайте гранулиране от 1 минута за въвеждане на време. Стъпките по подразбиране са 5 или 15 минути.',
   Details: 'Детайли',
+  'Once enabled, 1-minute intervals cannot be turned off': 'След като са активирани, интервалите от 1 минута не могат да бъдат изключени',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/csCZ.ts
@@ -399,4 +399,5 @@ export const csCZ = {
   'Use 1-minute intervals': 'Používejte minutové intervaly',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Povolte zadávání času s granularitou po 1 minutě. Výchozí přírůstky jsou 5 nebo 15 minut.',
   Details: 'Podrobnosti',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po zapnutí nelze minutové intervaly vypnout.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/da.ts
@@ -397,4 +397,5 @@ export const da = {
   timer: 'timer',
   'View pay rule set': 'Vis lønregelsæt',
   Close: 'Luk',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Når 1-minutters intervaller er aktiveret, kan de ikke slås fra',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/deDE.ts
@@ -399,4 +399,5 @@ export const deDE = {
   'Advanced settings': 'Erweiterte Einstellungen',
   'Use 1-minute intervals': 'Verwenden Sie 1-Minuten-Intervalle.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktivieren Sie die 1-Minuten-Granularität für die Zeiteingabe. Standardmäßig werden 5 oder 15 Minuten eingestellt.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Sobald die 1-Minuten-Intervalle aktiviert sind, können sie nicht mehr deaktiviert werden.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/elGR.ts
@@ -399,4 +399,5 @@ export const elGR = {
   'Use 1-minute intervals': 'Χρησιμοποιήστε διαστήματα 1 λεπτού',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ενεργοποιήστε την ευαισθησία 1 λεπτού για την εισαγωγή χρόνου. Τα προεπιλεγμένα βήματα είναι 5 ή 15 λεπτά.',
   Details: 'Καθέκαστα',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Μόλις ενεργοποιηθεί, τα διαστήματα 1 λεπτού δεν μπορούν να απενεργοποιηθούν',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/enUS.ts
@@ -319,6 +319,7 @@ export const enUS = {
   'Advanced settings': 'Advanced settings',
   'Use 1-minute intervals': 'Use 1-minute intervals',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Once enabled, 1-minute intervals cannot be turned off',
   'Hide employee from daily operations. Requires a resignation date. All settings below are hidden.': 'Hide employee from daily operations. Requires a resignation date. All settings below are hidden.',
   'Breaks are calculated automatically from the rule set. Manual break entry on shift tabs is disabled.': 'Breaks are calculated automatically from the rule set. Manual break entry on shift tabs is disabled.',
   'Main switch. When active, select registration method and editing policy below.': 'Main switch. When active, select registration method and editing policy below.',

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/esES.ts
@@ -399,4 +399,5 @@ export const esES = {
   'Use 1-minute intervals': 'Utilice intervalos de 1 minuto.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Habilite la granularidad de 1 minuto para el registro de tiempo. Los incrementos predeterminados son de 5 o 15 minutos.',
   Details: 'Detalles',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Una vez activados, los intervalos de 1 minuto no se pueden desactivar.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/etET.ts
@@ -399,4 +399,5 @@ export const etET = {
   'Use 1-minute intervals': 'Kasutage 1-minutilisi intervalle',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Luba aja sisestamisel 1-minutiline täpsus. Vaikimisi sammud on 5 või 15 minutit.',
   Details: 'Detailid',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kui see on lubatud, ei saa 1-minutilisi intervalle välja lülitada.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/fiFI.ts
@@ -399,4 +399,5 @@ export const fiFI = {
   'Use 1-minute intervals': 'Käytä 1 minuutin välein',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ota käyttöön 1 minuutin tarkkuudella ajan syöttö. Oletusarvoinen lisäys on 5 tai 15 minuuttia.',
   Details: 'Tiedot',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kun 1 minuutin välein on otettu käyttöön, niitä ei voi poistaa käytöstä.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/frFR.ts
@@ -399,4 +399,5 @@ export const frFR = {
   'Use 1-minute intervals': 'Utilisez des intervalles d&#39;une minute.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Activez la granularité à la minute pour la saisie de l&#39;heure. Les incréments par défaut sont de 5 ou 15 minutes.',
   Details: 'Détails',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Une fois activées, les intervalles d&#39;une minute ne peuvent pas être désactivés.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/hrHR.ts
@@ -399,4 +399,5 @@ export const hrHR = {
   'Use 1-minute intervals': 'Koristite intervale od 1 minute',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Omogućite granularnost od 1 minute za unos vremena. Zadani koraci su 5 ili 15 minuta.',
   Details: 'Detalji',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Nakon što su omogućeni, intervali od 1 minute ne mogu se isključiti',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/huHU.ts
@@ -399,4 +399,5 @@ export const huHU = {
   'Use 1-minute intervals': 'Használjon 1 perces intervallumokat',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': '1 perces részletesség engedélyezése az időbevitelhez. Az alapértelmezett lépésköz 5 vagy 15 perc.',
   Details: 'Részletek',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Engedélyezés után az 1 perces intervallumok nem kapcsolhatók ki.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/isIS.ts
@@ -399,4 +399,5 @@ export const isIS = {
   'Use 1-minute intervals': 'Notið 1 mínútu millibil',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Virkjaðu 1 mínútu nákvæmni fyrir tímaskráningu. Sjálfgefin þrep eru 5 eða 15 mínútur.',
   Details: 'Nánari upplýsingar',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Þegar 1 mínútu millibili er virkjað er ekki hægt að slökkva á því',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/itIT.ts
@@ -399,4 +399,5 @@ export const itIT = {
   'Use 1-minute intervals': 'Utilizzare intervalli di 1 minuto',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Abilita la granularità di 1 minuto per l&#39;inserimento dell&#39;ora. Gli incrementi predefiniti sono 5 o 15 minuti.',
   Details: 'Dettagli',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Una volta attivati, gli intervalli di 1 minuto non possono essere disattivati.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ltLT.ts
@@ -399,4 +399,5 @@ export const ltLT = {
   'Use 1-minute intervals': 'Naudokite 1 minutės intervalus',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Įgalinti 1 minutės tikslumą laiko įvedimui. Numatytieji žingsniai yra 5 arba 15 minučių.',
   Details: 'Išsami informacija',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Įjungus 1 minutės intervalus, jų išjungti negalima.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/lvLV.ts
@@ -399,4 +399,5 @@ export const lvLV = {
   'Use 1-minute intervals': 'Izmantojiet 1 minūtes intervālus',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Iespējot 1 minūtes granularitāti laika ievadei. Noklusējuma intervāli ir 5 vai 15 minūtes.',
   Details: 'Sīkāka informācija',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kad 1 minūtes intervāli ir iespējoti, tos nevar izslēgt.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/nlNL.ts
@@ -399,4 +399,5 @@ export const nlNL = {
   'Use 1-minute intervals': 'Gebruik intervallen van 1 minuut.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Schakel de mogelijkheid in om tijdsintervallen van 1 minuut in te voeren. De standaardintervallen zijn 5 of 15 minuten.',
   Details: 'Details',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Eenmaal ingeschakeld, kunnen intervallen van 1 minuut niet meer worden uitgeschakeld.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/noNO.ts
@@ -399,4 +399,5 @@ export const noNO = {
   'Use 1-minute intervals': 'Bruk intervaller på 1 minutt',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktiver 1-minutts granularitet for tidsregistrering. Standardintervaller er 5 eller 15 minutter.',
   Details: 'Detaljer',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Når intervaller på 1 minutt er aktivert, kan de ikke slås av',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/plPL.ts
@@ -399,4 +399,5 @@ export const plPL = {
   'Use 1-minute intervals': 'Używaj 1-minutowych interwałów',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Włącz dokładność wprowadzania czasu co 1 minutę. Domyślne wartości to 5 lub 15 minut.',
   Details: 'Bliższe dane',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po włączeniu nie można wyłączyć interwałów 1-minutowych',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ptBR.ts
@@ -399,4 +399,5 @@ export const ptBR = {
   'Use 1-minute intervals': 'Use intervalos de 1 minuto.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ative a granularidade de 1 minuto para a entrada de tempo. Os incrementos padrão são de 5 ou 15 minutos.',
   Details: 'Detalhes',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Uma vez ativado, o intervalo de 1 minuto não pode ser desativado.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ptPT.ts
@@ -399,4 +399,5 @@ export const ptPT = {
   'Use 1-minute intervals': 'Use intervalos de 1 minuto.',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ative a granularidade de 1 minuto para a entrada de tempo. Os incrementos padrão são de 5 ou 15 minutos.',
   Details: 'Detalhes',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Uma vez ativado, o intervalo de 1 minuto não pode ser desativado.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/roRO.ts
@@ -399,4 +399,5 @@ export const roRO = {
   'Use 1-minute intervals': 'Folosește intervale de 1 minut',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Activați granularitatea de 1 minut pentru introducerea timpului. Incrementele implicite sunt de 5 sau 15 minute.',
   Details: 'Detalii',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Odată activate, intervalele de 1 minut nu pot fi dezactivate',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/skSK.ts
@@ -399,4 +399,5 @@ export const skSK = {
   'Use 1-minute intervals': 'Používajte 1-minútové intervaly',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Povoľte 1-minútovú granularitu pre zadávanie času. Predvolené prírastky sú 5 alebo 15 minút.',
   Details: 'Detaily',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po zapnutí nie je možné minútové intervaly vypnúť.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/slSL.ts
@@ -399,4 +399,5 @@ export const slSL = {
   'Use 1-minute intervals': 'Uporabite 1-minutne intervale',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Omogočite 1-minutno natančnost za vnos časa. Privzeti koraki so 5 ali 15 minut.',
   Details: 'Podrobnosti',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Ko so omogočeni, 1-minutnih intervalov ni mogoče izklopiti.',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/svSE.ts
@@ -399,4 +399,5 @@ export const svSE = {
   'Use 1-minute intervals': 'Använd 1-minutsintervaller',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktivera 1-minuts granularitet för tidsinmatning. Standardintervallen är 5 eller 15 minuter.',
   Details: 'Detaljer',
+  'Once enabled, 1-minute intervals cannot be turned off': 'När 1-minutsintervaller är aktiverade kan de inte stängas av',
 };

--- a/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/i18n/ukUA.ts
@@ -399,4 +399,5 @@ export const ukUA = {
   'Use 1-minute intervals': 'Використовуйте інтервали в 1 хвилину',
   'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Увімкнути точність введення часу з кроком 1 хвилина. Крок за замовчуванням становить 5 або 15 хвилин.',
   Details: 'Деталі',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Після ввімкнення інтервали в 1 хвилину не можна вимкнути',
 };


### PR DESCRIPTION
## Summary
- `UpdateAssignedSite` now ORs `UseOneMinuteIntervals` with the stored value — once enabled, the API can never switch it off (one-way street).
- The assigned-site dialog initializes the checkbox **disabled** when the stored value is already true and adds an always-visible warning line ('Once enabled, 1-minute intervals cannot be turned off'; new i18n key in all locales, Danish hand-corrected: 'Når 1-minutters intervaller er aktiveret, kan de ikke slås fra'). A disabled control is omitted from `form.value`, so saves preserve the stored true.
- The `dashboard-edit-multishift` e2e for this checkbox previously asserted a bidirectional toggle; rewritten to lock the one-way behavior (unchecked-start: tick → save → reopen → checked **and disabled**; checked-start: assert disabled) so it passes deterministically on both fresh CI seeds and reruns.

Companion PR in eform-backendconfiguration-plugin adds the same setting (plus a pay-rule-set selector) to the property-workers modal and stops hardcoding `UseOneMinuteIntervals = true` for newly created workers.

## Test plan
- Verified live in dev: dialog checkbox disabled-when-true with warning line; API PUT with `useOneMinuteIntervals:false` on an already-true site (siteId 15570) leaves it true; pay rule set untouched by the change.
- Whole-solution backend build 0 errors; ng serve green; existing specs select by ids that are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)