### PR TITLE
fix(timezone): wall-time normalization at write + mode-at-registration display parity (one-minute sites)

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -252,9 +252,9 @@ jobs:
           - name: d
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
           - name: e
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
           - name: f
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.OneMinuteModeTimelineTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -241,9 +241,9 @@ jobs:
           - name: d
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
           - name: e
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
           - name: f
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceExtendedTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.OneMinuteModeTimelineTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperReadBySiteAndDateTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperTests|FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationServiceTests"
           - name: g
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/OneMinuteModeTimelineTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/OneMinuteModeTimelineTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Pure in-memory unit tests (no DB) for <see cref="OneMinuteModeTimeline"/>,
+/// the mode-at-registration resolver built from AssignedSiteVersions audit
+/// rows. Exercises every documented edge: no version rows (fallback to the
+/// current flag), flag already true in the earliest version (born-true),
+/// a single false→true flip, multiple toggles, mid-day saves governing the
+/// whole day (date-only comparison), and same-day double toggles where the
+/// last save wins.
+/// </summary>
+[TestFixture]
+public class OneMinuteModeTimelineTests
+{
+    private static readonly DateTime Origin = new(2026, 1, 1, 9, 30, 0);
+    private static readonly DateTime FlipDay = new(2026, 6, 1, 14, 45, 0); // mid-day save
+
+    private static OneMinuteModeTimeline Timeline(
+        bool fallback, params (bool Flag, DateTime SavedAt)[] versions)
+        => new(fallback, new List<(bool, DateTime)>(versions));
+
+    [Test]
+    public void NoVersionRows_FallsBackToCurrentFlag()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Timeline(true).WasOneMinuteAt(new DateTime(2020, 1, 1)), Is.True);
+            Assert.That(Timeline(true).WasOneMinuteAt(new DateTime(2030, 1, 1)), Is.True);
+            Assert.That(Timeline(false).WasOneMinuteAt(new DateTime(2026, 6, 1)), Is.False);
+        });
+    }
+
+    [Test]
+    public void BornTrue_TrueFromTheBeginningOfTime()
+    {
+        // Fallback deliberately contradicts the version row to prove the
+        // earliest version's value (not the fallback) governs all dates.
+        var timeline = Timeline(false, (true, Origin));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(DateTime.MinValue), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(-10)), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(10)), Is.True);
+        });
+    }
+
+    [Test]
+    public void SingleFlip_FalseThenTrue_SplitsOnTheSaveDate()
+    {
+        var timeline = Timeline(true, (false, Origin), (true, FlipDay));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(-1)), Is.False,
+                "Dates before the earliest version take the earliest value.");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 5, 31)), Is.False,
+                "The day before the flip stays 5-minute.");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 6, 1)), Is.True,
+                "A mid-day (14:45) flip governs the WHOLE flip day (date-only rule).");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 6, 2)), Is.True);
+        });
+    }
+
+    [Test]
+    public void ConsecutiveDuplicateVersions_ProduceNoChangePoints()
+    {
+        // Every AssignedSite edit writes a version row; most don't touch the
+        // flag. Duplicates must not create change points.
+        var timeline = Timeline(true,
+            (false, Origin),
+            (false, Origin.AddMonths(1)),
+            (false, Origin.AddMonths(2)),
+            (true, FlipDay),
+            (true, FlipDay.AddDays(3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(Origin.AddMonths(2)), Is.False);
+            Assert.That(timeline.WasOneMinuteAt(FlipDay), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(FlipDay.AddDays(10)), Is.True);
+        });
+    }
+
+    [Test]
+    public void MultiToggle_IntervalWalk()
+    {
+        var backDay = new DateTime(2026, 8, 15, 8, 0, 0);
+        var reFlipDay = new DateTime(2026, 11, 3, 16, 20, 0);
+        var timeline = Timeline(true,
+            (false, Origin), (true, FlipDay), (false, backDay), (true, reFlipDay));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 3, 1)), Is.False);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 7, 1)), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 8, 15)), Is.False);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 10, 1)), Is.False);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 11, 3)), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2027, 1, 1)), Is.True);
+        });
+    }
+
+    [Test]
+    public void SameDayDoubleToggle_LastSaveWins()
+    {
+        var timeline = Timeline(true,
+            (false, Origin),
+            (true, new DateTime(2026, 6, 1, 10, 0, 0)),
+            (false, new DateTime(2026, 6, 1, 11, 0, 0)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 6, 1)), Is.False,
+                "Two toggles saved the same day: the LAST save governs that day.");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 6, 2)), Is.False);
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 5, 31)), Is.False);
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/OneMinuteModeTimelineTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/OneMinuteModeTimelineTests.cs
@@ -11,8 +11,9 @@ namespace TimePlanning.Pn.Test;
 /// rows. Exercises every documented edge: no version rows (fallback to the
 /// current flag), flag already true in the earliest version (born-true),
 /// a single false→true flip, multiple toggles, mid-day saves governing the
-/// whole day (date-only comparison), and same-day double toggles where the
-/// last save wins.
+/// whole day (date-only comparison), same-day double toggles where the
+/// last save wins, and the divergence correction (trail flipped outside the
+/// audited path → current flag wins from the last audited save date).
 /// </summary>
 [TestFixture]
 public class OneMinuteModeTimelineTests
@@ -38,14 +39,35 @@ public class OneMinuteModeTimelineTests
     [Test]
     public void BornTrue_TrueFromTheBeginningOfTime()
     {
-        // Fallback deliberately contradicts the version row to prove the
-        // earliest version's value (not the fallback) governs all dates.
-        var timeline = Timeline(false, (true, Origin));
+        var timeline = Timeline(true, (true, Origin));
         Assert.Multiple(() =>
         {
             Assert.That(timeline.WasOneMinuteAt(DateTime.MinValue), Is.True);
-            Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(-10)), Is.True);
+            Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(-10)), Is.True,
+                "Dates before the first version row take the earliest version's value.");
             Assert.That(timeline.WasOneMinuteAt(Origin.AddYears(10)), Is.True);
+        });
+    }
+
+    /// <summary>
+    /// Divergence correction: the audit trail ends on false but the entity's
+    /// CURRENT flag is true — the flip happened outside the audited path
+    /// (raw-SQL ops change, or a seed dump predating the column; the l1m CI
+    /// shard is exactly this shape). The current flag must take over from the
+    /// LAST audited save date; audited history before it is preserved.
+    /// </summary>
+    [Test]
+    public void TrailDivergesFromCurrentFlag_CurrentFlagWinsFromLastAuditedSave()
+    {
+        var lastSave = new DateTime(2026, 3, 10, 9, 0, 0);
+        var timeline = Timeline(true, (false, Origin), (false, lastSave));
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 2, 1)), Is.False,
+                "Audited pre-divergence history stays authoritative.");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 3, 10)), Is.True,
+                "From the last audited save date the CURRENT flag governs.");
+            Assert.That(timeline.WasOneMinuteAt(new DateTime(2026, 7, 1)), Is.True);
         });
     }
 
