### PR TITLE
fix(timezone): store wall time at every write path + id-fallback projections (one-minute sites)

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -244,15 +244,15 @@ jobs:
       matrix:
         shard:
           - name: a
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.AbsenceRequestServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.CanaryInAColeMine"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.AbsenceRequestServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.CanaryInAColeMine|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeNormalizerTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeShiftFormattingTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimePayBandTests"
           - name: b
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PictureSnapshotServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.ContentHandoverServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DanLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.DataLonFileExporterTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PictureSnapshotServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.ContentHandoverServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DanLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.DataLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.WallTimeGrpcWritePathTests"
           - name: c
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
           - name: d
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeWorkingHoursWritePathTests"
           - name: e
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeProjectionIdFallbackTests"
           - name: f
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -233,15 +233,15 @@ jobs:
       matrix:
         shard:
           - name: a
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.AbsenceRequestServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.CanaryInAColeMine"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.AbsenceRequestServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.BreakPolicyServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.CanaryInAColeMine|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeNormalizerTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeShiftFormattingTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimePayBandTests"
           - name: b
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PictureSnapshotServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.ContentHandoverServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DanLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.DataLonFileExporterTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PictureSnapshotServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.ContentHandoverServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DanLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.DataLonFileExporterTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.WallTimeGrpcWritePathTests"
           - name: c
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.ScheduleMessageReadTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
           - name: d
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeWorkingHoursWritePathTests"
           - name: e
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests|FullyQualifiedName=TimePlanning.Pn.Test.WallTimeProjectionIdFallbackTests"
           - name: f
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g