@@ -105,7 +127,9 @@ public class OneMinuteModeTimelineTests
     [Test]
     public void SameDayDoubleToggle_LastSaveWins()
     {
-        var timeline = Timeline(true,
+        // Current flag false — consistent with the trail's last save, so the
+        // divergence correction stays inert and pure save-order rules apply.
+        var timeline = Timeline(false,
             (false, Origin),
             (true, new DateTime(2026, 6, 1, 10, 0, 0)),
             (false, new DateTime(2026, 6, 1, 11, 0, 0)));

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperDisplayParityTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperDisplayParityTests.cs
@@ -1,0 +1,439 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Helpers;
+using TimePlanning.Pn.Infrastructure.Models.Planning;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Services.TimePlanningPlanningService;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Stage 3 tick-exact display parity for the plannings projection
+/// (<see cref="PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod"/>).
+///
+/// The mode a row was REGISTERED under — resolved per row from the
+/// AssignedSiteVersions audit trail via <see cref="OneMinuteModeTimeline"/>,
+/// NOT the site's current flag — decides its Start/Stop rendering:
+///  - tick row (5-minute mode at registration): ALWAYS the Id-derived tick
+///    time, even when exact device stamps coexist on the row — bit-identical
+///    to what the row showed before a site flip;
+///  - one-minute row: the exact stamp first, falling back to the Id-derived
+///    time (<c>stamp ?? (id &gt; 0 ? midnight + (id*5 - 5) min : null)</c>)
+///    so a row never renders blank while an Id exists.
+///
+/// ReadBySiteAndDate is deliberately given NO synthesis at all: it feeds the
+/// app's read-modify-write loop (getPlanRegistrationForDate → the funnel
+/// echoes the whole registration back on save), so a stamp synthesized there
+/// would be persisted to the DB on the next save — de-facto data modification.
+/// The last test locks that no-echo-materialization guarantee.
+/// </summary>
+[TestFixture]
+public class PlanRegistrationHelperDisplayParityTests : TestBaseSetup
+{
+    private IPluginDbOptions<TimePlanningBaseSettings> _options;
+
+    [SetUp]
+    public void SetUpOptions()
+    {
+        _options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        _options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+    }
+
+    private async Task<TimePlanningPlanningPrDayModel> ProjectSingleDay(
+        AssignedSiteEntity assignedSite, DateTime date)
+    {
+        // Re-pull the registration the same shape Index() does (Id + Date only —
+        // UpdatePlanRegistrationsInPeriod re-fetches the full row internally).
+        var planningsInPeriod = await TimePlanningPnDbContext.PlanRegistrations
+            .AsNoTracking()
+            .Where(x => x.SdkSitId == assignedSite.SiteId)
+            .Select(x => new PlanRegistration { Id = x.Id, Date = x.Date })
+            .ToListAsync();
+
+        var siteModel = new TimePlanningPlanningModel
+        {
+            SiteId = assignedSite.SiteId,
+            SiteName = $"Test site {assignedSite.SiteId}",
+            UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals,
+            PlanningPrDayModels = new List<TimePlanningPlanningPrDayModel>()
+        };
+        var sdkSite = new SdkSite
+        {
+            Name = $"Test site {assignedSite.SiteId}",
+            MicrotingUid = assignedSite.SiteId
+        };
+
+        var result = await PlanRegistrationHelper.UpdatePlanRegistrationsInPeriod(
+            planningsInPeriod,
+            siteModel,
+            TimePlanningPnDbContext,
+            assignedSite,
+            Substitute.For<ILogger<TimePlanningPlanningService>>(),
+            sdkSite,
+            date.AddDays(-1),
+            date.AddDays(1),
+            _options);
+
+        return result.PlanningPrDayModels.Single(x => x.Date.Date == date.Date);
+    }
+
+    /// <summary>
+    /// (a) One-minute site, NULL stamps but interval Ids &gt; 0 on all 5 shifts
+    /// (the 5-minute-mode legacy shape) → the projection shows the Id-derived
+    /// times, exactly like the Excel export: midnight + (Id*5 - 5) minutes.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_OneMinuteSite_NullStampsWithIds_ProjectsIdDerivedTimes()
+    {
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 910,
+            UseOneMinuteIntervals = true,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var date = new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc); // Wednesday
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 910,
+            Date = date,
+            // 5-minute-mode legacy shape: Ids only, no exact stamps.
+            // Id 97 → 08:00, 121 → 10:00, 133 → 11:00, 157 → 13:00,
+            // 169 → 14:00, 181 → 15:00, 193 → 16:00, 205 → 17:00,
+            // 217 → 18:00, 229 → 19:00 (midnight + (Id-1)*5 min).
+            Start1Id = 97, Stop1Id = 121,
+            Start2Id = 133, Stop2Id = 157,
+            Start3Id = 169, Stop3Id = 181,
+            Start4Id = 193, Stop4Id = 205,
+            Start5Id = 217, Stop5Id = 229,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        var prDay = await ProjectSingleDay(assignedSite, date);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.EqualTo(date.AddHours(8)),
+                "Start1: NULL stamp + Id 97 must project 08:00.");
+            Assert.That(prDay.Stop1StoppedAt, Is.EqualTo(date.AddHours(10)),
+                "Stop1: NULL stamp + Id 121 must project 10:00.");
+            Assert.That(prDay.Start2StartedAt, Is.EqualTo(date.AddHours(11)),
+                "Start2: NULL stamp + Id 133 must project 11:00.");
+            Assert.That(prDay.Stop2StoppedAt, Is.EqualTo(date.AddHours(13)),
+                "Stop2: NULL stamp + Id 157 must project 13:00.");
+            Assert.That(prDay.Start3StartedAt, Is.EqualTo(date.AddHours(14)),
+                "Start3: NULL stamp + Id 169 must project 14:00.");
+            Assert.That(prDay.Stop3StoppedAt, Is.EqualTo(date.AddHours(15)),
+                "Stop3: NULL stamp + Id 181 must project 15:00.");
+            Assert.That(prDay.Start4StartedAt, Is.EqualTo(date.AddHours(16)),
+                "Start4: NULL stamp + Id 193 must project 16:00.");
+            Assert.That(prDay.Stop4StoppedAt, Is.EqualTo(date.AddHours(17)),
+                "Stop4: NULL stamp + Id 205 must project 17:00.");
+            Assert.That(prDay.Start5StartedAt, Is.EqualTo(date.AddHours(18)),
+                "Start5: NULL stamp + Id 217 must project 18:00.");
+            Assert.That(prDay.Stop5StoppedAt, Is.EqualTo(date.AddHours(19)),
+                "Stop5: NULL stamp + Id 229 must project 19:00.");
+        });
+    }
+
+    /// <summary>
+    /// (b) One-minute site, exact stamps present alongside Ids → the exact
+    /// stamps win unchanged. The stamps deliberately sit OFF the 5-minute grid
+    /// (08:07/16:03) so an accidental Id-derivation would be caught.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_OneMinuteSite_StampsPresent_StampsWinUnchanged()
+    {
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 911,
+            UseOneMinuteIntervals = true,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var date = new DateTime(2026, 5, 21, 0, 0, 0, DateTimeKind.Utc); // Thursday
+        var start = date.AddHours(8).AddMinutes(7);
+        var stop = date.AddHours(16).AddMinutes(3);
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 911,
+            Date = date,
+            Start1StartedAt = start,
+            Stop1StoppedAt = stop,
+            Start1Id = 97,   // 08:00 in the 5-min grid — must NOT override 08:07
+            Stop1Id = 193,   // 16:00 in the 5-min grid — must NOT override 16:03
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        var prDay = await ProjectSingleDay(assignedSite, date);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.EqualTo(start),
+                "Exact stamp 08:07 must win over the Id-derived 08:00.");
+            Assert.That(prDay.Stop1StoppedAt, Is.EqualTo(stop),
+                "Exact stamp 16:03 must win over the Id-derived 16:00.");
+        });
+    }
+
+    /// <summary>
+    /// (c) One-minute site, Ids = 0 and NULL stamps → the projection stays
+    /// NULL; the fallback must not fabricate times for untouched shifts.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_OneMinuteSite_ZeroIdsAndNullStamps_ProjectsNull()
+    {
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 912,
+            UseOneMinuteIntervals = true,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var date = new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc); // Friday
+        var planning = new PlanRegistration
+        {
+            SdkSitId = 912,
+            Date = date,
+            // Everything untouched: all Ids 0, all stamps NULL.
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        var prDay = await ProjectSingleDay(assignedSite, date);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.Null);
+            Assert.That(prDay.Stop1StoppedAt, Is.Null);
+            Assert.That(prDay.Start2StartedAt, Is.Null);
+            Assert.That(prDay.Stop2StoppedAt, Is.Null);
+            Assert.That(prDay.Start3StartedAt, Is.Null);
+            Assert.That(prDay.Stop3StoppedAt, Is.Null);
+            Assert.That(prDay.Start4StartedAt, Is.Null);
+            Assert.That(prDay.Stop4StoppedAt, Is.Null);
+            Assert.That(prDay.Start5StartedAt, Is.Null);
+            Assert.That(prDay.Stop5StoppedAt, Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// Seeds an AssignedSite whose flag flipped false→true saved mid-day on
+    /// <paramref name="flipDate"/>, with a fully controlled AssignedSiteVersions
+    /// audit trail. The site and its version rows are inserted through the raw
+    /// DbSets (NOT PnBase.Create/Update) so the version rows' UpdatedAt values
+    /// — the save times the timeline reconstructs change points from — are
+    /// exactly the test's chosen dates. Mirrors the prod schema quirk: the
+    /// version rows' CreatedAt is a COPY of the base entity's creation time.
+    /// </summary>
+    private async Task<AssignedSiteEntity> CreateSiteWithFlipHistory(int siteId, DateTime flipDate)
+    {
+        var createdAt = flipDate.AddYears(-1);
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = siteId,
+            UseOneMinuteIntervals = true, // current flag (post-flip)
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+            CreatedAt = createdAt,
+            UpdatedAt = flipDate,
+            Version = 2
+        };
+        TimePlanningPnDbContext.AssignedSites.Add(assignedSite);
+        await TimePlanningPnDbContext.SaveChangesAsync();
+
+        TimePlanningPnDbContext.AssignedSiteVersions.AddRange(
+            new AssignedSiteVersion
+            {
+                AssignedSiteId = assignedSite.Id,
+                SiteId = siteId,
+                UseOneMinuteIntervals = false,
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt, // saved at creation
+                Version = 1
+            },
+            new AssignedSiteVersion
+            {
+                AssignedSiteId = assignedSite.Id,
+                SiteId = siteId,
+                UseOneMinuteIntervals = true,
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedAt = createdAt, // prod quirk: copies the BASE CreatedAt
+                UpdatedAt = flipDate.Date.AddHours(14).AddMinutes(45), // mid-day save
+                Version = 2
+            });
+        await TimePlanningPnDbContext.SaveChangesAsync();
+        return assignedSite;
+    }
+
+    /// <summary>
+    /// Tick-exact parity across a flag flip: rows registered BEFORE the flip
+    /// (5-minute mode) must render their Id-derived tick times even though
+    /// exact off-grid stamps exist on the rows; rows registered AFTER the flip
+    /// render their exact stamps. Id 98 → 08:05, Id 193 → 16:00; the stamps
+    /// deliberately sit off the tick grid (08:07/16:03) so any wrong-leg
+    /// routing is caught.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_FlippedSite_PreFlipRowsTick_PostFlipRowsStamp()
+    {
+        var flipDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var assignedSite = await CreateSiteWithFlipHistory(915, flipDate);
+
+        var preFlipDate = new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc);
+        var postFlipDate = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc);
+        foreach (var date in new[] { preFlipDate, postFlipDate })
+        {
+            await new PlanRegistration
+            {
+                SdkSitId = 915,
+                Date = date,
+                // Both rows carry BOTH representations, exactly like real rows
+                // recorded by the device: tick ids plus exact wall-clock stamps.
+                Start1Id = 98,   // 08:05 on the 5-min grid
+                Stop1Id = 193,   // 16:00 on the 5-min grid
+                Start1StartedAt = date.AddHours(8).AddMinutes(7),
+                Stop1StoppedAt = date.AddHours(16).AddMinutes(3),
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            }.Create(TimePlanningPnDbContext);
+        }
+
+        var preFlipDay = await ProjectSingleDay(assignedSite, preFlipDate);
+        var postFlipDay = await ProjectSingleDay(assignedSite, postFlipDate);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(preFlipDay.Start1StartedAt, Is.EqualTo(preFlipDate.AddHours(8).AddMinutes(5)),
+                "Pre-flip (tick) row: Id-derived 08:05 must win over the exact stamp 08:07.");
+            Assert.That(preFlipDay.Stop1StoppedAt, Is.EqualTo(preFlipDate.AddHours(16)),
+                "Pre-flip (tick) row: Id-derived 16:00 must win over the exact stamp 16:03.");
+            Assert.That(postFlipDay.Start1StartedAt, Is.EqualTo(postFlipDate.AddHours(8).AddMinutes(7)),
+                "Post-flip (one-minute) row: the exact stamp 08:07 must win.");
+            Assert.That(postFlipDay.Stop1StoppedAt, Is.EqualTo(postFlipDate.AddHours(16).AddMinutes(3)),
+                "Post-flip (one-minute) row: the exact stamp 16:03 must win.");
+        });
+    }
+
+    /// <summary>
+    /// Regression: a never-flipped 5-minute site (flag false, born false) keeps
+    /// rendering Id-derived tick times — including for rows that carry exact
+    /// stamps. This is the pre-stage-3 false-leg behavior, now routed through
+    /// the per-row timeline (which is constant-false for such a site).
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_NeverFlippedFiveMinuteSite_RendersIdDerivedTimes()
+    {
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = 916,
+            UseOneMinuteIntervals = false,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await assignedSite.Create(TimePlanningPnDbContext);
+
+        var date = new DateTime(2026, 5, 25, 0, 0, 0, DateTimeKind.Utc); // Monday
+        await new PlanRegistration
+        {
+            SdkSitId = 916,
+            Date = date,
+            Start1Id = 98,   // 08:05
+            Stop1Id = 193,   // 16:00
+            Start1StartedAt = date.AddHours(8).AddMinutes(7), // must NOT surface
+            Stop1StoppedAt = date.AddHours(16).AddMinutes(3), // must NOT surface
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        }.Create(TimePlanningPnDbContext);
+
+        var prDay = await ProjectSingleDay(assignedSite, date);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prDay.Start1StartedAt, Is.EqualTo(date.AddHours(8).AddMinutes(5)));
+            Assert.That(prDay.Stop1StoppedAt, Is.EqualTo(date.AddHours(16)));
+        });
+    }
+
+    /// <summary>
+    /// No-echo-materialization guard: ReadBySiteAndDate must return NULL
+    /// stamps VERBATIM even when interval Ids exist.
+    ///
+    /// This projection feeds the app's read-modify-write loop
+    /// (getPlanRegistrationForDate → the shift-confirm funnel echoes the whole
+    /// registration back on the next save). If ReadBySiteAndDate synthesized a
+    /// stamp from the Id, that fabricated value would be PERSISTED to the DB on
+    /// the next save — de-facto data modification from a read path. Display
+    /// parity therefore lives only in UpdatePlanRegistrationsInPeriod (a pure
+    /// display projection); this test pins ReadBySiteAndDate to the raw row.
+    /// </summary>
+    [Test]
+    public async Task ReadBySiteAndDate_NullStampsWithIds_ReturnsNullStampsVerbatim()
+    {
+        var sdkSiteId = 913;
+        var date = new DateTime(2026, 5, 23, 0, 0, 0, DateTimeKind.Utc); // Saturday
+        var planning = new PlanRegistration
+        {
+            SdkSitId = sdkSiteId,
+            Date = date,
+            // 5-minute-mode legacy shape: Ids only, no exact stamps.
+            Start1Id = 97, Stop1Id = 193,
+            Start2Id = 205, Stop2Id = 217,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await planning.Create(TimePlanningPnDbContext);
+
+        var result = await PlanRegistrationHelper.ReadBySiteAndDate(
+            TimePlanningPnDbContext, sdkSiteId, date, null);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            // Ids pass through untouched...
+            Assert.That(result.Shift1Start, Is.EqualTo(97));
+            Assert.That(result.Shift1Stop, Is.EqualTo(193));
+            Assert.That(result.Shift2Start, Is.EqualTo(205));
+            Assert.That(result.Shift2Stop, Is.EqualTo(217));
+            // ...but the NULL stamps stay NULL — never Id-derived.
+            Assert.That(result.Start1StartedAt, Is.Null,
+                "ReadBySiteAndDate must NOT synthesize Start1StartedAt from Start1Id.");
+            Assert.That(result.Stop1StoppedAt, Is.Null,
+                "ReadBySiteAndDate must NOT synthesize Stop1StoppedAt from Stop1Id.");
+            Assert.That(result.Start2StartedAt, Is.Null,
+                "ReadBySiteAndDate must NOT synthesize Start2StartedAt from Start2Id.");
+            Assert.That(result.Stop2StoppedAt, Is.Null,
+                "ReadBySiteAndDate must NOT synthesize Stop2StoppedAt from Stop2Id.");
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperDisplayParityTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PlanRegistrationHelperDisplayParityTests.cs
@@ -386,6 +386,68 @@ public class PlanRegistrationHelperDisplayParityTests : TestBaseSetup
     }
 
     /// <summary>
+    /// Write-time mode marker (RegisteredUnderOneMinuteIntervals) beats the
+    /// AssignedSiteVersions timeline in BOTH directions; the timeline only
+    /// resolves legacy rows whose marker is NULL:
+    ///  - marker=true on a pre-flip-DATED row (the l1m scenario: an admin
+    ///    exact-minute edit AFTER the flip re-registers the row under
+    ///    one-minute mode) → exact stamps render;
+    ///  - marker NULL on a pre-flip row (untouched legacy row) → ticks;
+    ///  - marker=false on a post-flip-DATED row (written under 5-minute mode)
+    ///    → ticks even though the timeline says one-minute.
+    /// </summary>
+    [Test]
+    public async Task UpdatePlanRegistrationsInPeriod_WriteTimeMarker_WinsOverTimeline()
+    {
+        var flipDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var assignedSite = await CreateSiteWithFlipHistory(918, flipDate);
+
+        var markerTrueDate = new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc);  // pre-flip
+        var markerNullDate = new DateTime(2026, 5, 21, 0, 0, 0, DateTimeKind.Utc);  // pre-flip
+        var markerFalseDate = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc); // post-flip
+        foreach (var (date, marker) in new (DateTime, bool?)[]
+                 {
+                     (markerTrueDate, true),
+                     (markerNullDate, null),
+                     (markerFalseDate, false)
+                 })
+        {
+            await new PlanRegistration
+            {
+                SdkSitId = 918,
+                Date = date,
+                Start1Id = 98,   // 08:05 on the 5-min grid
+                Stop1Id = 193,   // 16:00 on the 5-min grid
+                Start1StartedAt = date.AddHours(8).AddMinutes(7),
+                Stop1StoppedAt = date.AddHours(16).AddMinutes(3),
+                RegisteredUnderOneMinuteIntervals = marker,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            }.Create(TimePlanningPnDbContext);
+        }
+
+        var markerTrueDay = await ProjectSingleDay(assignedSite, markerTrueDate);
+        var markerNullDay = await ProjectSingleDay(assignedSite, markerNullDate);
+        var markerFalseDay = await ProjectSingleDay(assignedSite, markerFalseDate);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(markerTrueDay.Start1StartedAt, Is.EqualTo(markerTrueDate.AddHours(8).AddMinutes(7)),
+                "marker=true (admin exact edit) on a pre-flip day must render the exact stamp 08:07.");
+            Assert.That(markerTrueDay.Stop1StoppedAt, Is.EqualTo(markerTrueDate.AddHours(16).AddMinutes(3)),
+                "marker=true (admin exact edit) on a pre-flip day must render the exact stamp 16:03.");
+            Assert.That(markerNullDay.Start1StartedAt, Is.EqualTo(markerNullDate.AddHours(8).AddMinutes(5)),
+                "marker NULL (untouched legacy row) resolves via the timeline → tick 08:05.");
+            Assert.That(markerNullDay.Stop1StoppedAt, Is.EqualTo(markerNullDate.AddHours(16)),
+                "marker NULL (untouched legacy row) resolves via the timeline → tick 16:00.");
+            Assert.That(markerFalseDay.Start1StartedAt, Is.EqualTo(markerFalseDate.AddHours(8).AddMinutes(5)),
+                "marker=false must render ticks even on a date the timeline says is one-minute.");
+            Assert.That(markerFalseDay.Stop1StoppedAt, Is.EqualTo(markerFalseDate.AddHours(16)),
+                "marker=false must render ticks even on a date the timeline says is one-minute.");
+        });
+    }
+
+    /// <summary>
     /// No-echo-materialization guard: ReadBySiteAndDate must return NULL
     /// stamps VERBATIM even when interval Ids exist.
     ///

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursDisplayParityTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursDisplayParityTests.cs
@@ -259,6 +259,71 @@ public class WorkingHoursDisplayParityTests : TestBaseSetup
         });
     }
 