--- a/docs/adr/0001-plan-registration-timestamps-wall-time.md
+++ b/docs/adr/0001-plan-registration-timestamps-wall-time.md
@@ -1,0 +1,85 @@
+# ADR 0001: PlanRegistration exact timestamps store user-local wall time
+
+Date: 2026-07-07
+Status: Accepted
+
+## Context
+
+The `PlanRegistration` exact-time columns (`Start{1..5}StartedAt`,
+`Stop{1..5}StoppedAt`, `Pause*StartedAt/StoppedAt`) were introduced for
+second-precision time tracking on `AssignedSite.UseOneMinuteIntervals=true`
+sites, alongside the legacy 5-minute interval ids (`Start1Id=79` ↔ 06:30).
+No storage-timezone convention was ever written down, and a July 2026
+production incident (a worker's 06:30 shift displayed as 04:30) forced the
+question: do these columns hold UTC or local wall time?
+
+A read-only classifier was run across all production tenants, comparing each
+row's exact stamps against its own interval ids (which have always encoded
+Danish wall time). Result:
+
+- Customer rows are ~100% LOCAL WALL-TIME digits (2746 observations).
+- True-UTC rows exist only in a small recent cluster; a version audit on
+  tenant 986 found 390 local-wall rows vs 10 UTC rows, and zero UTC rows on
+  tenants 1116/1124/1079.
+- All UTC rows date from July 4–7 2026 and were written by ONE writer: the
+  mobile app's edit screen ("register workday", used on
+  `UseOneMinuteIntervals=1` + `UsePunchClock=0` sites), whose
+  `.toUtc().toIso8601String()` path started shipping Z-suffixed strings in
+  the June 25 Android release. The server's gRPC `ParseDateTime`
+  (`AdjustToUniversal`) honored the Z and let UTC digits through to storage.
+- Every other writer produces wall digits: the punch-clock flows stamp local
+  wall time, the kiosk flow sends naive local digits, flag-off sites are
+  id-driven, and `TimePlanningPlanningService.EnsureTimestampsFromIds`
+  backfills the columns from interval ids — wall time by construction.
+
+So the de-facto (and now codified) convention of historical data is wall
+time; the UTC rows are a three-day-old regression from a single client path.
+
+## Decision
+
+**The PlanRegistration exact-time columns store USER-LOCAL WALL TIME with
+`DateTimeKind.Unspecified` — the digits the worker saw on the clock —
+consistent with the interval ids and `EnsureTimestampsFromIds`.**
+
+Enforcement (server-side, `WallTimeNormalizer` in
+`TimePlanning.Pn/Infrastructure/Helpers/WallTimeNormalizer.cs`):
+
+- Incoming timestamp strings are parsed with `DateTimeStyles.RoundtripKind`.
+- Naive digits are stored verbatim (already wall time).
+- Z-suffixed or offset-carrying input is converted through its UTC instant
+  into the current user's timezone
+  (`IUserService.GetCurrentUserTimeZoneInfo()`, IANA id, default
+  `Europe/Copenhagen`) and stored as `Kind=Unspecified` wall digits.
+- Applied at every timestamp-string write seam:
+  `TimePlanningPlanningsGrpcService.ParseDateTime` (the RPC the app edit
+  screen calls: `UpdatePlanningByCurrentUser`, plus `UpdatePlanning` for
+  symmetry) and both `TimePlanningWorkingHoursService.UpdateWorkingHour`
+  overloads (create + update branches). The kiosk overload authenticates via
+  a device token — no per-user zone exists, so it uses the documented default
+  `Europe/Copenhagen`.
+- The normalization stays in place even after the app-side cleanup ships, so
+  no client can corrupt storage again.
+- **No conversion on any read path.** Stored digits are the display truth.
+- Flag-true read projections (`PlanRegistrationHelper.ReadBySiteAndDate`,
+  `UpdatePlanRegistrationsInPeriod`) fall back to the id-derived wall time
+  (`midnight + (id-1)*5 min`, ids > 0) when a stamp is null, so a
+  false→true `UseOneMinuteIntervals` flip never blanks recorded times.
+
+## Consequences
+
+- Pay-band attribution, the Grundlovsdag after-noon rule, Excel exports and
+  all `HH:mm` formatting are correct by construction — they already operate
+  on wall digits.
+- Supporting users in timezones other than the site's wall-clock zone (true
+  per-user timezone rendering) would require a storage migration and is a
+  SEPARATE future project; this ADR intentionally does not attempt it.
+- DST: converting FROM an instant is deterministic — during the fall-back
+  overlap (e.g. 2026-10-25 02:00–03:00 in Copenhagen) two distinct instants
+  store the same wall digits; the stored value is ambiguous only in reverse.
+  This limitation is shared with the 5-minute interval ids and accepted.
+- The ~10 corrupted UTC rows on affected tenants (July 4–7 2026) are a data
+  repair concern outside this ADR.
+- Contract locked by tests: `WallTimeNormalizerTests`,
+  `WallTimeGrpcWritePathTests`, `WallTimeWorkingHoursWritePathTests`,
+  `WallTimeProjectionIdFallbackTests`, `WallTimeShiftFormattingTests`,
+  `WallTimePayBandTests`.

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/WallTimeGrpcWritePathTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/WallTimeGrpcWritePathTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Threading.Tasks;
+using Microting.eFormApi.BasePn.Abstractions;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Grpc;
+using TimePlanning.Pn.Infrastructure.Models.Planning;
+using TimePlanning.Pn.Services.GrpcServices;
+using TimePlanning.Pn.Services.TimePlanningPlanningService;
+using TimePlanning.Pn.Test.Helpers;
+using OperationResult = Microting.eFormApi.BasePn.Infrastructure.Models.API.OperationResult;
+
+namespace TimePlanning.Pn.Test.GrpcServices;
+
+/// <summary>
+/// WALL-TIME-AT-REST contract for the gRPC plannings write path
+/// (<c>UpdatePlanningByCurrentUser</c> / <c>UpdatePlanning</c> → MapDayFromGrpc →
+/// ParseDateTime). PlanRegistration exact-time columns store USER-LOCAL WALL
+/// TIME digits: punch-clock flows write local wall digits, flag-off sites are
+/// id-driven, and EnsureTimestampsFromIds backfills wall digits from interval
+/// ids. The ONLY UTC writer is the app edit screen ("register workday"), whose
+/// <c>.toUtc().toIso8601String()</c> Z-path shipped in the June 25 Android
+/// release — this RPC (<c>UpdatePlanningByCurrentUser</c>) is exactly what that
+/// screen calls, so it must normalize Z/offset-carrying stamps into the
+/// current user's zone (IUserService.GetCurrentUserTimeZoneInfo(), default
+/// Europe/Copenhagen) before they reach storage. Naive digits pass through
+/// verbatim.
+/// </summary>
+[TestFixture]
+public class WallTimeGrpcWritePathTests
+{
+    private ITimePlanningPlanningService _planningService = null!;
+    private TimePlanningPlanningsGrpcService _grpcService = null!;
+    private TimePlanningPlanningPrDayModel _captured = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _planningService = Substitute.For<ITimePlanningPlanningService>();
+
+        // The current user's zone — the fix resolves it once per write request
+        // via IUserService.GetCurrentUserTimeZoneInfo() (default when absent:
+        // Europe/Copenhagen, covered by WallTimeNormalizerTests).
+        var userService = Substitute.For<IUserService>();
+        userService.GetCurrentUserTimeZoneInfo()
+            .Returns(TimeZoneInfo.FindSystemTimeZoneById("Europe/Copenhagen"));
+
+        _grpcService = new TimePlanningPlanningsGrpcService(_planningService, userService);
+        _captured = null!;
+
+        _planningService.UpdateByCurrentUserNam(Arg.Any<TimePlanningPlanningPrDayModel>())
+            .Returns(ci =>
+            {
+                _captured = ci.Arg<TimePlanningPlanningPrDayModel>();
+                return new OperationResult(true, "OK");
+            });
+        _planningService.Update(Arg.Any<int>(), Arg.Any<TimePlanningPlanningPrDayModel>())
+            .Returns(ci =>
+            {
+                _captured = ci.ArgAt<TimePlanningPlanningPrDayModel>(1);
+                return new OperationResult(true, "OK");
+            });
+    }
+
+    private async Task<TimePlanningPlanningPrDayModel> MapViaUpdateByCurrentUser(PlanningPrDayModel proto)
+    {
+        await _grpcService.UpdatePlanningByCurrentUser(
+            new UpdatePlanningByCurrentUserRequest { Model = proto },
+            TestServerCallContextFactory.Create());
+        return _captured;
+    }
+
+    /// <summary>
+    /// The June-25 app edit screen path: Z-suffixed UTC stamps. 2026-07-07 is
+    /// CEST (+02:00), so 04:30Z/14:00Z is the 06:30–16:00 wall-time shift
+    /// (prod oracle row 16703 shape). The mapped model must carry the WALL
+    /// digits — today ParseDateTime's AdjustToUniversal lets the UTC digits
+    /// (04:30/14:00) through to storage.
+    /// </summary>
+    [Test]
+    public async Task UpdateByCurrentUser_ZSuffixedUtcStamps_NormalizeToWallDigits()
+    {
+        var model = await MapViaUpdateByCurrentUser(new PlanningPrDayModel
+        {
+            Id = 1,
+            Start1StartedAt = "2026-07-07T04:30:00Z",
+            Stop1StoppedAt = "2026-07-07T14:00:00Z",
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(model.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+                "Z-suffixed 04:30Z must be normalized to the user's wall time 06:30 " +
+                "(Europe/Copenhagen); letting UTC digits through violates wall-time-at-rest");
+            Assert.That(model.Stop1StoppedAt, Is.EqualTo(new DateTime(2026, 7, 7, 16, 0, 0)),
+                "Z-suffixed 14:00Z must be normalized to wall time 16:00");
+        });
+    }
+
+    /// <summary>
+    /// Explicit +00:00 offset — same instant as the Z form, same rule.
+    /// </summary>
+    [Test]
+    public async Task UpdateByCurrentUser_PlusZeroOffsetStamp_NormalizesToWallDigits()
+    {
+        var model = await MapViaUpdateByCurrentUser(new PlanningPrDayModel
+        {
+            Id = 1,
+            Start1StartedAt = "2026-07-07T04:30:00+00:00",
+        });
+
+        Assert.That(model.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+            "A +00:00 offset stamp is the same instant as 04:30Z and must land as wall 06:30");
+    }
+
+    /// <summary>
+    /// Non-UTC offset: 10:00+05:30 is the instant 04:30Z — must convert into
+    /// the USER's zone (06:30 Copenhagen wall), not be kept at the sender's
+    /// digits and not be adjusted to UTC.
+    /// </summary>
+    [Test]
+    public async Task UpdateByCurrentUser_NonUtcOffsetStamp_ConvertsIntoUserZone()
+    {
+        var model = await MapViaUpdateByCurrentUser(new PlanningPrDayModel
+        {
+            Id = 1,
+            Start1StartedAt = "2026-07-07T10:00:00+05:30",
+        });
+
+        Assert.That(model.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+            "10:00+05:30 == 04:30Z == 06:30 Europe/Copenhagen wall time");
+    }
+
+    /// <summary>
+    /// Admin path shares MapDayFromGrpc — same normalization rule.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanning_AdminPath_ZSuffixedUtcStamp_NormalizesToWallDigits()
+    {
+        await _grpcService.UpdatePlanning(new UpdatePlanningRequest
+        {
+            PlanningId = 5,
+            Model = new PlanningPrDayModel
+            {
+                Id = 5,
+                Start1StartedAt = "2026-07-07T04:30:00Z",
+            }
+        }, TestServerCallContextFactory.Create());
+
+        Assert.That(_captured.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+            "Admin gRPC update must apply the same UTC→wall normalization");
+    }
+
+    /// <summary>
+    /// REGRESSION LOCK (green today): naive wall digits — the shape all
+    /// punch-clock flows and pre-June-25 app builds send — pass through
+    /// verbatim, byte-identical.
+    /// </summary>
+    [Test]
+    public async Task UpdateByCurrentUser_NaiveWallDigits_PassThroughVerbatim()
+    {
+        var model = await MapViaUpdateByCurrentUser(new PlanningPrDayModel
+        {
+            Id = 1,
+            Start1StartedAt = "2026-07-07T06:30:00",
+            Stop1StoppedAt = "2026-07-07T16:00:00",
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(model.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+                "Naive wall digits are already the storage convention — must not be shifted");
+            Assert.That(model.Stop1StoppedAt, Is.EqualTo(new DateTime(2026, 7, 7, 16, 0, 0)));
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeNormalizerTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeNormalizerTests.cs
@@ -1,0 +1,152 @@
+using System;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Unit contract for <see cref="WallTimeNormalizer"/>, the single seam that
+/// enforces wall-time-at-rest on every timestamp-string write path:
+/// naive digits verbatim; Z / offset-carrying input converted through the UTC
+/// instant into the user's zone; result always Kind=Unspecified so the digits
+/// round-trip to MySQL untouched.
+/// </summary>
+[TestFixture]
+public class WallTimeNormalizerTests
+{
+    private static readonly TimeZoneInfo Cph =
+        TimeZoneInfo.FindSystemTimeZoneById("Europe/Copenhagen");
+
+    [Test]
+    public void NaiveDigits_ReturnedVerbatim_KindUnspecified()
+    {
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07T06:30:00", Cph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    public void ZSuffix_Summer_ConvertsToCestWall()
+    {
+        // 2026-07-07 is CEST (+02:00): 04:30Z == 06:30 wall.
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07T04:30:00Z", Cph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    public void ZSuffix_Winter_ConvertsToCetWall()
+    {
+        // 2026-01-07 is CET (+01:00): 05:30Z == 06:30 wall.
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-01-07T05:30:00Z", Cph);
+
+        Assert.That(result, Is.EqualTo(new DateTime(2026, 1, 7, 6, 30, 0)));
+    }
+
+    [Test]
+    public void PlusZeroOffset_TreatedAsUtc()
+    {
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07T04:30:00+00:00", Cph);
+
+        Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+    }
+
+    [Test]
+    public void NonUtcOffset_ConvertsThroughInstantIntoUserZone()
+    {
+        // 10:00+05:30 == 04:30Z == 06:30 Copenhagen wall.
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07T10:00:00+05:30", Cph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    /// <summary>
+    /// The punch-clock flows persist Dart's <c>DateTime.toString()</c> output:
+    /// space-separated, microsecond precision, no offset designator. This is
+    /// the majority production shape — it must round-trip byte-verbatim
+    /// (naive → wall time as-is, sub-second digits included, Kind=Unspecified).
+    /// </summary>
+    [Test]
+    public void DartToStringFormat_SpaceSeparatedMicroseconds_RoundTripsVerbatim()
+    {
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07 06:30:00.123456", Cph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0).AddTicks(1234560)),
+                "Dart DateTime.toString() digits (incl. .123456 = 1_234_560 ticks) must be preserved exactly");
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    public void NullTimeZone_FallsBackToCopenhagen()
+    {
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-07-07T04:30:00Z", null);
+
+        Assert.That(result, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+            "Null zone must use the documented default (Europe/Copenhagen)");
+    }
+
+    [Test]
+    public void EmptyOrNull_ReturnsNull_ViaOrNullOverload()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(WallTimeNormalizer.NormalizeToWallTimeOrNull(null, Cph), Is.Null);
+            Assert.That(WallTimeNormalizer.NormalizeToWallTimeOrNull("", Cph), Is.Null);
+            Assert.That(WallTimeNormalizer.NormalizeToWallTimeOrNull("2026-07-07T04:30:00Z", Cph),
+                Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        });
+    }
+
+    /// <summary>
+    /// DST fall-back boundary: Copenhagen leaves CEST on 2026-10-25 at 03:00
+    /// (clocks go back to 02:00), so wall times 02:00–03:00 occur twice.
+    /// Converting FROM an instant is deterministic — TimeZoneInfo maps
+    /// 00:30Z (still CEST, +2) and 01:30Z (already CET, +1) each to wall
+    /// 02:30. The two distinct instants therefore store the same digits;
+    /// the ambiguity exists only in reverse, a limitation shared with the
+    /// 5-minute interval ids (documented in the ADR).
+    /// </summary>
+    [Test]
+    public void DstFallBackOverlap_BothInstants_MapToSameWallDigits_Deterministically()
+    {
+        var beforeSwitch = WallTimeNormalizer.NormalizeToWallTime("2026-10-25T00:30:00Z", Cph);
+        var afterSwitch = WallTimeNormalizer.NormalizeToWallTime("2026-10-25T01:30:00Z", Cph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeSwitch, Is.EqualTo(new DateTime(2026, 10, 25, 2, 30, 0)),
+                "00:30Z is 02:30 CEST — first occurrence of the overlapped wall time");
+            Assert.That(afterSwitch, Is.EqualTo(new DateTime(2026, 10, 25, 2, 30, 0)),
+                "01:30Z is 02:30 CET — second occurrence; same wall digits, deterministic");
+        });
+    }
+
+    /// <summary>
+    /// DST spring-forward: 2026-03-29 02:00 CET jumps to 03:00 CEST; the wall
+    /// hour 02:00–03:00 does not exist. An instant can never land in the gap:
+    /// 01:30Z converts to 03:30 CEST.
+    /// </summary>
+    [Test]
+    public void DstSpringForward_InstantConvertsPastTheGap()
+    {
+        var result = WallTimeNormalizer.NormalizeToWallTime("2026-03-29T01:30:00Z", Cph);
+
+        Assert.That(result, Is.EqualTo(new DateTime(2026, 3, 29, 3, 30, 0)),
+            "01:30Z is after the 02:00→03:00 jump, i.e. 03:30 CEST");
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimePayBandTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimePayBandTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.Index;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// WALL-TIME-AT-REST regression lock (green) for pay attribution. Time-band
+/// pay rules (evening supplement) and the Grundlovsdag after-noon rule are
+/// defined in local wall time — and because PlanRegistration stamps STORE
+/// wall time, feeding the stored digits straight into seconds-of-day math is
+/// CORRECT by design. These tests document that invariant: had the columns
+/// held UTC, every band boundary would shift by the offset (the rejected
+/// alternative design).
+/// </summary>
+[TestFixture]
+public class WallTimePayBandTests
+{
+    private static TimePlanningWorkingHoursService BuildService()
+    {
+        return new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            dbContext: null!,
+            Substitute.For<IUserService>(),
+            Substitute.For<ITimePlanningLocalizationService>(),
+            baseDbContext: null!,
+            Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>(),
+            Substitute.For<IEFormCoreService>());
+    }
+
+    /// <summary>
+    /// Evening shift stored as wall digits 18:30 → 00:00 (next day). The
+    /// seconds-of-day pair is (66600, 86400): stop crosses midnight and clamps
+    /// to end-of-day per the documented per-day scoping.
+    /// </summary>
+    [Test]
+    public void ResolveShiftSeconds_WallDigits_MapDirectlyToSecondsOfDay()
+    {
+        var seg = TimePlanningWorkingHoursService.ResolveShiftSeconds(
+            new DateTime(2026, 6, 15, 18, 30, 0),  // wall time
+            new DateTime(2026, 6, 16, 0, 0, 0));   // wall time, crosses midnight
+
+        Assert.That(seg, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(seg!.Value.Start, Is.EqualTo(66600),
+                "18:30 wall = 66600 s — stored digits are already local, no conversion");
+            Assert.That(seg.Value.Stop, Is.EqualTo(86400),
+                "Midnight stop clamps to end of day");
+        });
+    }
+
+    /// <summary>
+    /// The full evening-band attribution: an 18:30–00:00 wall-time shift lies
+    /// entirely inside an 18:00–24:00 evening band, so all 19800 s go to
+    /// EVENING and nothing leaks into the default day code. 2026-06-15 is a
+    /// Monday (DayType.Monday).
+    /// </summary>
+    [Test]
+    public void CalculatePayLinesForDay_EveningBand_WallDigitsAttributeCorrectly()
+    {
+        var payRuleSet = new PayRuleSet
+        {
+            Name = "EveningBand",
+            DayRules = new List<PayDayRule>(),
+            DayTypeRules = new List<PayDayTypeRule>
+            {
+                new PayDayTypeRule
+                {
+                    DayType = DayType.Monday,
+                    DefaultPayCode = "DAY",
+                    Priority = 1,
+                    TimeBandRules = new List<PayTimeBandRule>
+                    {
+                        new PayTimeBandRule
+                        {
+                            StartSecondOfDay = 64800, // 18:00
+                            EndSecondOfDay = 86400,   // 24:00
+                            PayCode = "EVENING",
+                            PayrollCode = "200",
+                            Priority = 1
+                        }
+                    }
+                }
+            }
+        };
+
+        var model = new TimePlanningWorkingHoursModel
+        {
+            Date = new DateTime(2026, 6, 15),
+            Start1StartedAt = new DateTime(2026, 6, 15, 18, 30, 0), // wall time
+            Stop1StoppedAt = new DateTime(2026, 6, 16, 0, 0, 0),    // wall time
+        };
+
+        var lines = TimePlanningWorkingHoursService.CalculatePayLinesForDay(
+            planRegistrationId: 1, date: model.Date, dayModel: model,
+            totalSeconds: 19800, payRuleSet: payRuleSet);
+
+        var evening = lines.SingleOrDefault(l => l.PayCode == "EVENING");
+        Assert.That(evening, Is.Not.Null, "Shift must produce an EVENING pay line");
+        Assert.That(evening!.HoursInSeconds, Is.EqualTo(19800),
+            "All 5.5 h of the 18:30–00:00 wall shift fall in the 18:00+ band; " +
+            "correct precisely because stored digits are wall time");
+        Assert.That(lines.Any(l => l.PayCode == "DAY"), Is.False,
+            "Nothing may leak into the default day code");
+    }
+
+    /// <summary>
+    /// Grundlovsdag (June 5): only hours after 12:00 noon count. A shift
+    /// stored as wall digits 12:30–14:00 is entirely after noon → 1.5 h.
+    /// CalculateHoursAfterNoon compares the stored digits against a naive
+    /// 12:00 on the same date — correct under wall-time-at-rest.
+    /// (Private helper — driven via reflection like the export would.)
+    /// </summary>
+    [Test]
+    public void CalculateHoursAfterNoon_Grundlovsdag_WallDigits_CountAfterLocalNoon()
+    {
+        var day = new TimePlanningWorkingHoursModel
+        {
+            Date = new DateTime(2026, 6, 5),
+            Start1StartedAt = new DateTime(2026, 6, 5, 12, 30, 0), // wall time
+            Stop1StoppedAt = new DateTime(2026, 6, 5, 14, 0, 0),   // wall time
+        };
+
+        var method = typeof(TimePlanningWorkingHoursService).GetMethod(
+            "CalculateHoursAfterNoon", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.That(method, Is.Not.Null);
+
+        var hoursAfterNoon = (double)method!.Invoke(BuildService(), new object[] { day })!;
+
+        Assert.That(hoursAfterNoon, Is.EqualTo(1.5).Within(1e-9),
+            "12:30–14:00 wall time is entirely after the wall-clock noon → 1.5 h");
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeProjectionIdFallbackTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeProjectionIdFallbackTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+using TimePlanning.Pn.Infrastructure.Models.Planning;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Services.TimePlanningPlanningService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using PlanRegistrationEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// WALL-TIME-AT-REST projection contract for <c>UseOneMinuteIntervals=true</c>
+/// sites, covering the flag-flip gap: rows written while the flag was FALSE
+/// have interval ids (Start1Id=79 ↔ 06:30) but NULL exact-time stamps. The
+/// flag-true projection branch currently forwards the stamp verbatim — i.e.
+/// null — so the day silently loses its times in the app/web after a
+/// false→true flip. Required: fall back to the id-derived wall time
+/// (midnight + (id-1)*5 min), exactly what the flag-false branch and
+/// EnsureTimestampsFromIds already compute. Both timestamps and ids are wall
+/// time, so no timezone math is involved.
+///
+/// Also locks (green today): stored wall digits are served VERBATIM by both
+/// projections — no conversion on the read path, ever.
+/// </summary>
+[TestFixture]
+public class WallTimeProjectionIdFallbackTests : TestBaseSetup
+{
+    private static readonly DateTime Date = new DateTime(2026, 7, 7, 0, 0, 0);
+    private static readonly DateTime WallStart = new DateTime(2026, 7, 7, 6, 30, 0);  // id 79
+    private static readonly DateTime WallStop = new DateTime(2026, 7, 7, 16, 0, 0);   // id 193
+
+    private async Task<AssignedSiteEntity> SeedFlagOnSite(int sdkSiteId, DateTime? start1, DateTime? stop1)
+    {
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = sdkSiteId,
+            UseOneMinuteIntervals = true,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = sdkSiteId,
+            Date = Date,
+            Start1Id = 79,   // ↔ 06:30 wall time
+            Stop1Id = 193,   // ↔ 16:00 wall time
+            Pause1Id = 0,
+            Start1StartedAt = start1,
+            Stop1StoppedAt = stop1,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        }.Create(TimePlanningPnDbContext);
+
+        return assignedSite;
+    }
+
+    private async Task<TimePlanningPlanningPrDayModel> ProjectViaUpdatePlanRegistrationsInPeriod(
+        int sdkSiteId, AssignedSiteEntity assignedSite)
+    {
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
+        var planningsInPeriod = await TimePlanningPnDbContext.PlanRegistrations
+            .AsNoTracking()
+            .Where(x => x.SdkSitId == sdkSiteId)
+            .Select(x => new PlanRegistrationEntity { Id = x.Id, Date = x.Date })
+            .ToListAsync();
+
+        var siteModel = new TimePlanningPlanningModel
+        {
+            SiteId = sdkSiteId,
+            SiteName = $"Test site {sdkSiteId}",
+            UseOneMinuteIntervals = true,
+            PlanningPrDayModels = new List<TimePlanningPlanningPrDayModel>()
+        };
+
+        var result = await PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(
+            planningsInPeriod,
+            siteModel,
+            TimePlanningPnDbContext,
+            assignedSite,
+            Substitute.For<ILogger<TimePlanningPlanningService>>(),
+            new SdkSite { Name = $"Test site {sdkSiteId}", MicrotingUid = sdkSiteId },
+            Date.AddDays(-1),
+            Date.AddDays(1),
+            options);
+
+        return result.PlanningPrDayModels.Single(x => x.Date.Date == Date.Date);
+    }
+
+    // ------------------------------------------------------------------
+    // Null-stamp fallback (RED pre-fix: projections serve null)
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_FlagOn_NullStamps_FallBackToIdDerivedWallTime()
+    {
+        var assignedSite = await SeedFlagOnSite(9824, start1: null, stop1: null);
+
+        var prDay = await ProjectViaUpdatePlanRegistrationsInPeriod(9824, assignedSite);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.EqualTo(WallStart),
+                "Flag-true projection must fall back to the id-derived wall time " +
+                "(Start1Id=79 → 06:30) when the exact stamp is null, so a false→true " +
+                "flag flip is lossless; it currently forwards null");
+            Assert.That(prDay.Stop1StoppedAt, Is.EqualTo(WallStop),
+                "Stop1Id=193 → 16:00 fallback expected; currently null");
+        });
+    }
+
+    [Test]
+    public async Task ReadBySiteAndDate_FlagOn_NullStamps_FallBackToIdDerivedWallTime()
+    {
+        await SeedFlagOnSite(9825, start1: null, stop1: null);
+
+        var result = await PlanRegistrationHelper.ReadBySiteAndDate(
+            TimePlanningPnDbContext, 9825, Date, null);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Start1StartedAt, Is.EqualTo(WallStart),
+                "ReadBySiteAndDate must fall back to id-derived wall time (79 → 06:30) " +
+                "for a flag-true site when the stamp is null; it currently forwards null");
+            Assert.That(result.Stop1StoppedAt, Is.EqualTo(WallStop),
+                "Stop1Id=193 → 16:00 fallback expected; currently null");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Verbatim wall digits (GREEN today — locks no-read-conversion)
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_FlagOn_StoredWallDigits_ServedVerbatim()
+    {
+        var assignedSite = await SeedFlagOnSite(9826, WallStart, WallStop);
+
+        var prDay = await ProjectViaUpdatePlanRegistrationsInPeriod(9826, assignedSite);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.EqualTo(WallStart),
+                "Stored wall digits are the display truth — served verbatim, no conversion");
+            Assert.That(prDay.Stop1StoppedAt, Is.EqualTo(WallStop));
+        });
+    }
+
+    [Test]
+    public async Task ReadBySiteAndDate_FlagOn_StoredWallDigits_ServedVerbatim()
+    {
+        await SeedFlagOnSite(9827, WallStart, WallStop);
+
+        var result = await PlanRegistrationHelper.ReadBySiteAndDate(
+            TimePlanningPnDbContext, 9827, Date, null);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Start1StartedAt, Is.EqualTo(WallStart),
+                "Stored wall digits are served verbatim — no conversion on the read path");
+            Assert.That(result.Stop1StoppedAt, Is.EqualTo(WallStop));
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeShiftFormattingTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeShiftFormattingTests.cs
@@ -1,0 +1,97 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// WALL-TIME-AT-REST regression lock (green) for the read-side formatters.
+/// PlanRegistration exact-time columns store user-local WALL digits, so
+/// <c>GetShiftTime</c>/<c>GetShiftTimeFraction</c> must format the stored
+/// digits VERBATIM — no timezone conversion exists on the read path, by
+/// design. Also locks the id↔wall equivalence (Start1Id=79 ↔ 06:30) that the
+/// wall-time convention rests on: the id path and the stamp path must render
+/// the same wall time for the same shift.
+/// </summary>
+[TestFixture]
+public class WallTimeShiftFormattingTests
+{
+    private TimePlanningWorkingHoursService _service = null!;
+
+    [SetUp]
+    public void SetUpTest()
+    {
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+
+        // Pure formatting helpers — no database access, contexts stay null
+        // (same fixture shape as DagsoversigtWorksheetExportTests' helper test).
+        _service = new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            dbContext: null!,
+            userService,
+            Substitute.For<ITimePlanningLocalizationService>(),
+            baseDbContext: null!,
+            Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>(),
+            Substitute.For<IEFormCoreService>());
+    }
+
+    [Test]
+    public void GetShiftTime_OneMinuteFlag_WallDigits_FormattedVerbatim()
+    {
+        // Stored stamp is wall time (prod oracle: Start1Id=79 ↔ 06:30 wall).
+        var wallStamp = new DateTime(2026, 7, 7, 6, 30, 0);
+
+        var formatted = _service.GetShiftTime(new PlanRegistration(), 79, wallStamp,
+            useOneMinuteIntervals: true);
+
+        Assert.That(formatted, Is.EqualTo("06:30"),
+            "Stored wall digits must be rendered verbatim — no conversion on read");
+    }
+
+    [Test]
+    public void GetShiftTime_IdPathAndStampPath_AgreeOnWallTime()
+    {
+        var plr = new PlanRegistration();
+        var wallStamp = new DateTime(2026, 7, 7, 6, 30, 0);
+
+        var fromId = _service.GetShiftTime(plr, 79);
+        var fromStamp = _service.GetShiftTime(plr, 79, wallStamp, useOneMinuteIntervals: true);
+
+        Assert.That(fromStamp, Is.EqualTo(fromId),
+            "Interval id 79 and its wall stamp 06:30 must render identically — " +
+            "the invariant that makes wall-time-at-rest coherent");
+        Assert.That(fromId, Is.EqualTo("06:30"));
+    }
+
+    [Test]
+    public void GetShiftTimeFraction_OneMinuteFlag_WallDigits_UsedVerbatim()
+    {
+        var wallStamp = new DateTime(2026, 7, 7, 6, 30, 0);
+
+        var fraction = _service.GetShiftTimeFraction(79, wallStamp, useOneMinuteIntervals: true);
+
+        Assert.That(fraction, Is.Not.Null);
+        Assert.That(fraction!.Value, Is.EqualTo(390.0 / 1440.0).Within(1e-9),
+            "Day-fraction comes straight from the stored wall digits (06:30 = 390 min)");
+    }
+
+    [Test]
+    public void GetShiftTimeFraction_IdPathAndStampPath_AgreeOnWallTime()
+    {
+        var wallStamp = new DateTime(2026, 7, 7, 6, 30, 0);
+
+        var fromId = _service.GetShiftTimeFraction(79, null, useOneMinuteIntervals: false);
+        var fromStamp = _service.GetShiftTimeFraction(79, wallStamp, useOneMinuteIntervals: true);
+
+        Assert.That(fromStamp!.Value, Is.EqualTo(fromId!.Value).Within(1e-9),
+            "Id-derived and stamp-derived fractions must agree for the same wall time");
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeWorkingHoursWritePathTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WallTimeWorkingHoursWritePathTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.UpdateCreate;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using PlanRegistrationEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration;
+using RegistrationDeviceEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.RegistrationDevice;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// WALL-TIME-AT-REST hardening contract for the WorkingHours kiosk write path
+/// (<c>UpdateWorkingHour(int? sdkSiteId, model, token)</c>), which today uses
+/// plain <c>DateTime.Parse</c> on the incoming stamp strings. A Z-suffixed or
+/// offset-carrying string therefore lands as SERVER-LOCAL digits — the stored
+/// value silently depends on the host's timezone (UTC in CI/prod containers,
+/// CET on dev machines). No current client sends Z here (kiosk sends naive
+/// wall digits), but a future app cleanup or third-party client must not be
+/// able to corrupt storage — so these sites route through the same normalizer
+/// as the gRPC plannings path. The kiosk flow has no authenticated user, so
+/// instant-carrying input normalizes into the documented default zone
+/// (Europe/Copenhagen); naive digits stay verbatim.
+///
+/// NOTE on red evidence: the Z-input tests fail pre-fix on any host whose
+/// local timezone is NOT Europe/Copenhagen (run with TZ=UTC to reproduce CI);
+/// on a CET/CEST host they pass pre-fix by coincidence (server-local ==
+/// intended zone). Post-fix they are deterministic on every host.
+/// </summary>
+[TestFixture]
+public class WallTimeWorkingHoursWritePathTests : TestBaseSetup
+{
+    private TimePlanningWorkingHoursService _service = null!;
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+
+        var localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        var coreService = Substitute.For<IEFormCoreService>();
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
+        // The kiosk path only touches userService.UserId and dbContext;
+        // baseDbContext / coreHelper are never dereferenced on this branch
+        // (same fixture shape as WorkingHoursGrpcKioskNonRoundMinutesTests).
+        _service = new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            TimePlanningPnDbContext!,
+            userService,
+            localizationService,
+            baseDbContext: null!,
+            options,
+            coreService);
+    }
+
+    private async Task SeedKioskSite(int siteUid, string token)
+    {
+        await new AssignedSiteEntity
+        {
+            SiteId = siteUid,
+            UseOneMinuteIntervals = true,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        await new RegistrationDeviceEntity
+        {
+            Token = token,
+            Name = "Kiosk Device",
+            OtpCode = "12345",
+            SoftwareVersion = "1.0.0",
+            Manufacturer = "Test",
+            Model = "Test",
+            OsVersion = "1.0",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+    }
+
+    private static TimePlanningWorkingHoursUpdateModel BuildModel(
+        DateTime date, string start1, string stop1)
+    {
+        return new TimePlanningWorkingHoursUpdateModel
+        {
+            Date = date,
+            Shift1Start = 79,   // legacy 5-min slot ↔ 06:30 wall time
+            Shift1Stop = 193,   // legacy 5-min slot ↔ 16:00 wall time
+            Shift1Pause = 0,
+            Start1StartedAt = start1,
+            Stop1StoppedAt = stop1,
+            CommentWorker = "",
+            OsVersion = "1.0",
+            Model = "Test",
+            Manufacturer = "Test",
+            SoftwareVersion = "1.0.0",
+        };
+    }
+
+    [Test]
+    public async Task KioskCreate_ZSuffixedUtcStamps_PersistWallDigits()
+    {
+        const string token = "kiosk-walltime-create-z";
+        await SeedKioskSite(9821, token);
+
+        var date = new DateTime(2026, 7, 7, 0, 0, 0);
+        // 04:30Z / 14:00Z == the 06:30–16:00 CEST wall-time shift (prod oracle shape).
+        var model = BuildModel(date, "2026-07-07T04:30:00Z", "2026-07-07T14:00:00Z");
+
+        var result = await _service.UpdateWorkingHour(sdkSiteId: 9821, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking()
+            .SingleAsync(x => x.SdkSitId == 9821 && x.Date == date);
+        Assert.Multiple(() =>
+        {
+            Assert.That(pr.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+                "Z-suffixed input must persist as Europe/Copenhagen wall digits (06:30), " +
+                "not UTC digits and not whatever the server's local timezone happens to be");
+            Assert.That(pr.Stop1StoppedAt, Is.EqualTo(new DateTime(2026, 7, 7, 16, 0, 0)),
+                "Z-suffixed input must persist as wall digits (16:00)");
+        });
+    }
+
+    [Test]
+    public async Task KioskUpdate_ExistingRow_ZSuffixedUtcStamps_PersistWallDigits()
+    {
+        const string token = "kiosk-walltime-update-z";
+        await SeedKioskSite(9822, token);
+
+        var date = new DateTime(2026, 7, 7, 0, 0, 0);
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = 9822,
+            Date = date,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        var model = BuildModel(date, "2026-07-07T04:30:00Z", "2026-07-07T14:00:00Z");
+
+        var result = await _service.UpdateWorkingHour(sdkSiteId: 9822, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking()
+            .SingleAsync(x => x.SdkSitId == 9822 && x.Date == date);
+        Assert.Multiple(() =>
+        {
+            Assert.That(pr.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+                "Update branch must apply the same UTC→wall normalization as create");
+            Assert.That(pr.Stop1StoppedAt, Is.EqualTo(new DateTime(2026, 7, 7, 16, 0, 0)));
+        });
+    }
+
+    /// <summary>
+    /// REGRESSION LOCK (green today): naive wall digits — what the kiosk app
+    /// actually sends — persist byte-identical.
+    /// </summary>
+    [Test]
+    public async Task KioskCreate_NaiveWallDigits_PersistVerbatim()
+    {
+        const string token = "kiosk-walltime-create-naive";
+        await SeedKioskSite(9823, token);
+
+        var date = new DateTime(2026, 7, 7, 0, 0, 0);
+        var model = BuildModel(date, "2026-07-07T06:30:00", "2026-07-07T16:00:00");
+
+        var result = await _service.UpdateWorkingHour(sdkSiteId: 9823, model, token);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var pr = await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking()
+            .SingleAsync(x => x.SdkSitId == 9823 && x.Date == date);
+        Assert.Multiple(() =>
+        {
+            Assert.That(pr.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)),
+                "Naive wall digits must persist verbatim — no shifting");
+            Assert.That(pr.Stop1StoppedAt, Is.EqualTo(new DateTime(2026, 7, 7, 16, 0, 0)));
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -1112,60 +1112,110 @@ public static class PlanRegistrationHelper
                 AbsenceWithoutPermission = planRegistration.AbsenceWithoutPermission,
                 Start1StartedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Start1StartedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Start1Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Start1Id * 5) - 5))
                     : (planRegistration.Start1Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start1Id * 5) - 5)),
                 Stop1StoppedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Stop1StoppedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Stop1Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Stop1Id * 5) - 5))
                     : (planRegistration.Stop1Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop1Id * 5) - 5)),
                 Start2StartedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Start2StartedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Start2Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Start2Id * 5) - 5))
                     : (planRegistration.Start2Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start2Id * 5) - 5)),
                 Stop2StoppedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Stop2StoppedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Stop2Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Stop2Id * 5) - 5))
                     : (planRegistration.Stop2Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop2Id * 5) - 5)),
                 Start3StartedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Start3StartedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Start3Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Start3Id * 5) - 5))
                     : (planRegistration.Start3Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start3Id * 5) - 5)),
                 Stop3StoppedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Stop3StoppedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Stop3Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Stop3Id * 5) - 5))
                     : (planRegistration.Stop3Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop3Id * 5) - 5)),
                 Start4StartedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Start4StartedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Start4Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Start4Id * 5) - 5))
                     : (planRegistration.Start4Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start4Id * 5) - 5)),
                 Stop4StoppedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Stop4StoppedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Stop4Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Stop4Id * 5) - 5))
                     : (planRegistration.Stop4Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop4Id * 5) - 5)),
                 Start5StartedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Start5StartedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Start5Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Start5Id * 5) - 5))
                     : (planRegistration.Start5Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start5Id * 5) - 5)),
                 Stop5StoppedAt = dbAssignedSite.UseOneMinuteIntervals
                     ? planRegistration.Stop5StoppedAt
+                        // Wall-time-at-rest: fall back to the id-derived wall time so a
+                        // false->true UseOneMinuteIntervals flip never blanks recorded times.
+                        ?? (planRegistration.Stop5Id == 0
+                            ? (DateTime?)null
+                            : midnight.AddMinutes((planRegistration.Stop5Id * 5) - 5))
                     : (planRegistration.Stop5Id == 0
                         ? null
                         : midnight.AddMinutes(
@@ -1976,6 +2026,34 @@ public static class PlanRegistrationHelper
             Shift1PauseNumber = planRegistration.Shift1PauseNumber,
             Shift2PauseNumber = planRegistration.Shift2PauseNumber
         };
+
+        // Wall-time-at-rest: for UseOneMinuteIntervals sites, fall back to the
+        // id-derived wall time when a shift has an interval id but no exact
+        // stamp (rows written while the flag was still false), so a
+        // false->true flag flip never blanks recorded times. Interval ids and
+        // stamps both encode wall time, so no timezone math is involved —
+        // this mirrors the flag-true fallback in UpdatePlanRegistrationsInPeriod
+        // and the backfill in TimePlanningPlanningService.EnsureTimestampsFromIds.
+        var useOneMinuteIntervals = await dbContext.AssignedSites
+            .AsNoTracking()
+            .Where(x => x.SiteId == sdkSiteId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => x.UseOneMinuteIntervals)
+            .FirstOrDefaultAsync();
+        if (useOneMinuteIntervals)
+        {
+            DateTime? FromId(int id) => id > 0 ? midnight.AddMinutes((id * 5) - 5) : null;
+            timePlanningWorkingHoursModel.Start1StartedAt ??= FromId(planRegistration.Start1Id);
+            timePlanningWorkingHoursModel.Stop1StoppedAt ??= FromId(planRegistration.Stop1Id);
+            timePlanningWorkingHoursModel.Start2StartedAt ??= FromId(planRegistration.Start2Id);
+            timePlanningWorkingHoursModel.Stop2StoppedAt ??= FromId(planRegistration.Stop2Id);
+            timePlanningWorkingHoursModel.Start3StartedAt ??= FromId(planRegistration.Start3Id);
+            timePlanningWorkingHoursModel.Stop3StoppedAt ??= FromId(planRegistration.Stop3Id);
+            timePlanningWorkingHoursModel.Start4StartedAt ??= FromId(planRegistration.Start4Id);
+            timePlanningWorkingHoursModel.Stop4StoppedAt ??= FromId(planRegistration.Stop4Id);
+            timePlanningWorkingHoursModel.Start5StartedAt ??= FromId(planRegistration.Start5Id);
+            timePlanningWorkingHoursModel.Stop5StoppedAt ??= FromId(planRegistration.Stop5Id);
+        }
 
         // Approach C READ projection (today path): when a shift carries a pause
         // override, present a single synthesized pause pair and empty the

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/WallTimeNormalizer.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/WallTimeNormalizer.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Globalization;
+
+namespace TimePlanning.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// Enforces the storage convention for the PlanRegistration exact-time columns
+/// (<c>Start{N}StartedAt</c> / <c>Stop{N}StoppedAt</c> / <c>Pause*StartedAt</c> /
+/// <c>Pause*StoppedAt</c>): these columns store USER-LOCAL WALL TIME with
+/// <c>DateTimeKind.Unspecified</c> — the digits the worker saw on the clock —
+/// matching the 5-minute interval ids (Start1Id=79 ↔ 06:30) and the id-derived
+/// backfill in <c>TimePlanningPlanningService.EnsureTimestampsFromIds</c>.
+/// See docs/adr/0001-plan-registration-timestamps-wall-time.md.
+///
+/// Incoming timestamp strings arrive in two shapes:
+/// <list type="bullet">
+///   <item>naive digits ("2026-07-07T06:30:00") — already wall time; kept
+///   verbatim. Punch-clock flows, flag-off id-driven sites and pre-June-25
+///   app builds all write this shape.</item>
+///   <item>UTC or offset-carrying ("2026-07-07T04:30:00Z", "…+05:30") — sent
+///   by the app edit screen's <c>.toUtc().toIso8601String()</c> path since the
+///   June 25 Android release; must be converted into the user's zone so the
+///   stored digits are wall time. This normalization stays even after the
+///   app-side cleanup ships, so no client can ever corrupt storage again.</item>
+/// </list>
+/// </summary>
+public static class WallTimeNormalizer
+{
+    /// <summary>
+    /// IANA id used when no per-user timezone can be resolved (kiosk device
+    /// flows have no authenticated user; personal flows fall back here when
+    /// the user has no zone stored). All current customers operate in
+    /// Denmark, which is also the assumption the wall-time interval ids have
+    /// always encoded.
+    /// </summary>
+    public const string DefaultTimeZoneId = "Europe/Copenhagen";
+
+    public static TimeZoneInfo DefaultTimeZone =>
+        TimeZoneInfo.FindSystemTimeZoneById(DefaultTimeZoneId);
+
+    /// <summary>
+    /// Parses <paramref name="raw"/> and returns the user-local wall-time
+    /// digits with <c>Kind=Unspecified</c>, ready to be stored:
+    /// naive input is returned verbatim; input carrying Z or an explicit
+    /// offset is converted through UTC into <paramref name="timeZone"/>
+    /// (falling back to <see cref="DefaultTimeZone"/> when null).
+    ///
+    /// DST note: conversion FROM an instant is always deterministic — during
+    /// the fall-back overlap (e.g. 2026-10-25 02:00–03:00 in Copenhagen) both
+    /// the CEST and the CET instant map to the same wall digits; the stored
+    /// value is only ambiguous in reverse, a limitation shared with the
+    /// 5-minute interval ids.
+    /// </summary>
+    public static DateTime NormalizeToWallTime(string raw, TimeZoneInfo timeZone)
+    {
+        var parsed = DateTime.Parse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        if (parsed.Kind == DateTimeKind.Unspecified)
+        {
+            // Naive digits are already wall time — the storage convention.
+            return parsed;
+        }
+
+        // Kind=Utc (Z suffix / +00:00) or Kind=Local (explicit non-zero offset
+        // → RoundtripKind yields server-local): normalize via the UTC instant
+        // into the user's zone, then drop the kind so the wall digits
+        // round-trip to MySQL without any further adjustment.
+        var utc = parsed.ToUniversalTime();
+        var wall = TimeZoneInfo.ConvertTimeFromUtc(utc, timeZone ?? DefaultTimeZone);
+        return DateTime.SpecifyKind(wall, DateTimeKind.Unspecified);
+    }
+
+    /// <summary>
+    /// Null-tolerant convenience overload for the ubiquitous
+    /// "empty string means no stamp" call sites.
+    /// </summary>
+    public static DateTime? NormalizeToWallTimeOrNull(string raw, TimeZoneInfo timeZone) =>
+        string.IsNullOrEmpty(raw) ? null : NormalizeToWallTime(raw, timeZone);
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Microting.eFormApi.BasePn.Abstractions;
 using TimePlanning.Pn.Grpc;
+using TimePlanning.Pn.Infrastructure.Helpers;
 using TimePlanning.Pn.Infrastructure.Models.Planning;
 using TimePlanning.Pn.Services.TimePlanningPlanningService;
 
@@ -14,10 +16,38 @@ public class TimePlanningPlanningsGrpcService
     : TimePlanningPlanningsService.TimePlanningPlanningsServiceBase
 {
     private readonly ITimePlanningPlanningService _planningService;
+    private readonly IUserService _userService;
 
-    public TimePlanningPlanningsGrpcService(ITimePlanningPlanningService planningService)
+    // userService is optional so wall-time normalization degrades to the
+    // documented default zone (Europe/Copenhagen) when no user context exists;
+    // DI supplies it in the host.
+    public TimePlanningPlanningsGrpcService(
+        ITimePlanningPlanningService planningService,
+        IUserService userService = null)
     {
         _planningService = planningService;
+        _userService = userService;
+    }
+
+    /// <summary>
+    /// Resolves the current user's timezone for wall-time normalization of
+    /// incoming timestamp strings (see <see cref="WallTimeNormalizer"/>).
+    /// Falls back to Europe/Copenhagen when no user/zone is resolvable.
+    /// Resolved once per write request.
+    /// </summary>
+    private async Task<TimeZoneInfo> ResolveUserTimeZoneAsync()
+    {
+        try
+        {
+            var tz = _userService == null ? null : await _userService.GetCurrentUserTimeZoneInfo();
+            return tz ?? WallTimeNormalizer.DefaultTimeZone;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(
+                $"[GRPC-PLANNINGS] Could not resolve user timezone, falling back to {WallTimeNormalizer.DefaultTimeZoneId}: {ex.Message}");
+            return WallTimeNormalizer.DefaultTimeZone;
+        }
     }
 
     public override async Task<GetPlanningsByUserResponse> GetPlanningsByUser(
@@ -80,7 +110,9 @@ public class TimePlanningPlanningsGrpcService
     public override async Task<UpdatePlanningByCurrentUserResponse> UpdatePlanningByCurrentUser(
         UpdatePlanningByCurrentUserRequest request, ServerCallContext context)
     {
-        var model = MapDayFromGrpc(request.Model);
+        // The app edit screen calls this RPC and (builds ≥ June 25) may send
+        // Z-suffixed UTC stamps — normalize into the user's wall time here.
+        var model = MapDayFromGrpc(request.Model, await ResolveUserTimeZoneAsync());
         var result = await _planningService.UpdateByCurrentUserNam(model);
 
         return new UpdatePlanningByCurrentUserResponse
@@ -165,7 +197,7 @@ public class TimePlanningPlanningsGrpcService
     {
         try
         {
-            var model = MapDayFromGrpc(request.Model);
+            var model = MapDayFromGrpc(request.Model, await ResolveUserTimeZoneAsync());
             var result = await _planningService.Update(request.PlanningId, model);
 
             return new UpdatePlanningResponse
@@ -338,7 +370,7 @@ public class TimePlanningPlanningsGrpcService
         };
     }
 
-    private static TimePlanningPlanningPrDayModel MapDayFromGrpc(Grpc.PlanningPrDayModel? m)
+    private static TimePlanningPlanningPrDayModel MapDayFromGrpc(Grpc.PlanningPrDayModel? m, TimeZoneInfo tz)
     {
         if (m == null) return new TimePlanningPlanningPrDayModel();
 
@@ -404,89 +436,91 @@ public class TimePlanningPlanningsGrpcService
             CommentOffice = m.CommentOffice,
             WorkerComment = m.WorkerComment,
             // Primary shift timestamps — shifts 1-5
-            Start1StartedAt = ParseDateTime(m.Start1StartedAt),
-            Stop1StoppedAt = ParseDateTime(m.Stop1StoppedAt),
-            Pause1StartedAt = ParseDateTime(m.Pause1StartedAt),
-            Pause1StoppedAt = ParseDateTime(m.Pause1StoppedAt),
-            Start2StartedAt = ParseDateTime(m.Start2StartedAt),
-            Stop2StoppedAt = ParseDateTime(m.Stop2StoppedAt),
-            Pause2StartedAt = ParseDateTime(m.Pause2StartedAt),
-            Pause2StoppedAt = ParseDateTime(m.Pause2StoppedAt),
-            Start3StartedAt = ParseDateTime(m.Start3StartedAt),
-            Stop3StoppedAt = ParseDateTime(m.Stop3StoppedAt),
-            Pause3StartedAt = ParseDateTime(m.Pause3StartedAt),
-            Pause3StoppedAt = ParseDateTime(m.Pause3StoppedAt),
-            Start4StartedAt = ParseDateTime(m.Start4StartedAt),
-            Stop4StoppedAt = ParseDateTime(m.Stop4StoppedAt),
-            Pause4StartedAt = ParseDateTime(m.Pause4StartedAt),
-            Pause4StoppedAt = ParseDateTime(m.Pause4StoppedAt),
-            Start5StartedAt = ParseDateTime(m.Start5StartedAt),
-            Stop5StoppedAt = ParseDateTime(m.Stop5StoppedAt),
-            Pause5StartedAt = ParseDateTime(m.Pause5StartedAt),
-            Pause5StoppedAt = ParseDateTime(m.Pause5StoppedAt),
+            Start1StartedAt = ParseDateTime(m.Start1StartedAt, tz),
+            Stop1StoppedAt = ParseDateTime(m.Stop1StoppedAt, tz),
+            Pause1StartedAt = ParseDateTime(m.Pause1StartedAt, tz),
+            Pause1StoppedAt = ParseDateTime(m.Pause1StoppedAt, tz),
+            Start2StartedAt = ParseDateTime(m.Start2StartedAt, tz),
+            Stop2StoppedAt = ParseDateTime(m.Stop2StoppedAt, tz),
+            Pause2StartedAt = ParseDateTime(m.Pause2StartedAt, tz),
+            Pause2StoppedAt = ParseDateTime(m.Pause2StoppedAt, tz),
+            Start3StartedAt = ParseDateTime(m.Start3StartedAt, tz),
+            Stop3StoppedAt = ParseDateTime(m.Stop3StoppedAt, tz),
+            Pause3StartedAt = ParseDateTime(m.Pause3StartedAt, tz),
+            Pause3StoppedAt = ParseDateTime(m.Pause3StoppedAt, tz),
+            Start4StartedAt = ParseDateTime(m.Start4StartedAt, tz),
+            Stop4StoppedAt = ParseDateTime(m.Stop4StoppedAt, tz),
+            Pause4StartedAt = ParseDateTime(m.Pause4StartedAt, tz),
+            Pause4StoppedAt = ParseDateTime(m.Pause4StoppedAt, tz),
+            Start5StartedAt = ParseDateTime(m.Start5StartedAt, tz),
+            Stop5StoppedAt = ParseDateTime(m.Stop5StoppedAt, tz),
+            Pause5StartedAt = ParseDateTime(m.Pause5StartedAt, tz),
+            Pause5StoppedAt = ParseDateTime(m.Pause5StoppedAt, tz),
             // Detailed pause timestamps for shift 1
-            Pause10StartedAt = ParseDateTime(m.Pause10StartedAt),
-            Pause10StoppedAt = ParseDateTime(m.Pause10StoppedAt),
-            Pause11StartedAt = ParseDateTime(m.Pause11StartedAt),
-            Pause11StoppedAt = ParseDateTime(m.Pause11StoppedAt),
-            Pause12StartedAt = ParseDateTime(m.Pause12StartedAt),
-            Pause12StoppedAt = ParseDateTime(m.Pause12StoppedAt),
-            Pause13StartedAt = ParseDateTime(m.Pause13StartedAt),
-            Pause13StoppedAt = ParseDateTime(m.Pause13StoppedAt),
-            Pause14StartedAt = ParseDateTime(m.Pause14StartedAt),
-            Pause14StoppedAt = ParseDateTime(m.Pause14StoppedAt),
-            Pause15StartedAt = ParseDateTime(m.Pause15StartedAt),
-            Pause15StoppedAt = ParseDateTime(m.Pause15StoppedAt),
-            Pause16StartedAt = ParseDateTime(m.Pause16StartedAt),
-            Pause16StoppedAt = ParseDateTime(m.Pause16StoppedAt),
-            Pause17StartedAt = ParseDateTime(m.Pause17StartedAt),
-            Pause17StoppedAt = ParseDateTime(m.Pause17StoppedAt),
-            Pause18StartedAt = ParseDateTime(m.Pause18StartedAt),
-            Pause18StoppedAt = ParseDateTime(m.Pause18StoppedAt),
-            Pause19StartedAt = ParseDateTime(m.Pause19StartedAt),
-            Pause19StoppedAt = ParseDateTime(m.Pause19StoppedAt),
-            Pause100StartedAt = ParseDateTime(m.Pause100StartedAt),
-            Pause100StoppedAt = ParseDateTime(m.Pause100StoppedAt),
-            Pause101StartedAt = ParseDateTime(m.Pause101StartedAt),
-            Pause101StoppedAt = ParseDateTime(m.Pause101StoppedAt),
-            Pause102StartedAt = ParseDateTime(m.Pause102StartedAt),
-            Pause102StoppedAt = ParseDateTime(m.Pause102StoppedAt),
+            Pause10StartedAt = ParseDateTime(m.Pause10StartedAt, tz),
+            Pause10StoppedAt = ParseDateTime(m.Pause10StoppedAt, tz),
+            Pause11StartedAt = ParseDateTime(m.Pause11StartedAt, tz),
+            Pause11StoppedAt = ParseDateTime(m.Pause11StoppedAt, tz),
+            Pause12StartedAt = ParseDateTime(m.Pause12StartedAt, tz),
+            Pause12StoppedAt = ParseDateTime(m.Pause12StoppedAt, tz),
+            Pause13StartedAt = ParseDateTime(m.Pause13StartedAt, tz),
+            Pause13StoppedAt = ParseDateTime(m.Pause13StoppedAt, tz),
+            Pause14StartedAt = ParseDateTime(m.Pause14StartedAt, tz),
+            Pause14StoppedAt = ParseDateTime(m.Pause14StoppedAt, tz),
+            Pause15StartedAt = ParseDateTime(m.Pause15StartedAt, tz),
+            Pause15StoppedAt = ParseDateTime(m.Pause15StoppedAt, tz),
+            Pause16StartedAt = ParseDateTime(m.Pause16StartedAt, tz),
+            Pause16StoppedAt = ParseDateTime(m.Pause16StoppedAt, tz),
+            Pause17StartedAt = ParseDateTime(m.Pause17StartedAt, tz),
+            Pause17StoppedAt = ParseDateTime(m.Pause17StoppedAt, tz),
+            Pause18StartedAt = ParseDateTime(m.Pause18StartedAt, tz),
+            Pause18StoppedAt = ParseDateTime(m.Pause18StoppedAt, tz),
+            Pause19StartedAt = ParseDateTime(m.Pause19StartedAt, tz),
+            Pause19StoppedAt = ParseDateTime(m.Pause19StoppedAt, tz),
+            Pause100StartedAt = ParseDateTime(m.Pause100StartedAt, tz),
+            Pause100StoppedAt = ParseDateTime(m.Pause100StoppedAt, tz),
+            Pause101StartedAt = ParseDateTime(m.Pause101StartedAt, tz),
+            Pause101StoppedAt = ParseDateTime(m.Pause101StoppedAt, tz),
+            Pause102StartedAt = ParseDateTime(m.Pause102StartedAt, tz),
+            Pause102StoppedAt = ParseDateTime(m.Pause102StoppedAt, tz),
             // Detailed pause timestamps for shift 2
-            Pause20StartedAt = ParseDateTime(m.Pause20StartedAt),
-            Pause20StoppedAt = ParseDateTime(m.Pause20StoppedAt),
-            Pause21StartedAt = ParseDateTime(m.Pause21StartedAt),
-            Pause21StoppedAt = ParseDateTime(m.Pause21StoppedAt),
-            Pause22StartedAt = ParseDateTime(m.Pause22StartedAt),
-            Pause22StoppedAt = ParseDateTime(m.Pause22StoppedAt),
-            Pause23StartedAt = ParseDateTime(m.Pause23StartedAt),
-            Pause23StoppedAt = ParseDateTime(m.Pause23StoppedAt),
-            Pause24StartedAt = ParseDateTime(m.Pause24StartedAt),
-            Pause24StoppedAt = ParseDateTime(m.Pause24StoppedAt),
-            Pause25StartedAt = ParseDateTime(m.Pause25StartedAt),
-            Pause25StoppedAt = ParseDateTime(m.Pause25StoppedAt),
-            Pause26StartedAt = ParseDateTime(m.Pause26StartedAt),
-            Pause26StoppedAt = ParseDateTime(m.Pause26StoppedAt),
-            Pause27StartedAt = ParseDateTime(m.Pause27StartedAt),
-            Pause27StoppedAt = ParseDateTime(m.Pause27StoppedAt),
-            Pause28StartedAt = ParseDateTime(m.Pause28StartedAt),
-            Pause28StoppedAt = ParseDateTime(m.Pause28StoppedAt),
-            Pause29StartedAt = ParseDateTime(m.Pause29StartedAt),
-            Pause29StoppedAt = ParseDateTime(m.Pause29StoppedAt),
-            Pause200StartedAt = ParseDateTime(m.Pause200StartedAt),
-            Pause200StoppedAt = ParseDateTime(m.Pause200StoppedAt),
-            Pause201StartedAt = ParseDateTime(m.Pause201StartedAt),
-            Pause201StoppedAt = ParseDateTime(m.Pause201StoppedAt),
-            Pause202StartedAt = ParseDateTime(m.Pause202StartedAt),
-            Pause202StoppedAt = ParseDateTime(m.Pause202StoppedAt),
+            Pause20StartedAt = ParseDateTime(m.Pause20StartedAt, tz),
+            Pause20StoppedAt = ParseDateTime(m.Pause20StoppedAt, tz),
+            Pause21StartedAt = ParseDateTime(m.Pause21StartedAt, tz),
+            Pause21StoppedAt = ParseDateTime(m.Pause21StoppedAt, tz),
+            Pause22StartedAt = ParseDateTime(m.Pause22StartedAt, tz),
+            Pause22StoppedAt = ParseDateTime(m.Pause22StoppedAt, tz),
+            Pause23StartedAt = ParseDateTime(m.Pause23StartedAt, tz),
+            Pause23StoppedAt = ParseDateTime(m.Pause23StoppedAt, tz),
+            Pause24StartedAt = ParseDateTime(m.Pause24StartedAt, tz),
+            Pause24StoppedAt = ParseDateTime(m.Pause24StoppedAt, tz),
+            Pause25StartedAt = ParseDateTime(m.Pause25StartedAt, tz),
+            Pause25StoppedAt = ParseDateTime(m.Pause25StoppedAt, tz),
+            Pause26StartedAt = ParseDateTime(m.Pause26StartedAt, tz),
+            Pause26StoppedAt = ParseDateTime(m.Pause26StoppedAt, tz),
+            Pause27StartedAt = ParseDateTime(m.Pause27StartedAt, tz),
+            Pause27StoppedAt = ParseDateTime(m.Pause27StoppedAt, tz),
+            Pause28StartedAt = ParseDateTime(m.Pause28StartedAt, tz),
+            Pause28StoppedAt = ParseDateTime(m.Pause28StoppedAt, tz),
+            Pause29StartedAt = ParseDateTime(m.Pause29StartedAt, tz),
+            Pause29StoppedAt = ParseDateTime(m.Pause29StoppedAt, tz),
+            Pause200StartedAt = ParseDateTime(m.Pause200StartedAt, tz),
+            Pause200StoppedAt = ParseDateTime(m.Pause200StoppedAt, tz),
+            Pause201StartedAt = ParseDateTime(m.Pause201StartedAt, tz),
+            Pause201StoppedAt = ParseDateTime(m.Pause201StoppedAt, tz),
+            Pause202StartedAt = ParseDateTime(m.Pause202StartedAt, tz),
+            Pause202StoppedAt = ParseDateTime(m.Pause202StoppedAt, tz),
             // Netto hours override
             NettoHoursOverride = m.NettoHoursOverride,
             NettoHoursOverrideActive = m.NettoHoursOverrideActive,
         };
     }
 
-    private static DateTime? ParseDateTime(string s) =>
-        string.IsNullOrEmpty(s)
-            ? null
-            : DateTime.Parse(s, System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal);
+    /// <summary>
+    /// Wall-time-at-rest: naive digits pass through verbatim; Z / offset-
+    /// carrying stamps (sent by app edit-screen builds ≥ June 25) are
+    /// converted into the user's zone. See <see cref="WallTimeNormalizer"/>.
+    /// </summary>
+    private static DateTime? ParseDateTime(string s, TimeZoneInfo tz) =>
+        WallTimeNormalizer.NormalizeToWallTimeOrNull(s, tz);
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -1096,6 +1096,27 @@ public class TimePlanningWorkingHoursService(
         return nettoMinutes;
     }
 
+    /// <summary>
+    /// Resolves the current user's timezone for wall-time normalization of
+    /// incoming timestamp strings (see <see cref="WallTimeNormalizer"/>).
+    /// Falls back to Europe/Copenhagen when the user has no zone stored or
+    /// resolution fails.
+    /// </summary>
+    private async Task<TimeZoneInfo> GetCurrentUserTimeZoneOrDefaultAsync()
+    {
+        try
+        {
+            return await userService.GetCurrentUserTimeZoneInfo() ?? WallTimeNormalizer.DefaultTimeZone;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                "Could not resolve current user timezone, falling back to {DefaultTimeZoneId}: {Message}",
+                WallTimeNormalizer.DefaultTimeZoneId, ex.Message);
+            return WallTimeNormalizer.DefaultTimeZone;
+        }
+    }
+
     public async Task<OperationResult> UpdateWorkingHour(TimePlanningWorkingHoursUpdateModel model)
     {
         Console.WriteLine($"[DEBUG-GRPC-UPDATE] === UpdateWorkingHour (PERSONAL mode, 1-param) entered ===");
@@ -1110,6 +1131,12 @@ public class TimePlanningWorkingHoursService(
             Console.WriteLine($"[DEBUG-GRPC-UPDATE] EARLY RETURN: GetCurrentUserAsync returned null (JWT missing or invalid)");
             return new OperationResult(false, localizationService.GetString("UserNotFound"));
         }
+
+        // Wall-time-at-rest hardening: any Z/offset-carrying stamp below is
+        // normalized into this zone before persisting (naive digits — what the
+        // app actually sends here today — pass through verbatim).
+        var userTimeZone = await GetCurrentUserTimeZoneOrDefaultAsync();
+
         var currentUser = baseDbContext.Users
             .Single(x => x.Id == currentUserAsync.Id);
         var userEmail = (currentUser.Email ?? "").Trim().ToLower();
@@ -1199,221 +1226,221 @@ public class TimePlanningWorkingHoursService(
                 Pause5Id = model.Shift5Pause ?? 0,
                 Start1StartedAt = string.IsNullOrEmpty(model.Start1StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start1StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start1StartedAt, userTimeZone),
                 Stop1StoppedAt = string.IsNullOrEmpty(model.Stop1StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop1StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop1StoppedAt, userTimeZone),
                 Pause1StartedAt = string.IsNullOrEmpty(model.Pause1StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause1StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StartedAt, userTimeZone),
                 Pause1StoppedAt = string.IsNullOrEmpty(model.Pause1StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause1StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StoppedAt, userTimeZone),
                 Start2StartedAt = string.IsNullOrEmpty(model.Start2StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start2StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start2StartedAt, userTimeZone),
                 Stop2StoppedAt = string.IsNullOrEmpty(model.Stop2StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop2StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop2StoppedAt, userTimeZone),
                 Start3StartedAt = string.IsNullOrEmpty(model.Start3StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start3StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start3StartedAt, userTimeZone),
                 Stop3StoppedAt = string.IsNullOrEmpty(model.Stop3StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop3StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop3StoppedAt, userTimeZone),
                 Start4StartedAt = string.IsNullOrEmpty(model.Start4StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start4StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start4StartedAt, userTimeZone),
                 Stop4StoppedAt = string.IsNullOrEmpty(model.Stop4StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop4StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop4StoppedAt, userTimeZone),
                 Start5StartedAt = string.IsNullOrEmpty(model.Start5StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start5StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start5StartedAt, userTimeZone),
                 Stop5StoppedAt = string.IsNullOrEmpty(model.Stop5StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop5StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop5StoppedAt, userTimeZone),
                 Pause10StartedAt = string.IsNullOrEmpty(model.Pause10StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause10StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StartedAt, userTimeZone),
                 Pause10StoppedAt = string.IsNullOrEmpty(model.Pause10StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause10StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StoppedAt, userTimeZone),
                 Pause11StartedAt = string.IsNullOrEmpty(model.Pause11StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause11StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StartedAt, userTimeZone),
                 Pause11StoppedAt = string.IsNullOrEmpty(model.Pause11StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause11StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StoppedAt, userTimeZone),
                 Pause12StartedAt = string.IsNullOrEmpty(model.Pause12StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause12StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StartedAt, userTimeZone),
                 Pause12StoppedAt = string.IsNullOrEmpty(model.Pause12StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause12StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StoppedAt, userTimeZone),
                 Pause13StartedAt = string.IsNullOrEmpty(model.Pause13StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause13StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StartedAt, userTimeZone),
                 Pause13StoppedAt = string.IsNullOrEmpty(model.Pause13StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause13StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StoppedAt, userTimeZone),
                 Pause14StartedAt = string.IsNullOrEmpty(model.Pause14StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause14StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StartedAt, userTimeZone),
                 Pause14StoppedAt = string.IsNullOrEmpty(model.Pause14StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause14StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StoppedAt, userTimeZone),
                 Pause15StartedAt = string.IsNullOrEmpty(model.Pause15StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause15StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StartedAt, userTimeZone),
                 Pause15StoppedAt = string.IsNullOrEmpty(model.Pause15StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause15StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StoppedAt, userTimeZone),
                 Pause16StartedAt = string.IsNullOrEmpty(model.Pause16StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause16StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StartedAt, userTimeZone),
                 Pause16StoppedAt = string.IsNullOrEmpty(model.Pause16StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause16StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StoppedAt, userTimeZone),
                 Pause17StartedAt = string.IsNullOrEmpty(model.Pause17StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause17StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StartedAt, userTimeZone),
                 Pause17StoppedAt = string.IsNullOrEmpty(model.Pause17StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause17StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StoppedAt, userTimeZone),
                 Pause18StartedAt = string.IsNullOrEmpty(model.Pause18StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause18StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StartedAt, userTimeZone),
                 Pause18StoppedAt = string.IsNullOrEmpty(model.Pause18StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause18StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StoppedAt, userTimeZone),
                 Pause19StartedAt = string.IsNullOrEmpty(model.Pause19StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause19StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StartedAt, userTimeZone),
                 Pause19StoppedAt = string.IsNullOrEmpty(model.Pause19StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause19StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StoppedAt, userTimeZone),
                 Pause100StartedAt = string.IsNullOrEmpty(model.Pause100StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause100StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StartedAt, userTimeZone),
                 Pause100StoppedAt = string.IsNullOrEmpty(model.Pause100StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause100StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StoppedAt, userTimeZone),
                 Pause101StartedAt = string.IsNullOrEmpty(model.Pause101StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause101StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StartedAt, userTimeZone),
                 Pause101StoppedAt = string.IsNullOrEmpty(model.Pause101StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause101StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StoppedAt, userTimeZone),
                 Pause102StartedAt = string.IsNullOrEmpty(model.Pause102StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause102StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StartedAt, userTimeZone),
                 Pause102StoppedAt = string.IsNullOrEmpty(model.Pause102StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause102StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StoppedAt, userTimeZone),
 
                 Pause2StartedAt = string.IsNullOrEmpty(model.Pause2StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause2StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StartedAt, userTimeZone),
                 Pause2StoppedAt = string.IsNullOrEmpty(model.Pause2StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause2StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StoppedAt, userTimeZone),
                 Pause20StartedAt = string.IsNullOrEmpty(model.Pause20StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause20StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StartedAt, userTimeZone),
                 Pause20StoppedAt = string.IsNullOrEmpty(model.Pause20StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause20StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StoppedAt, userTimeZone),
                 Pause21StartedAt = string.IsNullOrEmpty(model.Pause21StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause21StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StartedAt, userTimeZone),
                 Pause21StoppedAt = string.IsNullOrEmpty(model.Pause21StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause21StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StoppedAt, userTimeZone),
                 Pause22StartedAt = string.IsNullOrEmpty(model.Pause22StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause22StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StartedAt, userTimeZone),
                 Pause22StoppedAt = string.IsNullOrEmpty(model.Pause22StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause22StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StoppedAt, userTimeZone),
                 Pause23StartedAt = string.IsNullOrEmpty(model.Pause23StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause23StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StartedAt, userTimeZone),
                 Pause23StoppedAt = string.IsNullOrEmpty(model.Pause23StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause23StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StoppedAt, userTimeZone),
                 Pause24StartedAt = string.IsNullOrEmpty(model.Pause24StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause24StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StartedAt, userTimeZone),
                 Pause24StoppedAt = string.IsNullOrEmpty(model.Pause24StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause24StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StoppedAt, userTimeZone),
                 Pause25StartedAt = string.IsNullOrEmpty(model.Pause25StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause25StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StartedAt, userTimeZone),
                 Pause25StoppedAt = string.IsNullOrEmpty(model.Pause25StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause25StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StoppedAt, userTimeZone),
                 Pause26StartedAt = string.IsNullOrEmpty(model.Pause26StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause26StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StartedAt, userTimeZone),
                 Pause26StoppedAt = string.IsNullOrEmpty(model.Pause26StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause26StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StoppedAt, userTimeZone),
                 Pause27StartedAt = string.IsNullOrEmpty(model.Pause27StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause27StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StartedAt, userTimeZone),
                 Pause27StoppedAt = string.IsNullOrEmpty(model.Pause27StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause27StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StoppedAt, userTimeZone),
                 Pause28StartedAt = string.IsNullOrEmpty(model.Pause28StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause28StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StartedAt, userTimeZone),
                 Pause28StoppedAt = string.IsNullOrEmpty(model.Pause28StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause28StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StoppedAt, userTimeZone),
                 Pause29StartedAt = string.IsNullOrEmpty(model.Pause29StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause29StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StartedAt, userTimeZone),
                 Pause29StoppedAt = string.IsNullOrEmpty(model.Pause29StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause29StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StoppedAt, userTimeZone),
                 Pause200StartedAt = string.IsNullOrEmpty(model.Pause200StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause200StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StartedAt, userTimeZone),
                 Pause200StoppedAt = string.IsNullOrEmpty(model.Pause200StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause200StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StoppedAt, userTimeZone),
                 Pause201StartedAt = string.IsNullOrEmpty(model.Pause201StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause201StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StartedAt, userTimeZone),
                 Pause201StoppedAt = string.IsNullOrEmpty(model.Pause201StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause201StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StoppedAt, userTimeZone),
                 Pause202StartedAt = string.IsNullOrEmpty(model.Pause202StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause202StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StartedAt, userTimeZone),
                 Pause202StoppedAt = string.IsNullOrEmpty(model.Pause202StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause202StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StoppedAt, userTimeZone),
                 Pause3StartedAt = string.IsNullOrEmpty(model.Pause3StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause3StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StartedAt, userTimeZone),
                 Pause3StoppedAt = string.IsNullOrEmpty(model.Pause3StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause3StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StoppedAt, userTimeZone),
                 Pause4StartedAt = string.IsNullOrEmpty(model.Pause4StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause4StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StartedAt, userTimeZone),
                 Pause4StoppedAt = string.IsNullOrEmpty(model.Pause4StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause4StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StoppedAt, userTimeZone),
                 Pause5StartedAt = string.IsNullOrEmpty(model.Pause5StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause5StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StartedAt, userTimeZone),
                 Pause5StoppedAt = string.IsNullOrEmpty(model.Pause5StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause5StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StoppedAt, userTimeZone),
                 Flex = 0,
                 WorkerComment = model.CommentWorker,
                 SdkSitId = sdkSite.MicrotingUid!.Value,
@@ -1491,225 +1518,225 @@ public class TimePlanningWorkingHoursService(
 
             planRegistration.Start1StartedAt = string.IsNullOrEmpty(model.Start1StartedAt)
                 ? null
-                : DateTime.Parse(model.Start1StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start1StartedAt, userTimeZone);
             planRegistration.Stop1StoppedAt = string.IsNullOrEmpty(model.Stop1StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop1StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop1StoppedAt, userTimeZone);
             planRegistration.Pause1StartedAt = string.IsNullOrEmpty(model.Pause1StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause1StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StartedAt, userTimeZone);
             planRegistration.Pause1StoppedAt = string.IsNullOrEmpty(model.Pause1StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause1StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StoppedAt, userTimeZone);
             planRegistration.Start2StartedAt = string.IsNullOrEmpty(model.Start2StartedAt)
                 ? null
-                : DateTime.Parse(model.Start2StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start2StartedAt, userTimeZone);
             planRegistration.Stop2StoppedAt = string.IsNullOrEmpty(model.Stop2StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop2StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop2StoppedAt, userTimeZone);
             planRegistration.Start3StartedAt = string.IsNullOrEmpty(model.Start3StartedAt)
                 ? null
-                : DateTime.Parse(model.Start3StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start3StartedAt, userTimeZone);
             planRegistration.Stop3StoppedAt = string.IsNullOrEmpty(model.Stop3StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop3StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop3StoppedAt, userTimeZone);
             planRegistration.Start4StartedAt = string.IsNullOrEmpty(model.Start4StartedAt)
                 ? null
-                : DateTime.Parse(model.Start4StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start4StartedAt, userTimeZone);
             planRegistration.Stop4StoppedAt = string.IsNullOrEmpty(model.Stop4StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop4StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop4StoppedAt, userTimeZone);
             planRegistration.Start5StartedAt = string.IsNullOrEmpty(model.Start5StartedAt)
                 ? null
-                : DateTime.Parse(model.Start5StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start5StartedAt, userTimeZone);
             planRegistration.Stop5StoppedAt = string.IsNullOrEmpty(model.Stop5StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop5StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop5StoppedAt, userTimeZone);
 
             planRegistration.Pause10StartedAt = string.IsNullOrEmpty(model.Pause10StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause10StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StartedAt, userTimeZone);
             planRegistration.Pause10StoppedAt = string.IsNullOrEmpty(model.Pause10StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause10StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StoppedAt, userTimeZone);
             planRegistration.Pause11StartedAt = string.IsNullOrEmpty(model.Pause11StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause11StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StartedAt, userTimeZone);
             planRegistration.Pause11StoppedAt = string.IsNullOrEmpty(model.Pause11StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause11StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StoppedAt, userTimeZone);
             planRegistration.Pause12StartedAt = string.IsNullOrEmpty(model.Pause12StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause12StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StartedAt, userTimeZone);
             planRegistration.Pause12StoppedAt = string.IsNullOrEmpty(model.Pause12StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause12StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StoppedAt, userTimeZone);
             planRegistration.Pause13StartedAt = string.IsNullOrEmpty(model.Pause13StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause13StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StartedAt, userTimeZone);
             planRegistration.Pause13StoppedAt = string.IsNullOrEmpty(model.Pause13StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause13StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StoppedAt, userTimeZone);
             planRegistration.Pause14StartedAt = string.IsNullOrEmpty(model.Pause14StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause14StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StartedAt, userTimeZone);
             planRegistration.Pause14StoppedAt = string.IsNullOrEmpty(model.Pause14StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause14StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StoppedAt, userTimeZone);
             planRegistration.Pause15StartedAt = string.IsNullOrEmpty(model.Pause15StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause15StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StartedAt, userTimeZone);
             planRegistration.Pause15StoppedAt = string.IsNullOrEmpty(model.Pause15StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause15StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StoppedAt, userTimeZone);
             planRegistration.Pause16StartedAt = string.IsNullOrEmpty(model.Pause16StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause16StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StartedAt, userTimeZone);
             planRegistration.Pause16StoppedAt = string.IsNullOrEmpty(model.Pause16StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause16StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StoppedAt, userTimeZone);
             planRegistration.Pause17StartedAt = string.IsNullOrEmpty(model.Pause17StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause17StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StartedAt, userTimeZone);
             planRegistration.Pause17StoppedAt = string.IsNullOrEmpty(model.Pause17StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause17StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StoppedAt, userTimeZone);
             planRegistration.Pause18StartedAt = string.IsNullOrEmpty(model.Pause18StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause18StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StartedAt, userTimeZone);
             planRegistration.Pause18StoppedAt = string.IsNullOrEmpty(model.Pause18StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause18StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StoppedAt, userTimeZone);
             planRegistration.Pause19StartedAt = string.IsNullOrEmpty(model.Pause19StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause19StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StartedAt, userTimeZone);
             planRegistration.Pause19StoppedAt = string.IsNullOrEmpty(model.Pause19StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause19StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StoppedAt, userTimeZone);
             planRegistration.Pause100StartedAt = string.IsNullOrEmpty(model.Pause100StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause100StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StartedAt, userTimeZone);
             planRegistration.Pause100StoppedAt = string.IsNullOrEmpty(model.Pause100StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause100StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StoppedAt, userTimeZone);
             planRegistration.Pause101StartedAt = string.IsNullOrEmpty(model.Pause101StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause101StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StartedAt, userTimeZone);
             planRegistration.Pause101StoppedAt = string.IsNullOrEmpty(model.Pause101StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause101StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StoppedAt, userTimeZone);
             planRegistration.Pause102StartedAt = string.IsNullOrEmpty(model.Pause102StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause102StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StartedAt, userTimeZone);
             planRegistration.Pause102StoppedAt = string.IsNullOrEmpty(model.Pause102StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause102StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StoppedAt, userTimeZone);
 
             planRegistration.Pause2StartedAt = string.IsNullOrEmpty(model.Pause2StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause2StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StartedAt, userTimeZone);
             planRegistration.Pause2StoppedAt = string.IsNullOrEmpty(model.Pause2StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause2StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StoppedAt, userTimeZone);
             planRegistration.Pause20StartedAt = string.IsNullOrEmpty(model.Pause20StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause20StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StartedAt, userTimeZone);
             planRegistration.Pause20StoppedAt = string.IsNullOrEmpty(model.Pause20StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause20StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StoppedAt, userTimeZone);
             planRegistration.Pause21StartedAt = string.IsNullOrEmpty(model.Pause21StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause21StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StartedAt, userTimeZone);
             planRegistration.Pause21StoppedAt = string.IsNullOrEmpty(model.Pause21StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause21StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StoppedAt, userTimeZone);
             planRegistration.Pause22StartedAt = string.IsNullOrEmpty(model.Pause22StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause22StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StartedAt, userTimeZone);
             planRegistration.Pause22StoppedAt = string.IsNullOrEmpty(model.Pause22StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause22StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StoppedAt, userTimeZone);
             planRegistration.Pause23StartedAt = string.IsNullOrEmpty(model.Pause23StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause23StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StartedAt, userTimeZone);
             planRegistration.Pause23StoppedAt = string.IsNullOrEmpty(model.Pause23StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause23StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StoppedAt, userTimeZone);
             planRegistration.Pause24StartedAt = string.IsNullOrEmpty(model.Pause24StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause24StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StartedAt, userTimeZone);
             planRegistration.Pause24StoppedAt = string.IsNullOrEmpty(model.Pause24StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause24StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StoppedAt, userTimeZone);
             planRegistration.Pause25StartedAt = string.IsNullOrEmpty(model.Pause25StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause25StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StartedAt, userTimeZone);
             planRegistration.Pause25StoppedAt = string.IsNullOrEmpty(model.Pause25StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause25StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StoppedAt, userTimeZone);
             planRegistration.Pause26StartedAt = string.IsNullOrEmpty(model.Pause26StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause26StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StartedAt, userTimeZone);
             planRegistration.Pause26StoppedAt = string.IsNullOrEmpty(model.Pause26StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause26StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StoppedAt, userTimeZone);
             planRegistration.Pause27StartedAt = string.IsNullOrEmpty(model.Pause27StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause27StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StartedAt, userTimeZone);
             planRegistration.Pause27StoppedAt = string.IsNullOrEmpty(model.Pause27StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause27StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StoppedAt, userTimeZone);
             planRegistration.Pause28StartedAt = string.IsNullOrEmpty(model.Pause28StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause28StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StartedAt, userTimeZone);
             planRegistration.Pause28StoppedAt = string.IsNullOrEmpty(model.Pause28StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause28StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StoppedAt, userTimeZone);
             planRegistration.Pause29StartedAt = string.IsNullOrEmpty(model.Pause29StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause29StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StartedAt, userTimeZone);
             planRegistration.Pause29StoppedAt = string.IsNullOrEmpty(model.Pause29StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause29StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StoppedAt, userTimeZone);
             planRegistration.Pause200StartedAt = string.IsNullOrEmpty(model.Pause200StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause200StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StartedAt, userTimeZone);
             planRegistration.Pause200StoppedAt = string.IsNullOrEmpty(model.Pause200StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause200StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StoppedAt, userTimeZone);
             planRegistration.Pause201StartedAt = string.IsNullOrEmpty(model.Pause201StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause201StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StartedAt, userTimeZone);
             planRegistration.Pause201StoppedAt = string.IsNullOrEmpty(model.Pause201StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause201StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StoppedAt, userTimeZone);
             planRegistration.Pause202StartedAt = string.IsNullOrEmpty(model.Pause202StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause202StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StartedAt, userTimeZone);
             planRegistration.Pause202StoppedAt = string.IsNullOrEmpty(model.Pause202StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause202StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StoppedAt, userTimeZone);
 
             planRegistration.Pause3StartedAt = string.IsNullOrEmpty(model.Pause3StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause3StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StartedAt, userTimeZone);
             planRegistration.Pause3StoppedAt = string.IsNullOrEmpty(model.Pause3StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause3StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StoppedAt, userTimeZone);
 
             planRegistration.Pause4StartedAt = string.IsNullOrEmpty(model.Pause4StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause4StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StartedAt, userTimeZone);
             planRegistration.Pause4StoppedAt = string.IsNullOrEmpty(model.Pause4StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause4StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StoppedAt, userTimeZone);
 
             planRegistration.Pause5StartedAt = string.IsNullOrEmpty(model.Pause5StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause5StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StartedAt, userTimeZone);
             planRegistration.Pause5StoppedAt = string.IsNullOrEmpty(model.Pause5StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause5StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StoppedAt, userTimeZone);
 
             planRegistration.Shift1PauseNumber = model.Shift1PauseNumber;
             planRegistration.Shift2PauseNumber = model.Shift2PauseNumber;
@@ -1789,6 +1816,15 @@ public class TimePlanningWorkingHoursService(
 
         await registrationDevice.Update(dbContext);
 
+        // Wall-time-at-rest hardening: the kiosk flow authenticates via a
+        // device token — there is no authenticated user whose timezone could
+        // be resolved, so Z/offset-carrying stamps are normalized into the
+        // documented default zone (Europe/Copenhagen), the same assumption the
+        // wall-time interval ids and EnsureTimestampsFromIds have always
+        // encoded. Naive digits (the shape the kiosk app actually sends) pass
+        // through verbatim.
+        var userTimeZone = WallTimeNormalizer.DefaultTimeZone;
+
         var todayAtMidnight = model.Date;
         Console.WriteLine($"[DEBUG-GRPC-UPDATE] KIOSK: Querying PlanRegistrations: Date={todayAtMidnight:yyyy-MM-dd}, SdkSitId={sdkSiteId}");
 
@@ -1831,229 +1867,229 @@ public class TimePlanningWorkingHoursService(
                 Pause5Id = model.Shift5Pause ?? 0,
                 Start1StartedAt = string.IsNullOrEmpty(model.Start1StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start1StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start1StartedAt, userTimeZone),
                 Stop1StoppedAt = string.IsNullOrEmpty(model.Stop1StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop1StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop1StoppedAt, userTimeZone),
 
                 Start2StartedAt = string.IsNullOrEmpty(model.Start2StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start2StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start2StartedAt, userTimeZone),
                 Stop2StoppedAt = string.IsNullOrEmpty(model.Stop2StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop2StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop2StoppedAt, userTimeZone),
 
                 Start3StartedAt = string.IsNullOrEmpty(model.Start3StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start3StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start3StartedAt, userTimeZone),
                 Stop3StoppedAt = string.IsNullOrEmpty(model.Stop3StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop3StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop3StoppedAt, userTimeZone),
 
                 Start4StartedAt = string.IsNullOrEmpty(model.Start4StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start4StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start4StartedAt, userTimeZone),
                 Stop4StoppedAt = string.IsNullOrEmpty(model.Stop4StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop4StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop4StoppedAt, userTimeZone),
 
                 Start5StartedAt = string.IsNullOrEmpty(model.Start5StartedAt)
                     ? null
-                    : DateTime.Parse(model.Start5StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Start5StartedAt, userTimeZone),
                 Stop5StoppedAt = string.IsNullOrEmpty(model.Stop5StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Stop5StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Stop5StoppedAt, userTimeZone),
 
                 Pause1StartedAt = string.IsNullOrEmpty(model.Pause1StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause1StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StartedAt, userTimeZone),
                 Pause1StoppedAt = string.IsNullOrEmpty(model.Pause1StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause1StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StoppedAt, userTimeZone),
                 Pause10StartedAt = string.IsNullOrEmpty(model.Pause10StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause10StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StartedAt, userTimeZone),
                 Pause10StoppedAt = string.IsNullOrEmpty(model.Pause10StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause10StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StoppedAt, userTimeZone),
                 Pause11StartedAt = string.IsNullOrEmpty(model.Pause11StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause11StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StartedAt, userTimeZone),
                 Pause11StoppedAt = string.IsNullOrEmpty(model.Pause11StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause11StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StoppedAt, userTimeZone),
                 Pause12StartedAt = string.IsNullOrEmpty(model.Pause12StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause12StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StartedAt, userTimeZone),
                 Pause12StoppedAt = string.IsNullOrEmpty(model.Pause12StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause12StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StoppedAt, userTimeZone),
                 Pause13StartedAt = string.IsNullOrEmpty(model.Pause13StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause13StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StartedAt, userTimeZone),
                 Pause13StoppedAt = string.IsNullOrEmpty(model.Pause13StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause13StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StoppedAt, userTimeZone),
                 Pause14StartedAt = string.IsNullOrEmpty(model.Pause14StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause14StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StartedAt, userTimeZone),
                 Pause14StoppedAt = string.IsNullOrEmpty(model.Pause14StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause14StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StoppedAt, userTimeZone),
                 Pause15StartedAt = string.IsNullOrEmpty(model.Pause15StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause15StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StartedAt, userTimeZone),
                 Pause15StoppedAt = string.IsNullOrEmpty(model.Pause15StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause15StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StoppedAt, userTimeZone),
                 Pause16StartedAt = string.IsNullOrEmpty(model.Pause16StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause16StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StartedAt, userTimeZone),
                 Pause16StoppedAt = string.IsNullOrEmpty(model.Pause16StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause16StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StoppedAt, userTimeZone),
                 Pause17StartedAt = string.IsNullOrEmpty(model.Pause17StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause17StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StartedAt, userTimeZone),
                 Pause17StoppedAt = string.IsNullOrEmpty(model.Pause17StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause17StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StoppedAt, userTimeZone),
                 Pause18StartedAt = string.IsNullOrEmpty(model.Pause18StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause18StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StartedAt, userTimeZone),
                 Pause18StoppedAt = string.IsNullOrEmpty(model.Pause18StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause18StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StoppedAt, userTimeZone),
                 Pause19StartedAt = string.IsNullOrEmpty(model.Pause19StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause19StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StartedAt, userTimeZone),
                 Pause19StoppedAt = string.IsNullOrEmpty(model.Pause19StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause19StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StoppedAt, userTimeZone),
                 Pause100StartedAt = string.IsNullOrEmpty(model.Pause100StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause100StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StartedAt, userTimeZone),
                 Pause100StoppedAt = string.IsNullOrEmpty(model.Pause100StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause100StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StoppedAt, userTimeZone),
                 Pause101StartedAt = string.IsNullOrEmpty(model.Pause101StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause101StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StartedAt, userTimeZone),
                 Pause101StoppedAt = string.IsNullOrEmpty(model.Pause101StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause101StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StoppedAt, userTimeZone),
                 Pause102StartedAt = string.IsNullOrEmpty(model.Pause102StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause102StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StartedAt, userTimeZone),
                 Pause102StoppedAt = string.IsNullOrEmpty(model.Pause102StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause102StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StoppedAt, userTimeZone),
 
                 Pause2StartedAt = string.IsNullOrEmpty(model.Pause2StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause2StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StartedAt, userTimeZone),
                 Pause2StoppedAt = string.IsNullOrEmpty(model.Pause2StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause2StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StoppedAt, userTimeZone),
                 Pause20StartedAt = string.IsNullOrEmpty(model.Pause20StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause20StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StartedAt, userTimeZone),
                 Pause20StoppedAt = string.IsNullOrEmpty(model.Pause20StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause20StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StoppedAt, userTimeZone),
                 Pause21StartedAt = string.IsNullOrEmpty(model.Pause21StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause21StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StartedAt, userTimeZone),
                 Pause21StoppedAt = string.IsNullOrEmpty(model.Pause21StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause21StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StoppedAt, userTimeZone),
                 Pause22StartedAt = string.IsNullOrEmpty(model.Pause22StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause22StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StartedAt, userTimeZone),
                 Pause22StoppedAt = string.IsNullOrEmpty(model.Pause22StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause22StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StoppedAt, userTimeZone),
                 Pause23StartedAt = string.IsNullOrEmpty(model.Pause23StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause23StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StartedAt, userTimeZone),
                 Pause23StoppedAt = string.IsNullOrEmpty(model.Pause23StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause23StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StoppedAt, userTimeZone),
                 Pause24StartedAt = string.IsNullOrEmpty(model.Pause24StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause24StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StartedAt, userTimeZone),
                 Pause24StoppedAt = string.IsNullOrEmpty(model.Pause24StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause24StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StoppedAt, userTimeZone),
                 Pause25StartedAt = string.IsNullOrEmpty(model.Pause25StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause25StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StartedAt, userTimeZone),
                 Pause25StoppedAt = string.IsNullOrEmpty(model.Pause25StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause25StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StoppedAt, userTimeZone),
                 Pause26StartedAt = string.IsNullOrEmpty(model.Pause26StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause26StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StartedAt, userTimeZone),
                 Pause26StoppedAt = string.IsNullOrEmpty(model.Pause26StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause26StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StoppedAt, userTimeZone),
                 Pause27StartedAt = string.IsNullOrEmpty(model.Pause27StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause27StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StartedAt, userTimeZone),
                 Pause27StoppedAt = string.IsNullOrEmpty(model.Pause27StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause27StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StoppedAt, userTimeZone),
                 Pause28StartedAt = string.IsNullOrEmpty(model.Pause28StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause28StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StartedAt, userTimeZone),
                 Pause28StoppedAt = string.IsNullOrEmpty(model.Pause28StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause28StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StoppedAt, userTimeZone),
                 Pause29StartedAt = string.IsNullOrEmpty(model.Pause29StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause29StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StartedAt, userTimeZone),
                 Pause29StoppedAt = string.IsNullOrEmpty(model.Pause29StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause29StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StoppedAt, userTimeZone),
                 Pause200StartedAt = string.IsNullOrEmpty(model.Pause200StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause200StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StartedAt, userTimeZone),
                 Pause200StoppedAt = string.IsNullOrEmpty(model.Pause200StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause200StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StoppedAt, userTimeZone),
                 Pause201StartedAt = string.IsNullOrEmpty(model.Pause201StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause201StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StartedAt, userTimeZone),
                 Pause201StoppedAt = string.IsNullOrEmpty(model.Pause201StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause201StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StoppedAt, userTimeZone),
                 Pause202StartedAt = string.IsNullOrEmpty(model.Pause202StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause202StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StartedAt, userTimeZone),
                 Pause202StoppedAt = string.IsNullOrEmpty(model.Pause202StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause202StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StoppedAt, userTimeZone),
 
                 Pause3StartedAt = string.IsNullOrEmpty(model.Pause3StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause3StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StartedAt, userTimeZone),
                 Pause3StoppedAt = string.IsNullOrEmpty(model.Pause3StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause3StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause3StoppedAt, userTimeZone),
 
                 Pause4StartedAt = string.IsNullOrEmpty(model.Pause4StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause4StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StartedAt, userTimeZone),
                 Pause4StoppedAt = string.IsNullOrEmpty(model.Pause4StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause4StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause4StoppedAt, userTimeZone),
 
                 Pause5StartedAt = string.IsNullOrEmpty(model.Pause5StartedAt)
                     ? null
-                    : DateTime.Parse(model.Pause5StartedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StartedAt, userTimeZone),
                 Pause5StoppedAt = string.IsNullOrEmpty(model.Pause5StoppedAt)
                     ? null
-                    : DateTime.Parse(model.Pause5StoppedAt),
+                    : WallTimeNormalizer.NormalizeToWallTime(model.Pause5StoppedAt, userTimeZone),
                 Flex = 0,
                 WorkerComment = model.CommentWorker,
                 SdkSitId = sdkSiteId!.Value,
@@ -2138,208 +2174,208 @@ public class TimePlanningWorkingHoursService(
 
             planRegistration.Start1StartedAt = string.IsNullOrEmpty(model.Start1StartedAt)
                 ? null
-                : DateTime.Parse(model.Start1StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start1StartedAt, userTimeZone);
             planRegistration.Stop1StoppedAt = string.IsNullOrEmpty(model.Stop1StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop1StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop1StoppedAt, userTimeZone);
 
             planRegistration.Start2StartedAt = string.IsNullOrEmpty(model.Start2StartedAt)
                 ? null
-                : DateTime.Parse(model.Start2StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start2StartedAt, userTimeZone);
             planRegistration.Stop2StoppedAt = string.IsNullOrEmpty(model.Stop2StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop2StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop2StoppedAt, userTimeZone);
 
             planRegistration.Start3StartedAt = string.IsNullOrEmpty(model.Start3StartedAt)
                 ? null
-                : DateTime.Parse(model.Start3StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start3StartedAt, userTimeZone);
             planRegistration.Stop3StoppedAt = string.IsNullOrEmpty(model.Stop3StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop3StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop3StoppedAt, userTimeZone);
 
             planRegistration.Start4StartedAt = string.IsNullOrEmpty(model.Start4StartedAt)
                 ? null
-                : DateTime.Parse(model.Start4StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start4StartedAt, userTimeZone);
             planRegistration.Stop4StoppedAt = string.IsNullOrEmpty(model.Stop4StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop4StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop4StoppedAt, userTimeZone);
 
             planRegistration.Start5StartedAt = string.IsNullOrEmpty(model.Start5StartedAt)
                 ? null
-                : DateTime.Parse(model.Start5StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Start5StartedAt, userTimeZone);
             planRegistration.Stop5StoppedAt = string.IsNullOrEmpty(model.Stop5StoppedAt)
                 ? null
-                : DateTime.Parse(model.Stop5StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Stop5StoppedAt, userTimeZone);
 
             planRegistration.Pause1StartedAt = string.IsNullOrEmpty(model.Pause1StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause1StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StartedAt, userTimeZone);
             planRegistration.Pause1StoppedAt = string.IsNullOrEmpty(model.Pause1StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause1StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause1StoppedAt, userTimeZone);
             planRegistration.Pause10StartedAt = string.IsNullOrEmpty(model.Pause10StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause10StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StartedAt, userTimeZone);
             planRegistration.Pause10StoppedAt = string.IsNullOrEmpty(model.Pause10StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause10StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause10StoppedAt, userTimeZone);
             planRegistration.Pause11StartedAt = string.IsNullOrEmpty(model.Pause11StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause11StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StartedAt, userTimeZone);
             planRegistration.Pause11StoppedAt = string.IsNullOrEmpty(model.Pause11StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause11StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause11StoppedAt, userTimeZone);
             planRegistration.Pause12StartedAt = string.IsNullOrEmpty(model.Pause12StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause12StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StartedAt, userTimeZone);
             planRegistration.Pause12StoppedAt = string.IsNullOrEmpty(model.Pause12StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause12StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause12StoppedAt, userTimeZone);
             planRegistration.Pause13StartedAt = string.IsNullOrEmpty(model.Pause13StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause13StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StartedAt, userTimeZone);
             planRegistration.Pause13StoppedAt = string.IsNullOrEmpty(model.Pause13StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause13StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause13StoppedAt, userTimeZone);
             planRegistration.Pause14StartedAt = string.IsNullOrEmpty(model.Pause14StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause14StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StartedAt, userTimeZone);
             planRegistration.Pause14StoppedAt = string.IsNullOrEmpty(model.Pause14StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause14StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause14StoppedAt, userTimeZone);
             planRegistration.Pause15StartedAt = string.IsNullOrEmpty(model.Pause15StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause15StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StartedAt, userTimeZone);
             planRegistration.Pause15StoppedAt = string.IsNullOrEmpty(model.Pause15StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause15StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause15StoppedAt, userTimeZone);
             planRegistration.Pause16StartedAt = string.IsNullOrEmpty(model.Pause16StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause16StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StartedAt, userTimeZone);
             planRegistration.Pause16StoppedAt = string.IsNullOrEmpty(model.Pause16StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause16StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause16StoppedAt, userTimeZone);
             planRegistration.Pause17StartedAt = string.IsNullOrEmpty(model.Pause17StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause17StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StartedAt, userTimeZone);
             planRegistration.Pause17StoppedAt = string.IsNullOrEmpty(model.Pause17StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause17StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause17StoppedAt, userTimeZone);
             planRegistration.Pause18StartedAt = string.IsNullOrEmpty(model.Pause18StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause18StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StartedAt, userTimeZone);
             planRegistration.Pause18StoppedAt = string.IsNullOrEmpty(model.Pause18StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause18StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause18StoppedAt, userTimeZone);
             planRegistration.Pause19StartedAt = string.IsNullOrEmpty(model.Pause19StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause19StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StartedAt, userTimeZone);
             planRegistration.Pause19StoppedAt = string.IsNullOrEmpty(model.Pause19StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause19StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause19StoppedAt, userTimeZone);
             planRegistration.Pause100StartedAt = string.IsNullOrEmpty(model.Pause100StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause100StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StartedAt, userTimeZone);
             planRegistration.Pause100StoppedAt = string.IsNullOrEmpty(model.Pause100StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause100StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause100StoppedAt, userTimeZone);
             planRegistration.Pause101StartedAt = string.IsNullOrEmpty(model.Pause101StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause101StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StartedAt, userTimeZone);
             planRegistration.Pause101StoppedAt = string.IsNullOrEmpty(model.Pause101StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause101StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause101StoppedAt, userTimeZone);
             planRegistration.Pause102StartedAt = string.IsNullOrEmpty(model.Pause102StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause102StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StartedAt, userTimeZone);
             planRegistration.Pause102StoppedAt = string.IsNullOrEmpty(model.Pause102StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause102StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause102StoppedAt, userTimeZone);
 
             planRegistration.Pause2StartedAt = string.IsNullOrEmpty(model.Pause2StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause2StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StartedAt, userTimeZone);
             planRegistration.Pause2StoppedAt = string.IsNullOrEmpty(model.Pause2StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause2StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause2StoppedAt, userTimeZone);
             planRegistration.Pause20StartedAt = string.IsNullOrEmpty(model.Pause20StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause20StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StartedAt, userTimeZone);
             planRegistration.Pause20StoppedAt = string.IsNullOrEmpty(model.Pause20StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause20StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause20StoppedAt, userTimeZone);
             planRegistration.Pause21StartedAt = string.IsNullOrEmpty(model.Pause21StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause21StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StartedAt, userTimeZone);
             planRegistration.Pause21StoppedAt = string.IsNullOrEmpty(model.Pause21StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause21StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause21StoppedAt, userTimeZone);
             planRegistration.Pause22StartedAt = string.IsNullOrEmpty(model.Pause22StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause22StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StartedAt, userTimeZone);
             planRegistration.Pause22StoppedAt = string.IsNullOrEmpty(model.Pause22StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause22StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause22StoppedAt, userTimeZone);
             planRegistration.Pause23StartedAt = string.IsNullOrEmpty(model.Pause23StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause23StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StartedAt, userTimeZone);
             planRegistration.Pause23StoppedAt = string.IsNullOrEmpty(model.Pause23StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause23StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause23StoppedAt, userTimeZone);
             planRegistration.Pause24StartedAt = string.IsNullOrEmpty(model.Pause24StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause24StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StartedAt, userTimeZone);
             planRegistration.Pause24StoppedAt = string.IsNullOrEmpty(model.Pause24StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause24StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause24StoppedAt, userTimeZone);
             planRegistration.Pause25StartedAt = string.IsNullOrEmpty(model.Pause25StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause25StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StartedAt, userTimeZone);
             planRegistration.Pause25StoppedAt = string.IsNullOrEmpty(model.Pause25StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause25StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause25StoppedAt, userTimeZone);
             planRegistration.Pause26StartedAt = string.IsNullOrEmpty(model.Pause26StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause26StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StartedAt, userTimeZone);
             planRegistration.Pause26StoppedAt = string.IsNullOrEmpty(model.Pause26StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause26StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause26StoppedAt, userTimeZone);
             planRegistration.Pause27StartedAt = string.IsNullOrEmpty(model.Pause27StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause27StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StartedAt, userTimeZone);
             planRegistration.Pause27StoppedAt = string.IsNullOrEmpty(model.Pause27StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause27StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause27StoppedAt, userTimeZone);
             planRegistration.Pause28StartedAt = string.IsNullOrEmpty(model.Pause28StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause28StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StartedAt, userTimeZone);
             planRegistration.Pause28StoppedAt = string.IsNullOrEmpty(model.Pause28StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause28StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause28StoppedAt, userTimeZone);
             planRegistration.Pause29StartedAt = string.IsNullOrEmpty(model.Pause29StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause29StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StartedAt, userTimeZone);
             planRegistration.Pause29StoppedAt = string.IsNullOrEmpty(model.Pause29StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause29StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause29StoppedAt, userTimeZone);
             planRegistration.Pause200StartedAt = string.IsNullOrEmpty(model.Pause200StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause200StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StartedAt, userTimeZone);
             planRegistration.Pause200StoppedAt = string.IsNullOrEmpty(model.Pause200StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause200StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause200StoppedAt, userTimeZone);
             planRegistration.Pause201StartedAt = string.IsNullOrEmpty(model.Pause201StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause201StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StartedAt, userTimeZone);
             planRegistration.Pause201StoppedAt = string.IsNullOrEmpty(model.Pause201StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause201StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause201StoppedAt, userTimeZone);
             planRegistration.Pause202StartedAt = string.IsNullOrEmpty(model.Pause202StartedAt)
                 ? null
-                : DateTime.Parse(model.Pause202StartedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StartedAt, userTimeZone);
             planRegistration.Pause202StoppedAt = string.IsNullOrEmpty(model.Pause202StoppedAt)
                 ? null
-                : DateTime.Parse(model.Pause202StoppedAt);
+                : WallTimeNormalizer.NormalizeToWallTime(model.Pause202StoppedAt, userTimeZone);
 
             planRegistration.Shift1PauseNumber = model.Shift1PauseNumber;
             planRegistration.Shift2PauseNumber = model.Shift2PauseNumber;


### PR DESCRIPTION
## Summary

Codifies **wall-time-at-rest** for the `PlanRegistration` exact-timestamp columns and enforces it at every write parse site. Full decision record: [docs/adr/0001-plan-registration-timestamps-wall-time.md](../blob/feat/one-minute-timezone-conversion/docs/adr/0001-plan-registration-timestamps-wall-time.md).

## Writer map (production evidence)

| Writer | Shape written |
|---|---|
| Punch-clock flows (app) | LOCAL wall digits (naive Dart `toString()`) |
| App edit screen ("register workday", `UseOneMinuteIntervals=1` + `UsePunchClock=0`) | **Z-suffixed UTC since the June 25 Android release** (`.toUtc().toIso8601String()`) — the only UTC writer |
| Flag-off sites | id-driven; `EnsureTimestampsFromIds` backfills wall digits from interval ids |

Classifier across all prod tenants: customer rows ~100% wall-time digits (2746 obs); version-audit oracle on tenant 986: 390 local vs 10 UTC rows, zero UTC on 1116/1124/1079; all UTC rows date July 4–7 and trace to the edit-screen path.

## Changes

- **`WallTimeNormalizer`** (new): naive input → byte-verbatim; Z/offset input → converted through the UTC instant into the current user's timezone (`IUserService.GetCurrentUserTimeZoneInfo()`, default `Europe/Copenhagen`), stored `Kind=Unspecified`.
- Applied at the gRPC plannings write path (`UpdatePlanningByCurrentUser` — the edit screen's RPC — and `UpdatePlanning`), and hardened at all 282 WorkingHours write parse sites (both overloads, create+update; kiosk overload documented default zone — no authenticated user).
- **Null-stamp id-fallback** in the flag-true projections (`ReadBySiteAndDate`, `UpdatePlanRegistrationsInPeriod`): `stamp ?? midnight+(id−1)*5min` so false→true flag flips never blank historical rows.
- No conversion anywhere on the read path — stored digits are the display truth.
- 29 new tests lock the contract (incl. DST fall-back overlap determinism + spring-forward, Dart `toString()` microsecond round-trip); wired into CI shards in both workflows.

## Red→green evidence (captured pre-fix)

| Test | Expected | Pre-fix actual |
|---|---|---|
| gRPC `UpdateByCurrentUser` Z-stamps | 06:30 / 16:00 | 04:30 / 14:00 |
| gRPC `+00:00` offset | 06:30 | 04:30 |
| gRPC `+05:30` offset (10:00+05:30) | 06:30 | 04:30 |
| gRPC `UpdatePlanning` (admin) Z | 06:30 | 04:30 |
| Kiosk CREATE Z-stamps (TZ=UTC) | 06:30 / 16:00 | 04:30 / 14:00 |
| Kiosk UPDATE Z-stamps (TZ=UTC) | 06:30 / 16:00 | 04:30 / 14:00 |
| `UpdatePlanRegistrationsInPeriod` null-stamp fallback | 06:30 / 16:00 | null / null |
| `ReadBySiteAndDate` null-stamp fallback | 06:30 / 16:00 | null / null |

All 29 green post-fix; naive-verbatim / read-verbatim / formatting / pay-band regressions green before and after.

## Out of scope

Repair of the existing UTC-corrupted rows (July 4–7, affected tenants) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)