+    /// <summary>
+    /// Write-time mode marker beats the timeline on the working-hours surface
+    /// too (Index DTO → web grid, Excel cells, pay lines): a pre-flip-DATED row
+    /// whose marker is true (admin exact edit after the flip — the l1m
+    /// scenario) surfaces its exact stamps; a post-flip-DATED row whose marker
+    /// is false surfaces ticks.
+    /// </summary>
+    [Test]
+    public async Task Index_WriteTimeMarker_WinsOverTimeline()
+    {
+        const int siteUid = 919;
+        var flipDate = new DateTime(2026, 6, 1);
+        var markerTrueDate = new DateTime(2026, 5, 20);  // pre-flip, marker=true
+        var markerFalseDate = new DateTime(2026, 6, 10); // post-flip, marker=false
+
+        await SeedSdkSite(siteUid);
+        await SeedFlippedAssignedSite(siteUid, flipDate);
+        foreach (var (date, marker) in new (DateTime, bool?)[]
+                 {
+                     (markerTrueDate, true),
+                     (markerFalseDate, false)
+                 })
+        {
+            await new PlanRegistrationEntity
+            {
+                SdkSitId = siteUid,
+                Date = date,
+                Start1Id = 98,   // 08:05
+                Stop1Id = 193,   // 16:00
+                Start1StartedAt = date.AddHours(8).AddMinutes(7),
+                Stop1StoppedAt = date.AddHours(16).AddMinutes(3),
+                RegisteredUnderOneMinuteIntervals = marker,
+                PlanText = "",
+                CommentOffice = "",
+                CommentOfficeAll = "",
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            }.Create(TimePlanningPnDbContext!);
+        }
+
+        var result = await _service.Index(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = siteUid,
+            DateFrom = markerTrueDate,
+            DateTo = markerFalseDate
+        });
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var markerTrueDay = result.Model.Single(x => x.Date == markerTrueDate);
+        var markerFalseDay = result.Model.Single(x => x.Date == markerFalseDate);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(markerTrueDay.Start1StartedAt, Is.EqualTo(markerTrueDate.AddHours(8).AddMinutes(7)),
+                "marker=true pre-flip row: Index must surface the exact 08:07 stamp.");
+            Assert.That(markerTrueDay.Stop1StoppedAt, Is.EqualTo(markerTrueDate.AddHours(16).AddMinutes(3)),
+                "marker=true pre-flip row: Index must surface the exact 16:03 stamp.");
+            Assert.That(markerFalseDay.Start1StartedAt, Is.EqualTo(markerFalseDate.AddHours(8).AddMinutes(5)),
+                "marker=false post-flip row: Index must surface the tick 08:05.");
+            Assert.That(markerFalseDay.Stop1StoppedAt, Is.EqualTo(markerFalseDate.AddHours(16)),
+                "marker=false post-flip row: Index must surface the tick 16:00.");
+        });
+    }
+
     // ------------------------------------------------------------------
     // Seed helpers
     // ------------------------------------------------------------------

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursDisplayParityTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/WorkingHoursDisplayParityTests.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.TimePlanningBase.Infrastructure.Data.Entities;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.Index;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using PlanRegistrationEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration;
+using SdkLanguage = Microting.eForm.Infrastructure.Data.Entities.Language;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using SdkSiteWorker = Microting.eForm.Infrastructure.Data.Entities.SiteWorker;
+using SdkWorker = Microting.eForm.Infrastructure.Data.Entities.Worker;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Stage 3 tick-exact parity on the working-hours surfaces
+/// (<see cref="TimePlanningWorkingHoursService"/>): a row registered under
+/// 5-minute mode must keep rendering AND totalling its tick times on every
+/// surface — Index DTO stamps (web grid + pay-line feed), Excel day cells
+/// (GetShiftTime / GetShiftTimeFraction with the PER-ROW mode), and time-band
+/// pay lines (CalculatePayLinesForDay over the normalized DTO) — even after
+/// the site flips UseOneMinuteIntervals to true. The per-row mode comes from
+/// the AssignedSiteVersions audit trail (OneMinuteModeTimeline); the Index
+/// normalization itself lives in ApplyModeAtRegistrationStamps.
+/// </summary>
+[TestFixture]
+public class WorkingHoursDisplayParityTests : TestBaseSetup
+{
+    private TimePlanningWorkingHoursService _service = null!;
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+
+        var localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        var coreService = Substitute.For<IEFormCoreService>();
+        var core = await GetCore();
+        coreService.GetCore().Returns(core);
+
+        var sdkDb = core.DbContextHelper.GetDbContext();
+        var language = await sdkDb.Languages.FirstOrDefaultAsync(l => l.LanguageCode == "da");
+        if (language == null)
+        {
+            language = new SdkLanguage { LanguageCode = "da", Name = "Danish" };
+            await language.Create(sdkDb);
+        }
+        userService.GetCurrentUserLanguage().Returns(language);
+
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
+        _service = new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            TimePlanningPnDbContext!,
+            userService,
+            localizationService,
+            baseDbContext: null!,
+            options,
+            coreService);
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Pure helpers: per-row mode drives the Excel cell formatters.
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// GetShiftTime's flag argument is now the PER-ROW mode at registration:
+    /// a tick row (false) formats from the Id even when an exact stamp is
+    /// available; a one-minute row (true) formats the stamp.
+    /// </summary>
+    [Test]
+    public void GetShiftTime_PerRowMode_TickRowFormatsFromId_OneMinuteRowFromStamp()
+    {
+        var plr = new PlanRegistrationEntity();
+        var stamp = new DateTime(2026, 5, 20, 8, 7, 0); // off-grid on purpose
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_service.GetShiftTime(plr, 98, stamp, useOneMinuteIntervals: false),
+                Is.EqualTo("08:05"),
+                "Tick row: Id 98 → 08:05 must win over the exact stamp 08:07.");
+            Assert.That(_service.GetShiftTime(plr, 98, stamp, useOneMinuteIntervals: true),
+                Is.EqualTo("08:07"),
+                "One-minute row: the exact stamp must win.");
+            // Tick edge kept intact: Id 289 = 24:00 (don't-wrap convention).
+            Assert.That(_service.GetShiftTime(plr, 289, stamp, useOneMinuteIntervals: false),
+                Is.EqualTo("24:00"));
+        });
+    }
+
+    /// <summary>Same per-row rule for the Dagsoversigt day-fraction cells.</summary>
+    [Test]
+    public void GetShiftTimeFraction_PerRowMode_TickRowFromId_OneMinuteRowFromStamp()
+    {
+        var stamp = new DateTime(2026, 5, 20, 8, 7, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_service.GetShiftTimeFraction(98, stamp, useOneMinuteIntervals: false)!.Value,
+                Is.EqualTo((8 * 60 + 5) / 1440.0).Within(1e-9),
+                "Tick row: fraction derives from Id 98 → 08:05.");
+            Assert.That(_service.GetShiftTimeFraction(98, stamp, useOneMinuteIntervals: true)!.Value,
+                Is.EqualTo((8 * 60 + 7) / 1440.0).Within(1e-9),
+                "One-minute row: fraction derives from the exact stamp 08:07.");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. DTO normalization: ApplyModeAtRegistrationStamps.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void ApplyModeAtRegistrationStamps_TickRow_OverwritesStampsWithIdDerived()
+    {
+        var date = new DateTime(2026, 5, 20);
+        var day = new TimePlanningWorkingHoursModel
+        {
+            Date = date,
+            Shift1Start = 98, Shift1Stop = 193,
+            Start1StartedAt = date.AddHours(8).AddMinutes(7),
+            Stop1StoppedAt = date.AddHours(16).AddMinutes(3),
+            // Shift 2 untouched (ids 0) but carrying a stray stamp: a tick row's
+            // truth is its ids, so the stamp must clear (pre-flip it never
+            // rendered nor summed either — id path showed blank).
+            Start2StartedAt = date.AddHours(18)
+        };
+
+        TimePlanningWorkingHoursService.ApplyModeAtRegistrationStamps(day, rowIsOneMinute: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(day.Start1StartedAt, Is.EqualTo(date.AddHours(8).AddMinutes(5)));
+            Assert.That(day.Stop1StoppedAt, Is.EqualTo(date.AddHours(16)));
+            Assert.That(day.Start2StartedAt, Is.Null);
+            Assert.That(day.Stop2StoppedAt, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ApplyModeAtRegistrationStamps_OneMinuteRow_StampsWin_NullsFallBackToIds()
+    {
+        var date = new DateTime(2026, 6, 10);
+        var day = new TimePlanningWorkingHoursModel
+        {
+            Date = date,
+            Shift1Start = 98, Shift1Stop = 193,
+            Start1StartedAt = date.AddHours(8).AddMinutes(7), // exact stamp wins
+            Stop1StoppedAt = null,                            // falls back to Id 193
+            Shift2Start = 205, Shift2Stop = 0                 // 17:00 fallback / null
+        };
+
+        TimePlanningWorkingHoursService.ApplyModeAtRegistrationStamps(day, rowIsOneMinute: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(day.Start1StartedAt, Is.EqualTo(date.AddHours(8).AddMinutes(7)));
+            Assert.That(day.Stop1StoppedAt, Is.EqualTo(date.AddHours(16)));
+            Assert.That(day.Start2StartedAt, Is.EqualTo(date.AddHours(17)));
+            Assert.That(day.Stop2StoppedAt, Is.Null);
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 3. End-to-end: Index normalizes per-row; pay lines total tick seconds
+    //    for pre-flip rows and exact seconds for post-flip rows.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Index_FlippedSite_PreFlipRowTickStamps_PostFlipRowExactStamps_AndPayLineSeconds()
+    {
+        const int siteUid = 917;
+        var flipDate = new DateTime(2026, 6, 1);
+        var preFlipDate = new DateTime(2026, 5, 20);  // Wednesday, before flip
+        var postFlipDate = new DateTime(2026, 6, 10); // Wednesday, after flip
+
+        await SeedSdkSite(siteUid);
+        await SeedFlippedAssignedSite(siteUid, flipDate);
+        foreach (var date in new[] { preFlipDate, postFlipDate })
+        {
+            await new PlanRegistrationEntity
+            {
+                SdkSitId = siteUid,
+                Date = date,
+                Start1Id = 98,   // 08:05
+                Stop1Id = 193,   // 16:00
+                Start1StartedAt = date.AddHours(8).AddMinutes(7),
+                Stop1StoppedAt = date.AddHours(16).AddMinutes(3),
+                PlanText = "",
+                CommentOffice = "",
+                CommentOfficeAll = "",
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedByUserId = 1,
+                UpdatedByUserId = 1
+            }.Create(TimePlanningPnDbContext!);
+        }
+
+        var result = await _service.Index(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = siteUid,
+            DateFrom = preFlipDate,
+            DateTo = postFlipDate
+        });
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var preFlipDay = result.Model.Single(x => x.Date == preFlipDate);
+        var postFlipDay = result.Model.Single(x => x.Date == postFlipDate);
+
+        Assert.Multiple(() =>
+        {
+            // Web grid / pay-line feed: pre-flip row carries TICK stamps...
+            Assert.That(preFlipDay.Start1StartedAt, Is.EqualTo(preFlipDate.AddHours(8).AddMinutes(5)),
+                "Pre-flip (tick) row: Index must surface the Id-derived 08:05, not the raw 08:07 stamp.");
+            Assert.That(preFlipDay.Stop1StoppedAt, Is.EqualTo(preFlipDate.AddHours(16)),
+                "Pre-flip (tick) row: Index must surface the Id-derived 16:00, not the raw 16:03 stamp.");
+            // ...while the post-flip row keeps its exact stamps.
+            Assert.That(postFlipDay.Start1StartedAt, Is.EqualTo(postFlipDate.AddHours(8).AddMinutes(7)));
+            Assert.That(postFlipDay.Stop1StoppedAt, Is.EqualTo(postFlipDate.AddHours(16).AddMinutes(3)));
+        });
+
+        // Time-band pay lines consume the SAME normalized models (this mirrors
+        // the export wiring at GenerateExcelDashboard): pre-flip totals must be
+        // TICK seconds (08:05→16:00 = 28500 s), post-flip totals exact-stamp
+        // seconds (08:07→16:03 = 28560 s) — no drift when the site flips.
+        var payRuleSet = AllDayWednesdayBand();
+        var preFlipLines = TimePlanningWorkingHoursService.CalculatePayLinesForDay(
+            preFlipDay.Id ?? 0, preFlipDay.Date, preFlipDay, totalSeconds: 0, payRuleSet);
+        var postFlipLines = TimePlanningWorkingHoursService.CalculatePayLinesForDay(
+            postFlipDay.Id ?? 0, postFlipDay.Date, postFlipDay, totalSeconds: 0, payRuleSet);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(preFlipLines.Sum(l => l.HoursInSeconds), Is.EqualTo((193 - 98) * 5 * 60),
+                "Pre-flip (tick) row: pay-band attribution must total tick seconds (28500).");
+            Assert.That(postFlipLines.Sum(l => l.HoursInSeconds), Is.EqualTo(28560),
+                "Post-flip (one-minute) row: pay-band attribution must total exact stamp seconds.");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Seed helpers
+    // ------------------------------------------------------------------
+
+    private async Task SeedSdkSite(int siteUid)
+    {
+        var core = await GetCore();
+        var sdkDb = core.DbContextHelper.GetDbContext();
+
+        var site = new SdkSite { Name = $"Site {siteUid}", MicrotingUid = siteUid };
+        await site.Create(sdkDb);
+
+        var worker = new SdkWorker
+        {
+            FirstName = "Test",
+            LastName = "Worker",
+            Email = $"test{siteUid}@example.com",
+            MicrotingUid = 1000 + siteUid
+        };
+        await worker.Create(sdkDb);
+
+        await new SdkSiteWorker
+        {
+            SiteId = site.Id,
+            WorkerId = worker.Id,
+            MicrotingUid = 2000 + siteUid
+        }.Create(sdkDb);
+    }
+
+    /// <summary>
+    /// AssignedSite flipped false→true saved mid-day on <paramref name="flipDate"/>,
+    /// seeded through the raw DbSets so the AssignedSiteVersions audit trail's
+    /// UpdatedAt save times (which the timeline reconstructs change points
+    /// from) are exactly the test's chosen dates. Mirrors the prod quirk:
+    /// version rows COPY the base entity's CreatedAt.
+    /// </summary>
+    private async Task SeedFlippedAssignedSite(int siteUid, DateTime flipDate)
+    {
+        var createdAt = flipDate.AddYears(-1);
+        var assignedSite = new AssignedSiteEntity
+        {
+            SiteId = siteUid,
+            UseOneMinuteIntervals = true, // current flag (post-flip)
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+            CreatedAt = createdAt,
+            UpdatedAt = flipDate,
+            Version = 2
+        };
+        TimePlanningPnDbContext!.AssignedSites.Add(assignedSite);
+        await TimePlanningPnDbContext.SaveChangesAsync();
+
+        TimePlanningPnDbContext.AssignedSiteVersions.AddRange(
+            new AssignedSiteVersion
+            {
+                AssignedSiteId = assignedSite.Id,
+                SiteId = siteUid,
+                UseOneMinuteIntervals = false,
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+                Version = 1
+            },
+            new AssignedSiteVersion
+            {
+                AssignedSiteId = assignedSite.Id,
+                SiteId = siteUid,
+                UseOneMinuteIntervals = true,
+                WorkflowState = Constants.WorkflowStates.Created,
+                CreatedAt = createdAt, // prod quirk: copy of the BASE CreatedAt
+                UpdatedAt = flipDate.AddHours(14).AddMinutes(45),
+                Version = 2
+            });
+        await TimePlanningPnDbContext.SaveChangesAsync();
+    }
+
+    private static PayRuleSet AllDayWednesdayBand() => new()
+    {
+        Name = "AllDayWednesday",
+        DayRules = new List<PayDayRule>(),
+        DayTypeRules = new List<PayDayTypeRule>
+        {
+            new PayDayTypeRule
+            {
+                DayType = DayType.Wednesday,
+                DefaultPayCode = "WORK",
+                Priority = 1,
+                TimeBandRules = new List<PayTimeBandRule>
+                {
+                    new PayTimeBandRule
+                    {
+                        StartSecondOfDay = 0, EndSecondOfDay = 86400,
+                        PayCode = "WORK", PayrollCode = "100", Priority = 1
+                    }
+                }
+            }
+        }
+    };
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OneMinuteModeTimeline.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OneMinuteModeTimeline.cs
@@ -45,6 +45,14 @@ namespace TimePlanning.Pn.Infrastructure.Helpers;
 ///    created before the audit row — same mode as at creation).
 ///  - Multiple toggles → interval walk over the change points; several
 ///    toggles on the same date → the last save wins.
+///  - Divergence correction: when the entity's CURRENT flag differs from the
+///    last audited version value, the flag was flipped OUTSIDE the audited
+///    path (raw-SQL ops change, or a CI seed whose dump predates the column —
+///    PnBase writes a version row on every API save, so a complete trail
+///    always ends on the current value). The exact flip time is unknowable,
+///    so the current flag takes over from the LAST audited save date — the
+///    earliest possible un-audited flip point. Audited history before that
+///    date is preserved; for sites flipped through the API this is a no-op.
 ///
 /// Cost: ONE query per site (<see cref="BuildAsync"/>); lookups are pure
 /// in-memory. Build once per site per request scope — never per row.
@@ -59,17 +67,21 @@ public sealed class OneMinuteModeTimeline
     /// <summary>
     /// In-memory constructor (also used directly by unit tests).
     /// <paramref name="versionFlags"/> must be in version-row Id (save) order;
-    /// pass an empty list to fall back to <paramref name="fallbackValue"/>.
+    /// pass an empty list to fall back to <paramref name="currentFlag"/>.
+    /// <paramref name="currentFlag"/> is the entity's CURRENT flag — the
+    /// no-version-rows fallback AND the divergence-correction authority (see
+    /// class docs): when the trail does not end on this value, the current
+    /// flag takes over from the last audited save date.
     /// </summary>
     internal OneMinuteModeTimeline(
-        bool fallbackValue,
+        bool currentFlag,
         IReadOnlyList<(bool UseOneMinuteIntervals, DateTime SavedAt)> versionFlags)
     {
         _changePoints = new List<(DateTime, bool)>();
 
         if (versionFlags == null || versionFlags.Count == 0)
         {
-            _initialValue = fallbackValue;
+            _initialValue = currentFlag;
             return;
         }
 
@@ -84,6 +96,17 @@ public sealed class OneMinuteModeTimeline
             }
             current = value;
             _changePoints.Add((savedAt.Date, current));
+        }
+
+        // Divergence correction: an audit trail written by PnBase always ends
+        // on the entity's current value; when it doesn't, the flag was flipped
+        // outside the audited path (raw-SQL ops change / legacy seed). Trust
+        // the CURRENT flag from the last audited save date — the earliest
+        // possible un-audited flip point — appended LAST so it wins over an
+        // audited toggle on that same date (see WasOneMinuteAt walk order).
+        if (current != currentFlag)
+        {
+            _changePoints.Add((versionFlags[^1].SavedAt.Date, currentFlag));
         }
     }
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OneMinuteModeTimeline.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/OneMinuteModeTimeline.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.TimePlanningBase.Infrastructure.Data;
+using AssignedSite = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+
+namespace TimePlanning.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// Reconstructs the history of an AssignedSite's <c>UseOneMinuteIntervals</c>
+/// flag from its <c>AssignedSiteVersions</c> audit rows so read/display/calc
+/// paths can resolve the mode that was IN FORCE when a given row was
+/// registered ("mode at registration") instead of the site's current flag.
+///
+/// Why: a row registered under 5-minute mode carries tick ids as its truth;
+/// a row registered under one-minute mode carries exact stamps. When a site
+/// flips the flag, per-site forking silently reinterprets historical rows
+/// (tick rows suddenly render/pay from raw stamps → drift in every total).
+/// Discriminating on stamp-nullness does not work either, because exact
+/// stamps exist on virtually all tick rows (devices record them alongside
+/// the tick ids). The reliable discriminator is this timeline.
+///
+/// Schema quirk (verified in prod): <c>PnBase.MapVersion</c> copies EVERY
+/// property of the base entity onto the version row — including
+/// <c>CreatedAt</c>, which therefore always holds the BASE entity's original
+/// creation time on every version row. The actual save time of a version row
+/// is its <c>UpdatedAt</c> (PnBase sets the base entity's UpdatedAt to
+/// UtcNow immediately before mapping the version). Change points are hence
+/// derived from consecutive version rows' flag values using UpdatedAt as the
+/// transition instant, ordered by version row Id (insert order).
+///
+/// Date granularity: comparisons are DATE-ONLY. A flag flip saved mid-day
+/// governs that WHOLE day under the new value — a PlanRegistration's Date is
+/// a midnight anchor with no time-of-day, so a finer resolution is not
+/// representable; making the flip day take the new mode matches the
+/// operational reality that the flip is done before/with the first
+/// registrations the admin wants under the new mode.
+///
+/// Edge cases:
+///  - No version rows at all → the site's CURRENT flag for all dates.
+///  - Flag already true in the earliest version row → true from the
+///    beginning of time (dates before the first row exist only for rows
+///    created before the audit row — same mode as at creation).
+///  - Multiple toggles → interval walk over the change points; several
+///    toggles on the same date → the last save wins.
+///
+/// Cost: ONE query per site (<see cref="BuildAsync"/>); lookups are pure
+/// in-memory. Build once per site per request scope — never per row.
+/// </summary>
+public sealed class OneMinuteModeTimeline
+{
+    private readonly bool _initialValue;
+
+    /// <summary>Date-only change points in save order (date, value-from-that-date).</summary>
+    private readonly List<(DateTime Date, bool Value)> _changePoints;
+
+    /// <summary>
+    /// In-memory constructor (also used directly by unit tests).
+    /// <paramref name="versionFlags"/> must be in version-row Id (save) order;
+    /// pass an empty list to fall back to <paramref name="fallbackValue"/>.
+    /// </summary>
+    internal OneMinuteModeTimeline(
+        bool fallbackValue,
+        IReadOnlyList<(bool UseOneMinuteIntervals, DateTime SavedAt)> versionFlags)
+    {
+        _changePoints = new List<(DateTime, bool)>();
+
+        if (versionFlags == null || versionFlags.Count == 0)
+        {
+            _initialValue = fallbackValue;
+            return;
+        }
+
+        // The earliest version row's value holds from the beginning of time.
+        _initialValue = versionFlags[0].UseOneMinuteIntervals;
+        var current = _initialValue;
+        foreach (var (value, savedAt) in versionFlags)
+        {
+            if (value == current)
+            {
+                continue;
+            }
+            current = value;
+            _changePoints.Add((savedAt.Date, current));
+        }
+    }
+
+    /// <summary>
+    /// Builds the timeline for one AssignedSite with a single
+    /// AssignedSiteVersions query. An unsaved entity (Id == 0) or a site
+    /// without audit rows yields a constant timeline of the current flag.
+    /// </summary>
+    public static async Task<OneMinuteModeTimeline> BuildAsync(
+        TimePlanningPnDbContext dbContext, AssignedSite assignedSite)
+    {
+        var versionFlags = await dbContext.AssignedSiteVersions
+            .AsNoTracking()
+            .Where(x => x.AssignedSiteId == assignedSite.Id)
+            .OrderBy(x => x.Id)
+            // UpdatedAt is the save time of the version row (see class docs);
+            // CreatedAt (a copy of the base entity's creation time) is the
+            // stand-in for legacy rows whose UpdatedAt is NULL.
+            .Select(x => new { x.UseOneMinuteIntervals, x.UpdatedAt, x.CreatedAt })
+            .ToListAsync();
+
+        return new OneMinuteModeTimeline(
+            assignedSite.UseOneMinuteIntervals,
+            versionFlags
+                .Select(x => (x.UseOneMinuteIntervals, x.UpdatedAt ?? x.CreatedAt))
+                .ToList());
+    }
+
+    /// <summary>
+    /// The <c>UseOneMinuteIntervals</c> value in force on <paramref name="rowDate"/>
+    /// (date-only comparison; the time component is ignored).
+    /// </summary>
+    public bool WasOneMinuteAt(DateTime rowDate)
+    {
+        var date = rowDate.Date;
+        var value = _initialValue;
+        // Walk ALL change points in save order (no early break): the LAST save
+        // whose date is on/before the row's date wins, which stays correct even
+        // if UpdatedAt values are not strictly monotonic across version rows.
+        foreach (var (changeDate, newValue) in _changePoints)
+        {
+            if (changeDate <= date)
+            {
+                value = newValue;
+            }
+        }
+        return value;
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -560,6 +560,13 @@ public static class PlanRegistrationHelper
         // Load the message catalog once (no N+1) so each day can resolve its
         // localized label without re-querying per row.
         var messagesById = await dbContext.Messages.AsNoTracking().ToDictionaryAsync(m => m.Id);
+        // Stage 3 tick-exact parity: resolve the UseOneMinuteIntervals mode that
+        // was in force when each row was REGISTERED (from AssignedSiteVersions —
+        // one query, in-memory lookups) so the Start/Stop display projection
+        // below renders tick rows from ids and one-minute rows from stamps,
+        // regardless of the site's CURRENT flag. Write/calc forks in this method
+        // intentionally keep using dbAssignedSite.UseOneMinuteIntervals.
+        var oneMinuteTimeline = await OneMinuteModeTimeline.BuildAsync(dbContext, dbAssignedSite);
         var toDay = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, 0, 0, 0);
         // var dayOfPayment = toDay.Day >= settingsDayOfPayment
         //     ? new DateTime(DateTime.Now.Year, DateTime.Now.Month, settingsDayOfPayment, 0, 0, 0)
@@ -570,6 +577,8 @@ public static class PlanRegistrationHelper
             var planRegistration = await dbContext.PlanRegistrations.AsTracking().FirstAsync(x => x.Id == plan.Id);
             var midnight = new DateTime(planRegistration.Date.Year, planRegistration.Date.Month,
                 planRegistration.Date.Day, 0, 0, 0);
+            // Mode at registration (see timeline build above) — display-only.
+            var rowIsOneMinute = oneMinuteTimeline.WasOneMinuteAt(planRegistration.Date);
 
             if (planRegistration.Start1Id > 289)
             {
@@ -1110,62 +1119,112 @@ public static class PlanRegistrationHelper
                 Sick = planRegistration.Sick,
                 OtherAllowedAbsence = planRegistration.OtherAllowedAbsence,
                 AbsenceWithoutPermission = planRegistration.AbsenceWithoutPermission,
-                Start1StartedAt = dbAssignedSite.UseOneMinuteIntervals
+                // Stage 3 tick-exact display parity, forked on the mode AT
+                // REGISTRATION (rowIsOneMinute, from OneMinuteModeTimeline) —
+                // not the site's current flag:
+                //  - tick row (registered under 5-minute mode): ALWAYS the
+                //    Id-derived tick time, even when an exact stamp exists —
+                //    bit-identical to what the row showed before a site flip.
+                //  - one-minute row: the exact stamp first, falling back to the
+                //    Id-derived time when the stamp is NULL but the Id exists
+                //    (mirrors the Excel export / EnsureTimestampsFromIds rule)
+                //    so no row ever renders blank while an Id is present.
+                Start1StartedAt = rowIsOneMinute
                     ? planRegistration.Start1StartedAt
+                      ?? (planRegistration.Start1Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Start1Id * 5) - 5)
+                          : null)
                     : (planRegistration.Start1Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start1Id * 5) - 5)),
-                Stop1StoppedAt = dbAssignedSite.UseOneMinuteIntervals
+                Stop1StoppedAt = rowIsOneMinute
                     ? planRegistration.Stop1StoppedAt
+                      ?? (planRegistration.Stop1Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Stop1Id * 5) - 5)
+                          : null)
                     : (planRegistration.Stop1Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop1Id * 5) - 5)),
-                Start2StartedAt = dbAssignedSite.UseOneMinuteIntervals
+                Start2StartedAt = rowIsOneMinute
                     ? planRegistration.Start2StartedAt
+                      ?? (planRegistration.Start2Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Start2Id * 5) - 5)
+                          : null)
                     : (planRegistration.Start2Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start2Id * 5) - 5)),
-                Stop2StoppedAt = dbAssignedSite.UseOneMinuteIntervals
+                Stop2StoppedAt = rowIsOneMinute
                     ? planRegistration.Stop2StoppedAt
+                      ?? (planRegistration.Stop2Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Stop2Id * 5) - 5)
+                          : null)
                     : (planRegistration.Stop2Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop2Id * 5) - 5)),
-                Start3StartedAt = dbAssignedSite.UseOneMinuteIntervals
+                Start3StartedAt = rowIsOneMinute
                     ? planRegistration.Start3StartedAt
+                      ?? (planRegistration.Start3Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Start3Id * 5) - 5)
+                          : null)
                     : (planRegistration.Start3Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start3Id * 5) - 5)),
-                Stop3StoppedAt = dbAssignedSite.UseOneMinuteIntervals
+                Stop3StoppedAt = rowIsOneMinute
                     ? planRegistration.Stop3StoppedAt
+                      ?? (planRegistration.Stop3Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Stop3Id * 5) - 5)
+                          : null)
                     : (planRegistration.Stop3Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop3Id * 5) - 5)),
-                Start4StartedAt = dbAssignedSite.UseOneMinuteIntervals
+                Start4StartedAt = rowIsOneMinute
                     ? planRegistration.Start4StartedAt
+                      ?? (planRegistration.Start4Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Start4Id * 5) - 5)
+                          : null)
                     : (planRegistration.Start4Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start4Id * 5) - 5)),
-                Stop4StoppedAt = dbAssignedSite.UseOneMinuteIntervals
+                Stop4StoppedAt = rowIsOneMinute
                     ? planRegistration.Stop4StoppedAt
+                      ?? (planRegistration.Stop4Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Stop4Id * 5) - 5)
+                          : null)
                     : (planRegistration.Stop4Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Stop4Id * 5) - 5)),
-                Start5StartedAt = dbAssignedSite.UseOneMinuteIntervals
+                Start5StartedAt = rowIsOneMinute
                     ? planRegistration.Start5StartedAt
+                      ?? (planRegistration.Start5Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Start5Id * 5) - 5)
+                          : null)
                     : (planRegistration.Start5Id == 0
                         ? null
                         : midnight.AddMinutes(
                             (planRegistration.Start5Id * 5) - 5)),
-                Stop5StoppedAt = dbAssignedSite.UseOneMinuteIntervals
+                Stop5StoppedAt = rowIsOneMinute
                     ? planRegistration.Stop5StoppedAt
+                      ?? (planRegistration.Stop5Id > 0
+                          ? midnight.AddMinutes(
+                              (planRegistration.Stop5Id * 5) - 5)
+                          : null)
                     : (planRegistration.Stop5Id == 0
                         ? null
                         : midnight.AddMinutes(

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PlanRegistrationHelper.cs
@@ -577,8 +577,12 @@ public static class PlanRegistrationHelper
             var planRegistration = await dbContext.PlanRegistrations.AsTracking().FirstAsync(x => x.Id == plan.Id);
             var midnight = new DateTime(planRegistration.Date.Year, planRegistration.Date.Month,
                 planRegistration.Date.Day, 0, 0, 0);
-            // Mode at registration (see timeline build above) — display-only.
-            var rowIsOneMinute = oneMinuteTimeline.WasOneMinuteAt(planRegistration.Date);
+            // Mode at registration — display-only. The write-time marker (stamped
+            // by every Start/Stop-writing save from the site's then-current flag)
+            // is authoritative; the AssignedSiteVersions timeline is the fallback
+            // for legacy rows written before the marker existed (marker NULL).
+            var rowIsOneMinute = planRegistration.RegisteredUnderOneMinuteIntervals
+                                 ?? oneMinuteTimeline.WasOneMinuteAt(planRegistration.Date);
 
             if (planRegistration.Start1Id > 289)
             {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningWorkingHoursModel.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Models/WorkingHours/Index/TimePlanningWorkingHoursModel.cs
@@ -164,4 +164,12 @@ public class TimePlanningWorkingHoursModel
     public int Shift2PauseNumber { get; set; }
     public double NettoHoursOverride { get; set; }
     public bool NettoHoursOverrideActive { get; set; }
+
+    /// <summary>
+    /// Write-time mode marker copied from the PlanRegistration row: the site's
+    /// UseOneMinuteIntervals in force when the row's Start/Stop values were last
+    /// written. Governs per-row display/calc (exact stamps vs 5-minute ticks);
+    /// null = legacy row, resolved via the AssignedSiteVersions timeline.
+    /// </summary>
+    public bool? RegisteredUnderOneMinuteIntervals { get; set; }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningPlanningService/TimePlanningPlanningService.cs
@@ -937,6 +937,13 @@ public class TimePlanningPlanningService(
                 DeriveLegacyShiftIdsFromTimestamps(planning);
             }
 
+            // Write-time mode marker: this admin edit rewrites the Start/Stop
+            // registrations, so the row is (re-)registered under the site's
+            // CURRENT input mode — an exact-minute edit on a one-minute site
+            // renders exactly forever, even when the row's date predates the
+            // site's flip to one-minute intervals.
+            planning.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+
             if (!assignedSite.UseOnlyPlanHours)
             {
                 double minutesPlanned = 0;
@@ -1346,6 +1353,12 @@ public class TimePlanningPlanningService(
                 planning.Start5Id = model.Start5Id ?? 0;
                 planning.Stop5Id = model.Stop5Id ?? 0;
             }
+
+            // Write-time mode marker: this save rewrites the Start/Stop
+            // registrations, so the row is (re-)registered under the site's
+            // CURRENT input mode.
+            planning.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+
             planning.WorkerComment = model.WorkerComment;
 
             planning = PlanRegistrationHelper.CalculatePauseAutoBreakCalculationActive(assignedSite, planning);

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -99,6 +99,11 @@ public class TimePlanningWorkingHoursService(
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .FirstOrDefaultAsync(x => x.SiteId == model.SiteId);
             var useOneMinuteIntervals = assignedSite?.UseOneMinuteIntervals ?? false;
+            // Stage 3 tick-exact parity: per-row mode-at-registration from the
+            // AssignedSiteVersions audit trail (one query; in-memory lookups).
+            var oneMinuteTimeline = assignedSite != null
+                ? await OneMinuteModeTimeline.BuildAsync(dbContext, assignedSite)
+                : new OneMinuteModeTimeline(false, Array.Empty<(bool, DateTime)>());
 
             var timePlanningRequest = dbContext.PlanRegistrations
                 .AsNoTracking()
@@ -388,6 +393,27 @@ public class TimePlanningWorkingHoursService(
             }
 
             timePlannings = timePlannings.OrderBy(x => x.Date).ToList();
+
+            // Stage 3 tick-exact parity: normalize each row's Start/Stop stamps
+            // in the RESPONSE MODEL to its mode at registration —
+            //  - tick row: stamps := Id-derived tick times (the exact device
+            //    stamps that may coexist on the row are NOT shown/summed),
+            //  - one-minute row: exact stamp, falling back to the Id-derived
+            //    time when the stamp is NULL but the Id exists.
+            // Every stamp consumer downstream (web grid, Excel day cells via
+            // GetShiftTime/GetShiftTimeFraction, time-band pay lines via
+            // EnumerateShiftSegments, Grundlovsdag hours via
+            // CalculateHoursAfterNoon, and all totals built from those) then
+            // derives from tick times for tick rows — no drift when a site
+            // flips UseOneMinuteIntervals. Read-only: the save path
+            // (UpdatePlanning) copies only Shift{N} ids and numeric fields from
+            // this model, never the stamps, so nothing synthesized here can be
+            // echoed back into the DB.
+            foreach (var timePlanning in timePlannings)
+            {
+                ApplyModeAtRegistrationStamps(
+                    timePlanning, oneMinuteTimeline.WasOneMinuteAt(timePlanning.Date));
+            }
 
             var j = 0;
             double sumFlexEnd = 0;
@@ -2421,6 +2447,10 @@ public class TimePlanningWorkingHoursService(
 
             var isFifthShiftEnabled = assignedSite.FifthShiftActive;
 
+            // Stage 3 tick-exact parity: per-row mode-at-registration so day
+            // cells render tick rows from ids and one-minute rows from stamps.
+            var oneMinuteTimeline = await OneMinuteModeTimeline.BuildAsync(dbContext, assignedSite);
+
             // Load PayRuleSet with day rules + tiers AND day type rules + time bands
             PayRuleSet payRuleSet = null;
             if (assignedSite.PayRuleSetId.HasValue)
@@ -2500,7 +2530,9 @@ public class TimePlanningWorkingHoursService(
                     WorkerName = site.Name,
                     Date = p.Date,
                     Planning = p,
-                    UseOneMinuteIntervals = assignedSite.UseOneMinuteIntervals
+                    // Per-row mode at registration (tick rows keep tick cells
+                    // even after the site flips to one-minute).
+                    UseOneMinuteIntervals = oneMinuteTimeline.WasOneMinuteAt(p.Date)
                 }).ToList();
                 BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
 
@@ -2627,7 +2659,7 @@ public class TimePlanningWorkingHoursService(
                 foreach (var planning in timePlannings)
                 {
                     var dataRow = new Row() { RowIndex = (uint)rowIndex };
-                    FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, assignedSite.UseOneMinuteIntervals);
+                    FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, oneMinuteTimeline.WasOneMinuteAt(planning.Date));
 
                     // Append pay code values for this day
                     var dayPayLines = payLinesByDate.ContainsKey(planning.Date)
@@ -3068,7 +3100,11 @@ public class TimePlanningWorkingHoursService(
                     AssignedSite = assignedSiteForCache,
                     PayRuleSet = payRuleSetForCache,
                     TimePlannings = siteTimePlannings,
-                    PayLinesByDate = payLinesByDate
+                    PayLinesByDate = payLinesByDate,
+                    // Stage 3 tick-exact parity: one timeline per site, shared by
+                    // the per-site sheet and day-overview writers below.
+                    OneMinuteTimeline =
+                        await OneMinuteModeTimeline.BuildAsync(dbContext, assignedSiteForCache)
                 };
             }
 
@@ -3113,7 +3149,6 @@ public class TimePlanningWorkingHoursService(
                     var doWorker = await sdkContext.Workers.FirstAsync(x => x.Id == doSiteWorker.WorkerId);
                     perSiteCache.TryGetValue(siteIds[i], out var doCache);
                     var doPlannings = doCache?.TimePlannings ?? new List<TimePlanningWorkingHoursModel>();
-                    var doUseOneMinute = doCache?.AssignedSite?.UseOneMinuteIntervals ?? false;
                     foreach (var planning in doPlannings)
                     {
                         dayOverviewRows.Add(new DayOverviewRow
@@ -3122,7 +3157,10 @@ public class TimePlanningWorkingHoursService(
                             WorkerName = doSite.Name,
                             Date = planning.Date,
                             Planning = planning,
-                            UseOneMinuteIntervals = doUseOneMinute
+                            // Per-row mode at registration (tick rows keep tick
+                            // cells even after the site flips to one-minute).
+                            UseOneMinuteIntervals =
+                                doCache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date) ?? false
                         });
                     }
                 }
@@ -3364,7 +3402,7 @@ public class TimePlanningWorkingHoursService(
                         var dataRow = new Row() { RowIndex = (uint)rowIndex };
                         try
                         {
-                            FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, cache?.AssignedSite?.UseOneMinuteIntervals ?? false);
+                            FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, cache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date) ?? false);
 
                             // Append pay code values for this day
                             var dayPayLines = (cache != null && cache.PayLinesByDate.ContainsKey(planning.Date))
@@ -4022,6 +4060,55 @@ public class TimePlanningWorkingHoursService(
     }
 
     /// <summary>
+    /// Stage 3 tick-exact parity: rewrites one day-model's Start/Stop stamps to
+    /// the mode the row was REGISTERED under (per-row, from
+    /// <see cref="OneMinuteModeTimeline"/>), so every stamp consumer — the web
+    /// grid DTO, Excel day cells, time-band pay lines
+    /// (<see cref="EnumerateShiftSegments"/>) and Grundlovsdag holiday math
+    /// (<see cref="CalculateHoursAfterNoon"/>) — derives from tick times for
+    /// tick rows and from exact stamps for one-minute rows:
+    ///  - tick row:      stamp := Id-derived (midnight + (Id*5 - 5) min; NULL when Id == 0)
+    ///  - one-minute row: stamp := exact stamp ?? Id-derived fallback
+    /// Pause stamps are intentionally untouched (out of scope for this pass).
+    /// Note the Id 289 (= 24:00, don't-wrap convention) derives to next-day
+    /// 00:00, which <see cref="ResolveShiftSeconds"/> clamps back to 86400s —
+    /// the Excel cells still render "24:00" because their per-row mode routes
+    /// tick rows through the Id-based formatting path.
+    /// </summary>
+    internal static void ApplyModeAtRegistrationStamps(TimePlanningWorkingHoursModel day, bool rowIsOneMinute)
+    {
+        var midnight = day.Date.Date;
+        DateTime? FromId(int? id) => id is > 0 ? midnight.AddMinutes((id.Value * 5) - 5) : null;
+
+        if (rowIsOneMinute)
+        {
+            day.Start1StartedAt ??= FromId(day.Shift1Start);
+            day.Stop1StoppedAt ??= FromId(day.Shift1Stop);
+            day.Start2StartedAt ??= FromId(day.Shift2Start);
+            day.Stop2StoppedAt ??= FromId(day.Shift2Stop);
+            day.Start3StartedAt ??= FromId(day.Shift3Start);
+            day.Stop3StoppedAt ??= FromId(day.Shift3Stop);
+            day.Start4StartedAt ??= FromId(day.Shift4Start);
+            day.Stop4StoppedAt ??= FromId(day.Shift4Stop);
+            day.Start5StartedAt ??= FromId(day.Shift5Start);
+            day.Stop5StoppedAt ??= FromId(day.Shift5Stop);
+        }
+        else
+        {
+            day.Start1StartedAt = FromId(day.Shift1Start);
+            day.Stop1StoppedAt = FromId(day.Shift1Stop);
+            day.Start2StartedAt = FromId(day.Shift2Start);
+            day.Stop2StoppedAt = FromId(day.Shift2Stop);
+            day.Start3StartedAt = FromId(day.Shift3Start);
+            day.Stop3StoppedAt = FromId(day.Shift3Stop);
+            day.Start4StartedAt = FromId(day.Shift4Start);
+            day.Stop4StoppedAt = FromId(day.Shift4Stop);
+            day.Start5StartedAt = FromId(day.Shift5Start);
+            day.Stop5StoppedAt = FromId(day.Shift5Stop);
+        }
+    }
+
+    /// <summary>
     /// Aggregates pay lines with the same PayCode by summing seconds and hours.
     /// Preserves PlanRegistrationId / PayRuleSetId / CalculatedAt from the first occurrence.
     /// </summary>
@@ -4115,6 +4202,8 @@ public class TimePlanningWorkingHoursService(
         public PayRuleSet PayRuleSet { get; set; }
         public List<TimePlanningWorkingHoursModel> TimePlannings { get; set; }
         public Dictionary<DateTime, List<PlanRegistrationPayLine>> PayLinesByDate { get; set; }
+        /// <summary>Per-site mode-at-registration timeline (built once in the pre-pass).</summary>
+        public OneMinuteModeTimeline OneMinuteTimeline { get; set; }
     }
 
     private sealed class DayOverviewRow

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -185,7 +185,9 @@ public class TimePlanningWorkingHoursService(
                     NettoHoursOverride = x.NettoHoursOverride,
                     NettoHoursOverrideActive = x.NettoHoursOverrideActive,
                     IsSaturday = x.Date.DayOfWeek == DayOfWeek.Saturday,
-                    IsSunday = x.Date.DayOfWeek == DayOfWeek.Sunday
+                    IsSunday = x.Date.DayOfWeek == DayOfWeek.Sunday,
+                    // Write-time mode marker (null = legacy row → timeline fallback).
+                    RegisteredUnderOneMinuteIntervals = x.RegisteredUnderOneMinuteIntervals
                 })
                 .ToListAsync();
 
@@ -350,6 +352,7 @@ public class TimePlanningWorkingHoursService(
                         Message = lastPlanning?.MessageId,
                         CommentWorker = lastPlanning?.WorkerComment?.Replace("\r", "<br />"),
                         CommentOffice = lastPlanning?.CommentOffice?.Replace("\r", "<br />"),
+                        RegisteredUnderOneMinuteIntervals = lastPlanning?.RegisteredUnderOneMinuteIntervals,
                         IsLocked = true,
                         IsWeekend = lastPlanning != null
                             ? lastPlanning.Date.DayOfWeek == DayOfWeek.Saturday ||
@@ -412,7 +415,9 @@ public class TimePlanningWorkingHoursService(
             foreach (var timePlanning in timePlannings)
             {
                 ApplyModeAtRegistrationStamps(
-                    timePlanning, oneMinuteTimeline.WasOneMinuteAt(timePlanning.Date));
+                    timePlanning,
+                    timePlanning.RegisteredUnderOneMinuteIntervals
+                        ?? oneMinuteTimeline.WasOneMinuteAt(timePlanning.Date));
             }
 
             var j = 0;
@@ -638,6 +643,14 @@ public class TimePlanningWorkingHoursService(
                     StatusCaseId = 0
                 };
 
+                // Write-time mode marker: this create carries Start/Stop ids, so
+                // record the input mode in force at this write (null site → marker
+                // stays NULL and resolves via the AssignedSiteVersions timeline).
+                var assignedSite = await dbContext.AssignedSites
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .FirstOrDefaultAsync(x => x.SiteId == microtingUid);
+                planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite?.UseOneMinuteIntervals;
+
                 var preTimePlanning =
                     await dbContext.PlanRegistrations.AsNoTracking().Where(x => x.Date < planRegistration.Date
                             && x.SdkSitId == planRegistration.SdkSitId).OrderByDescending(x => x.Date)
@@ -716,6 +729,15 @@ public class TimePlanningWorkingHoursService(
         var assignedSite = await dbContext.AssignedSites
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .FirstOrDefaultAsync(x => x.SiteId == microtingUid);
+
+        // Write-time mode marker: only the Date != midnight branch above rewrites
+        // the Start/Stop ids, so only that branch re-registers the row's mode
+        // (null site → marker unchanged; timeline fallback resolves it).
+        if (planRegistration.Date != midnight && assignedSite != null)
+        {
+            planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+        }
+
         planRegistration = await PlanRegistrationHelper
             .UpdatePlanRegistration(planRegistration, dbContext, assignedSite, DateTime.Now.AddMonths(-1));
 
@@ -1454,6 +1476,16 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
+            // Write-time mode marker: this save carries Start/Stop registrations,
+            // so record the input mode (UseOneMinuteIntervals) in force at THIS
+            // write. Display/calc renders the row per this marker forever; a null
+            // site leaves the marker unchanged (mode unknown → resolved via the
+            // AssignedSiteVersions timeline fallback).
+            if (assignedSite != null)
+            {
+                planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+            }
+
             double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
@@ -1746,6 +1778,16 @@ public class TimePlanningWorkingHoursService(
             // Self-heal a corrupt incoming pauseNId from the truthful pause
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
+
+            // Write-time mode marker: this save carries Start/Stop registrations,
+            // so record the input mode (UseOneMinuteIntervals) in force at THIS
+            // write. Display/calc renders the row per this marker forever; a null
+            // site leaves the marker unchanged (mode unknown → resolved via the
+            // AssignedSiteVersions timeline fallback).
+            if (assignedSite != null)
+            {
+                planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+            }
 
             double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
@@ -2099,6 +2141,16 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
+            // Write-time mode marker: this save carries Start/Stop registrations,
+            // so record the input mode (UseOneMinuteIntervals) in force at THIS
+            // write. Display/calc renders the row per this marker forever; a null
+            // site leaves the marker unchanged (mode unknown → resolved via the
+            // AssignedSiteVersions timeline fallback).
+            if (assignedSite != null)
+            {
+                planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+            }
+
             double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
@@ -2381,6 +2433,16 @@ public class TimePlanningWorkingHoursService(
             // timestamps before the inline netto math (5-min sites, flag on).
             SelfHealCorruptPauseIds(planRegistration, assignedSite);
 
+            // Write-time mode marker: this save carries Start/Stop registrations,
+            // so record the input mode (UseOneMinuteIntervals) in force at THIS
+            // write. Display/calc renders the row per this marker forever; a null
+            // site leaves the marker unchanged (mode unknown → resolved via the
+            // AssignedSiteVersions timeline fallback).
+            if (assignedSite != null)
+            {
+                planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite.UseOneMinuteIntervals;
+            }
+
             double nettoMinutes = ComputeFlagOffNettoMinutes(planRegistration);
 
             double hours = nettoMinutes / 60;
@@ -2530,9 +2592,11 @@ public class TimePlanningWorkingHoursService(
                     WorkerName = site.Name,
                     Date = p.Date,
                     Planning = p,
-                    // Per-row mode at registration (tick rows keep tick cells
-                    // even after the site flips to one-minute).
-                    UseOneMinuteIntervals = oneMinuteTimeline.WasOneMinuteAt(p.Date)
+                    // Per-row mode at registration: write-time marker first,
+                    // AssignedSiteVersions timeline fallback for legacy rows
+                    // (tick rows keep tick cells even after the site flips).
+                    UseOneMinuteIntervals = p.RegisteredUnderOneMinuteIntervals
+                                            ?? oneMinuteTimeline.WasOneMinuteAt(p.Date)
                 }).ToList();
                 BuildDayOverviewWorksheet(dayOverviewWorksheetPart, dayOverviewRows, culture);
 
@@ -2659,7 +2723,7 @@ public class TimePlanningWorkingHoursService(
                 foreach (var planning in timePlannings)
                 {
                     var dataRow = new Row() { RowIndex = (uint)rowIndex };
-                    FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, oneMinuteTimeline.WasOneMinuteAt(planning.Date));
+                    FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, planning.RegisteredUnderOneMinuteIntervals ?? oneMinuteTimeline.WasOneMinuteAt(planning.Date));
 
                     // Append pay code values for this day
                     var dayPayLines = payLinesByDate.ContainsKey(planning.Date)
@@ -3157,10 +3221,13 @@ public class TimePlanningWorkingHoursService(
                             WorkerName = doSite.Name,
                             Date = planning.Date,
                             Planning = planning,
-                            // Per-row mode at registration (tick rows keep tick
-                            // cells even after the site flips to one-minute).
+                            // Per-row mode at registration: write-time marker
+                            // first, timeline fallback for legacy rows (tick rows
+                            // keep tick cells even after the site flips).
                             UseOneMinuteIntervals =
-                                doCache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date) ?? false
+                                planning.RegisteredUnderOneMinuteIntervals
+                                ?? doCache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date)
+                                ?? false
                         });
                     }
                 }
@@ -3402,7 +3469,7 @@ public class TimePlanningWorkingHoursService(
                         var dataRow = new Row() { RowIndex = (uint)rowIndex };
                         try
                         {
-                            FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, cache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date) ?? false);
+                            FillDataRow(dataRow, worker, site, culture, planning, plr, language, isThirdShiftEnabled, isFourthShiftEnabled, isFifthShiftEnabled, planning.RegisteredUnderOneMinuteIntervals ?? cache?.OneMinuteTimeline?.WasOneMinuteAt(planning.Date) ?? false);
 
                             // Append pay code values for this day
                             var dayPayLines = (cache != null && cache.PayLinesByDate.ContainsKey(planning.Date))

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
@@ -33,7 +33,7 @@
       <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.35" />
       <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.29" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.53" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.54" />
       <PackageReference Include="Sentry" Version="6.6.0" />
       <PackageReference Include="FirebaseAdmin" Version="3.5.0" />
       <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />


### PR DESCRIPTION
> **DRAFT** — awaiting Microting.TimePlanningBase **v10.0.54** on nuget.org (base PR #895 / commit c4d0d0e adds the `RegisteredUnderOneMinuteIntervals` column). Stage 1 was extracted and shipped separately as PR #1638. Local plugin-side implementation of the marker is complete (built against a local pack of 10.0.54) and will be pushed once the package resolves publicly.

## Problem

Since 2026-07-03 the register/edit flow on one-minute sites (live on tenants **986** and **1123**) stored UTC instants in the exact-stamp columns while every surface shows raw digits (stage 1, now PR #1638). Independently, rows registered under 5-minute mode were silently reinterpreted from raw device stamps after a site flips `UseOneMinuteIntervals` — display and pay drifting from the tick truth they were registered under.

## Design — write-time mode marker (option A), three-layer resolution

Per-row mode = **`PlanRegistration.RegisteredUnderOneMinuteIntervals ?? OneMinuteModeTimeline.WasOneMinuteAt(row.Date)`**:

1. **Marker (authoritative)** — nullable bool stamped by every Start/Stop-writing save from the site's then-current flag. An admin exact-minute edit AFTER a flip re-registers the row under one-minute mode, so back-edits round-trip exactly (fixes the l1m e2e conflict found in review: a pre-flip-dated cell edited with 03:03 previously redisplayed 03:00).
2. **Timeline (legacy fallback, marker NULL)** — flag history reconstructed from `AssignedSiteVersions` (version rows copy the entity's `CreatedAt`; save time is the version row's `UpdatedAt`); date-only change points; divergence correction when the trail was bypassed by raw-SQL flips.
3. Applied at `UpdatePlanRegistrationsInPeriod` (web plannings + app lists) and the working-hours `Index()` DTO boundary + per-row Excel formatter threading — so grid, both Excel exports, time-band pay lines and the Grundlovsdag rule all inherit one rule.

### Write-path stamping map
| Path | Stamped where |
|---|---|
| `TimePlanningWorkingHoursService.UpdateWorkingHour` (personal, create+update) | after `SelfHealCorruptPauseIds` in both branches |
| `TimePlanningWorkingHoursService.UpdateWorkingHour` (kiosk/token, create+update) | after `SelfHealCorruptPauseIds` in both branches |
| `TimePlanningWorkingHoursService.CreateUpdate` → `CreatePlanning` / `UpdatePlanning` | after entity construction / after the `Date != midnight` id-write guard |
| `TimePlanningPlanningService.Update` (admin workday dialog) | after the Start/Stop + exact-minutes block |
| `TimePlanningPlanningService.UpdateByCurrentUserNam` | after the Start/Stop + id-derivation block |
| NOT stamped (no Start/Stop writes): AbsenceRequestService, GoogleSheetHelper plan import, read-path persistence in `UpdatePlanRegistrationsInPeriod` (incl. >289 workaround), `TimeSettingService` | by design — saves that don't touch registrations must not re-register the row's mode |

Null-site saves leave the marker unchanged (mode unknown → timeline fallback). **No stored data modified** by reads; the app's read-modify-write echo path (`ReadBySiteAndDate`) stays verbatim (test-locked).

## Guarantees & behavior notes
- Marker=NULL legacy rows behave exactly as the previous revision of this PR (timeline).
- Never-flipped 5-minute sites: time-band pay lines become tick-based (pay == display) — unchanged callout from the earlier revision, please review (payroll-affecting).
- Schema: nullable column via EF migration in the base package; existing rows stay NULL.

## Tests
`OneMinuteModeTimelineTests` (incl. divergence correction), `PlanRegistrationHelperDisplayParityTests` (+ marker-wins matrix: true/pre-flip → exact, NULL → tick, false/post-flip → tick), `WorkingHoursDisplayParityTests` (+ Index marker E2E), plus the stage-3 flip/regression suite. CI shards e/f wired.

## Follow-up
The app-side `toUtc()` removal ships separately with the next app release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
