### PR TITLE
fix(timezone): normalize explicit-offset gRPC timestamps to wall time (stage 1)

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -258,7 +258,7 @@ jobs:
           - name: g
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTimeZoneTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
     steps:
     - uses: actions/checkout@v3
     - name: Create docker network

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -247,7 +247,7 @@ jobs:
           - name: g
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServicePhoneNumberTests|FullyQualifiedName=TimePlanning.Pn.Test.TimePlanningWorkingHoursExportTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAbsenceRequestGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningAuthGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.DagsoversigtWorksheetExportTests"
           - name: h
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.SettingsServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningContentHandoverGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningPlanningsGrpcServiceTimeZoneTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningSettingsGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GrpcServices.TimePlanningWorkingHoursGrpcServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursExcelExportE2ETests"
     steps:
     - uses: actions/checkout@v3
     - name: Create docker network

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningPlanningsGrpcServiceTimeZoneTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/GrpcServices/TimePlanningPlanningsGrpcServiceTimeZoneTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using Microting.eFormApi.BasePn.Abstractions;
+using TimePlanning.Pn.Grpc;
+using TimePlanning.Pn.Infrastructure.Models.Planning;
+using TimePlanning.Pn.Services.GrpcServices;
+using TimePlanning.Pn.Services.TimePlanningPlanningService;
+using TimePlanning.Pn.Test.Helpers;
+using OperationResult = Microting.eFormApi.BasePn.Infrastructure.Models.API.OperationResult;
+
+namespace TimePlanning.Pn.Test.GrpcServices;
+
+/// <summary>
+/// Regression tests for the timezone handling in the gRPC write path
+/// (UpdatePlanningByCurrentUser / UpdatePlanning → MapDayFromGrpc →
+/// ParseDateTime). PlanRegistration exact-timestamp columns hold user-local
+/// wall time by convention, so:
+/// - input WITH an explicit zone designator (Z or ±hh:mm) must be converted
+///   to the current user's timezone wall time (Kind=Unspecified);
+/// - naive input (no designator) must be stored byte-verbatim.
+/// </summary>
+[TestFixture]
+public class TimePlanningPlanningsGrpcServiceTimeZoneTests
+{
+    private ITimePlanningPlanningService _planningService;
+    private IUserService _userService;
+    private TimePlanningPlanningsGrpcService _grpcService;
+
+    // Captured domain model passed to the service
+    private TimePlanningPlanningPrDayModel _captured;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _planningService = Substitute.For<ITimePlanningPlanningService>();
+        _userService = Substitute.For<IUserService>();
+        _userService.GetCurrentUserTimeZoneInfo()
+            .Returns(TimeZoneInfo.FindSystemTimeZoneById("Europe/Copenhagen"));
+
+        _grpcService = new TimePlanningPlanningsGrpcService(_planningService, _userService);
+        _captured = null!;
+
+        _planningService.UpdateByCurrentUserNam(Arg.Any<TimePlanningPlanningPrDayModel>())
+            .Returns(ci =>
+            {
+                _captured = ci.Arg<TimePlanningPlanningPrDayModel>();
+                return new OperationResult(true, "OK");
+            });
+        _planningService.Update(Arg.Any<int>(), Arg.Any<TimePlanningPlanningPrDayModel>())
+            .Returns(ci =>
+            {
+                _captured = ci.Arg<TimePlanningPlanningPrDayModel>();
+                return new OperationResult(true, "OK");
+            });
+    }
+
+    private async Task<TimePlanningPlanningPrDayModel> MapViaUpdateByCurrentUser(string start1StartedAt)
+    {
+        var request = new UpdatePlanningByCurrentUserRequest
+        {
+            Model = new PlanningPrDayModel { Start1StartedAt = start1StartedAt }
+        };
+        await _grpcService.UpdatePlanningByCurrentUser(
+            request, TestServerCallContextFactory.Create());
+        return _captured;
+    }
+
+    private async Task<TimePlanningPlanningPrDayModel> MapViaUpdatePlanning(string start1StartedAt)
+    {
+        var request = new UpdatePlanningRequest
+        {
+            PlanningId = 1,
+            Model = new PlanningPrDayModel { Start1StartedAt = start1StartedAt }
+        };
+        await _grpcService.UpdatePlanning(
+            request, TestServerCallContextFactory.Create());
+        return _captured;
+    }
+
+    // ---------------------------------------------------------------
+    // Explicit zone designator → converted to user wall time
+    // ---------------------------------------------------------------
+
+    [Test]
+    public async Task ZSuffixedUtc_Summer_IsConvertedToUserWallTime()
+    {
+        // 04:30 UTC on a CEST date (+02:00) is 06:30 Copenhagen wall time.
+        var result = await MapViaUpdateByCurrentUser("2026-07-07T04:30:00Z");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task ZSuffixedUtc_Winter_IsConvertedToUserWallTime()
+    {
+        // 04:30 UTC on a CET date (+01:00) is 05:30 Copenhagen wall time.
+        var result = await MapViaUpdateByCurrentUser("2026-01-15T04:30:00Z");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 1, 15, 5, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task ExplicitZeroOffset_IsConvertedToUserWallTime()
+    {
+        // "+00:00" is the same instant as "Z" and must behave identically.
+        var result = await MapViaUpdateByCurrentUser("2026-07-07T04:30:00+00:00");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task ExplicitNonUtcOffset_IsConvertedToUserWallTime()
+    {
+        // 10:00 +05:30 is 04:30 UTC, i.e. 06:30 Copenhagen wall time (CEST).
+        var result = await MapViaUpdateByCurrentUser("2026-07-07T10:00:00+05:30");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task ZSuffixedUtc_ViaAdminUpdatePlanning_IsConvertedToUserWallTime()
+    {
+        // The admin UpdatePlanning RPC shares MapDayFromGrpc and must normalize too.
+        var result = await MapViaUpdatePlanning("2026-07-07T04:30:00Z");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    // ---------------------------------------------------------------
+    // Naive input (no zone designator) → byte-verbatim
+    // ---------------------------------------------------------------
+
+    [Test]
+    public async Task NaiveTSeparated_IsStoredVerbatim()
+    {
+        var result = await MapViaUpdateByCurrentUser("2026-07-07T06:30:00");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task NaiveSpaceSeparatedDartToString_IsStoredVerbatim()
+    {
+        // Dart's DateTime.toString() for a naive local value.
+        var result = await MapViaUpdateByCurrentUser("2026-07-07 06:30:00.000");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+        Assert.That(result.Start1StartedAt!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    // ---------------------------------------------------------------
+    // Timezone resolution fallback
+    // ---------------------------------------------------------------
+
+    [Test]
+    public async Task UserTimeZoneResolutionThrows_FallsBackToEuropeCopenhagen()
+    {
+        _userService.GetCurrentUserTimeZoneInfo()
+            .Throws(new Exception("User not authorized!"));
+
+        var result = await MapViaUpdateByCurrentUser("2026-07-07T04:30:00Z");
+
+        Assert.That(result.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+    }
+
+    [Test]
+    public async Task NoUserService_FallsBackToEuropeCopenhagen()
+    {
+        // Existing fixtures construct the service without IUserService;
+        // conversion must still normalize against the fallback zone.
+        var grpcService = new TimePlanningPlanningsGrpcService(_planningService);
+        var request = new UpdatePlanningByCurrentUserRequest
+        {
+            Model = new PlanningPrDayModel { Start1StartedAt = "2026-07-07T04:30:00Z" }
+        };
+        await grpcService.UpdatePlanningByCurrentUser(
+            request, TestServerCallContextFactory.Create());
+
+        Assert.That(_captured.Start1StartedAt, Is.EqualTo(new DateTime(2026, 7, 7, 6, 30, 0)));
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningPlanningsGrpcService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Microting.eFormApi.BasePn.Abstractions;
 using TimePlanning.Pn.Grpc;
 using TimePlanning.Pn.Infrastructure.Models.Planning;
 using TimePlanning.Pn.Services.TimePlanningPlanningService;
@@ -14,10 +15,14 @@ public class TimePlanningPlanningsGrpcService
     : TimePlanningPlanningsService.TimePlanningPlanningsServiceBase
 {
     private readonly ITimePlanningPlanningService _planningService;
+    private readonly IUserService _userService;
 
-    public TimePlanningPlanningsGrpcService(ITimePlanningPlanningService planningService)
+    public TimePlanningPlanningsGrpcService(
+        ITimePlanningPlanningService planningService,
+        IUserService userService = null)
     {
         _planningService = planningService;
+        _userService = userService;
     }
 
     public override async Task<GetPlanningsByUserResponse> GetPlanningsByUser(
@@ -80,7 +85,8 @@ public class TimePlanningPlanningsGrpcService
     public override async Task<UpdatePlanningByCurrentUserResponse> UpdatePlanningByCurrentUser(
         UpdatePlanningByCurrentUserRequest request, ServerCallContext context)
     {
-        var model = MapDayFromGrpc(request.Model);
+        var userTimeZone = await ResolveUserTimeZone();
+        var model = MapDayFromGrpc(request.Model, userTimeZone);
         var result = await _planningService.UpdateByCurrentUserNam(model);
 
         return new UpdatePlanningByCurrentUserResponse
@@ -165,7 +171,8 @@ public class TimePlanningPlanningsGrpcService
     {
         try
         {
-            var model = MapDayFromGrpc(request.Model);
+            var userTimeZone = await ResolveUserTimeZone();
+            var model = MapDayFromGrpc(request.Model, userTimeZone);
             var result = await _planningService.Update(request.PlanningId, model);
 
             return new UpdatePlanningResponse
@@ -338,7 +345,30 @@ public class TimePlanningPlanningsGrpcService
         };
     }
 
-    private static TimePlanningPlanningPrDayModel MapDayFromGrpc(Grpc.PlanningPrDayModel? m)
+    /// <summary>
+    /// Resolves the current user's time zone for normalizing incoming shift
+    /// timestamps. Falls back to Europe/Copenhagen when no user context is
+    /// available or resolution fails — the host implementation's own fallback
+    /// ("E. Europe Standard Time") throws on Linux, so it must never be relied on.
+    /// </summary>
+    private async Task<TimeZoneInfo> ResolveUserTimeZone()
+    {
+        try
+        {
+            if (_userService != null)
+            {
+                return await _userService.GetCurrentUserTimeZoneInfo();
+            }
+        }
+        catch
+        {
+            // Fall through to the safe default below.
+        }
+
+        return TimeZoneInfo.FindSystemTimeZoneById("Europe/Copenhagen");
+    }
+
+    private static TimePlanningPlanningPrDayModel MapDayFromGrpc(Grpc.PlanningPrDayModel? m, TimeZoneInfo userTimeZone)
     {
         if (m == null) return new TimePlanningPlanningPrDayModel();
 
@@ -404,89 +434,122 @@ public class TimePlanningPlanningsGrpcService
             CommentOffice = m.CommentOffice,
             WorkerComment = m.WorkerComment,
             // Primary shift timestamps — shifts 1-5
-            Start1StartedAt = ParseDateTime(m.Start1StartedAt),
-            Stop1StoppedAt = ParseDateTime(m.Stop1StoppedAt),
-            Pause1StartedAt = ParseDateTime(m.Pause1StartedAt),
-            Pause1StoppedAt = ParseDateTime(m.Pause1StoppedAt),
-            Start2StartedAt = ParseDateTime(m.Start2StartedAt),
-            Stop2StoppedAt = ParseDateTime(m.Stop2StoppedAt),
-            Pause2StartedAt = ParseDateTime(m.Pause2StartedAt),
-            Pause2StoppedAt = ParseDateTime(m.Pause2StoppedAt),
-            Start3StartedAt = ParseDateTime(m.Start3StartedAt),
-            Stop3StoppedAt = ParseDateTime(m.Stop3StoppedAt),
-            Pause3StartedAt = ParseDateTime(m.Pause3StartedAt),
-            Pause3StoppedAt = ParseDateTime(m.Pause3StoppedAt),
-            Start4StartedAt = ParseDateTime(m.Start4StartedAt),
-            Stop4StoppedAt = ParseDateTime(m.Stop4StoppedAt),
-            Pause4StartedAt = ParseDateTime(m.Pause4StartedAt),
-            Pause4StoppedAt = ParseDateTime(m.Pause4StoppedAt),
-            Start5StartedAt = ParseDateTime(m.Start5StartedAt),
-            Stop5StoppedAt = ParseDateTime(m.Stop5StoppedAt),
-            Pause5StartedAt = ParseDateTime(m.Pause5StartedAt),
-            Pause5StoppedAt = ParseDateTime(m.Pause5StoppedAt),
+            Start1StartedAt = ParseDateTime(m.Start1StartedAt, userTimeZone),
+            Stop1StoppedAt = ParseDateTime(m.Stop1StoppedAt, userTimeZone),
+            Pause1StartedAt = ParseDateTime(m.Pause1StartedAt, userTimeZone),
+            Pause1StoppedAt = ParseDateTime(m.Pause1StoppedAt, userTimeZone),
+            Start2StartedAt = ParseDateTime(m.Start2StartedAt, userTimeZone),
+            Stop2StoppedAt = ParseDateTime(m.Stop2StoppedAt, userTimeZone),
+            Pause2StartedAt = ParseDateTime(m.Pause2StartedAt, userTimeZone),
+            Pause2StoppedAt = ParseDateTime(m.Pause2StoppedAt, userTimeZone),
+            Start3StartedAt = ParseDateTime(m.Start3StartedAt, userTimeZone),
+            Stop3StoppedAt = ParseDateTime(m.Stop3StoppedAt, userTimeZone),
+            Pause3StartedAt = ParseDateTime(m.Pause3StartedAt, userTimeZone),
+            Pause3StoppedAt = ParseDateTime(m.Pause3StoppedAt, userTimeZone),
+            Start4StartedAt = ParseDateTime(m.Start4StartedAt, userTimeZone),
+            Stop4StoppedAt = ParseDateTime(m.Stop4StoppedAt, userTimeZone),
+            Pause4StartedAt = ParseDateTime(m.Pause4StartedAt, userTimeZone),
+            Pause4StoppedAt = ParseDateTime(m.Pause4StoppedAt, userTimeZone),
+            Start5StartedAt = ParseDateTime(m.Start5StartedAt, userTimeZone),
+            Stop5StoppedAt = ParseDateTime(m.Stop5StoppedAt, userTimeZone),
+            Pause5StartedAt = ParseDateTime(m.Pause5StartedAt, userTimeZone),
+            Pause5StoppedAt = ParseDateTime(m.Pause5StoppedAt, userTimeZone),
             // Detailed pause timestamps for shift 1
-            Pause10StartedAt = ParseDateTime(m.Pause10StartedAt),
-            Pause10StoppedAt = ParseDateTime(m.Pause10StoppedAt),
-            Pause11StartedAt = ParseDateTime(m.Pause11StartedAt),
-            Pause11StoppedAt = ParseDateTime(m.Pause11StoppedAt),
-            Pause12StartedAt = ParseDateTime(m.Pause12StartedAt),
-            Pause12StoppedAt = ParseDateTime(m.Pause12StoppedAt),
-            Pause13StartedAt = ParseDateTime(m.Pause13StartedAt),
-            Pause13StoppedAt = ParseDateTime(m.Pause13StoppedAt),
-            Pause14StartedAt = ParseDateTime(m.Pause14StartedAt),
-            Pause14StoppedAt = ParseDateTime(m.Pause14StoppedAt),
-            Pause15StartedAt = ParseDateTime(m.Pause15StartedAt),
-            Pause15StoppedAt = ParseDateTime(m.Pause15StoppedAt),
-            Pause16StartedAt = ParseDateTime(m.Pause16StartedAt),
-            Pause16StoppedAt = ParseDateTime(m.Pause16StoppedAt),
-            Pause17StartedAt = ParseDateTime(m.Pause17StartedAt),
-            Pause17StoppedAt = ParseDateTime(m.Pause17StoppedAt),
-            Pause18StartedAt = ParseDateTime(m.Pause18StartedAt),
-            Pause18StoppedAt = ParseDateTime(m.Pause18StoppedAt),
-            Pause19StartedAt = ParseDateTime(m.Pause19StartedAt),
-            Pause19StoppedAt = ParseDateTime(m.Pause19StoppedAt),
-            Pause100StartedAt = ParseDateTime(m.Pause100StartedAt),
-            Pause100StoppedAt = ParseDateTime(m.Pause100StoppedAt),
-            Pause101StartedAt = ParseDateTime(m.Pause101StartedAt),
-            Pause101StoppedAt = ParseDateTime(m.Pause101StoppedAt),
-            Pause102StartedAt = ParseDateTime(m.Pause102StartedAt),
-            Pause102StoppedAt = ParseDateTime(m.Pause102StoppedAt),
+            Pause10StartedAt = ParseDateTime(m.Pause10StartedAt, userTimeZone),
+            Pause10StoppedAt = ParseDateTime(m.Pause10StoppedAt, userTimeZone),
+            Pause11StartedAt = ParseDateTime(m.Pause11StartedAt, userTimeZone),
+            Pause11StoppedAt = ParseDateTime(m.Pause11StoppedAt, userTimeZone),
+            Pause12StartedAt = ParseDateTime(m.Pause12StartedAt, userTimeZone),
+            Pause12StoppedAt = ParseDateTime(m.Pause12StoppedAt, userTimeZone),
+            Pause13StartedAt = ParseDateTime(m.Pause13StartedAt, userTimeZone),
+            Pause13StoppedAt = ParseDateTime(m.Pause13StoppedAt, userTimeZone),
+            Pause14StartedAt = ParseDateTime(m.Pause14StartedAt, userTimeZone),
+            Pause14StoppedAt = ParseDateTime(m.Pause14StoppedAt, userTimeZone),
+            Pause15StartedAt = ParseDateTime(m.Pause15StartedAt, userTimeZone),
+            Pause15StoppedAt = ParseDateTime(m.Pause15StoppedAt, userTimeZone),
+            Pause16StartedAt = ParseDateTime(m.Pause16StartedAt, userTimeZone),
+            Pause16StoppedAt = ParseDateTime(m.Pause16StoppedAt, userTimeZone),
+            Pause17StartedAt = ParseDateTime(m.Pause17StartedAt, userTimeZone),
+            Pause17StoppedAt = ParseDateTime(m.Pause17StoppedAt, userTimeZone),
+            Pause18StartedAt = ParseDateTime(m.Pause18StartedAt, userTimeZone),
+            Pause18StoppedAt = ParseDateTime(m.Pause18StoppedAt, userTimeZone),
+            Pause19StartedAt = ParseDateTime(m.Pause19StartedAt, userTimeZone),
+            Pause19StoppedAt = ParseDateTime(m.Pause19StoppedAt, userTimeZone),
+            Pause100StartedAt = ParseDateTime(m.Pause100StartedAt, userTimeZone),
+            Pause100StoppedAt = ParseDateTime(m.Pause100StoppedAt, userTimeZone),
+            Pause101StartedAt = ParseDateTime(m.Pause101StartedAt, userTimeZone),
+            Pause101StoppedAt = ParseDateTime(m.Pause101StoppedAt, userTimeZone),
+            Pause102StartedAt = ParseDateTime(m.Pause102StartedAt, userTimeZone),
+            Pause102StoppedAt = ParseDateTime(m.Pause102StoppedAt, userTimeZone),
             // Detailed pause timestamps for shift 2
-            Pause20StartedAt = ParseDateTime(m.Pause20StartedAt),
-            Pause20StoppedAt = ParseDateTime(m.Pause20StoppedAt),
-            Pause21StartedAt = ParseDateTime(m.Pause21StartedAt),
-            Pause21StoppedAt = ParseDateTime(m.Pause21StoppedAt),
-            Pause22StartedAt = ParseDateTime(m.Pause22StartedAt),
-            Pause22StoppedAt = ParseDateTime(m.Pause22StoppedAt),
-            Pause23StartedAt = ParseDateTime(m.Pause23StartedAt),
-            Pause23StoppedAt = ParseDateTime(m.Pause23StoppedAt),
-            Pause24StartedAt = ParseDateTime(m.Pause24StartedAt),
-            Pause24StoppedAt = ParseDateTime(m.Pause24StoppedAt),
-            Pause25StartedAt = ParseDateTime(m.Pause25StartedAt),
-            Pause25StoppedAt = ParseDateTime(m.Pause25StoppedAt),
-            Pause26StartedAt = ParseDateTime(m.Pause26StartedAt),
-            Pause26StoppedAt = ParseDateTime(m.Pause26StoppedAt),
-            Pause27StartedAt = ParseDateTime(m.Pause27StartedAt),
-            Pause27StoppedAt = ParseDateTime(m.Pause27StoppedAt),
-            Pause28StartedAt = ParseDateTime(m.Pause28StartedAt),
-            Pause28StoppedAt = ParseDateTime(m.Pause28StoppedAt),
-            Pause29StartedAt = ParseDateTime(m.Pause29StartedAt),
-            Pause29StoppedAt = ParseDateTime(m.Pause29StoppedAt),
-            Pause200StartedAt = ParseDateTime(m.Pause200StartedAt),
-            Pause200StoppedAt = ParseDateTime(m.Pause200StoppedAt),
-            Pause201StartedAt = ParseDateTime(m.Pause201StartedAt),
-            Pause201StoppedAt = ParseDateTime(m.Pause201StoppedAt),
-            Pause202StartedAt = ParseDateTime(m.Pause202StartedAt),
-            Pause202StoppedAt = ParseDateTime(m.Pause202StoppedAt),
+            Pause20StartedAt = ParseDateTime(m.Pause20StartedAt, userTimeZone),
+            Pause20StoppedAt = ParseDateTime(m.Pause20StoppedAt, userTimeZone),
+            Pause21StartedAt = ParseDateTime(m.Pause21StartedAt, userTimeZone),
+            Pause21StoppedAt = ParseDateTime(m.Pause21StoppedAt, userTimeZone),
+            Pause22StartedAt = ParseDateTime(m.Pause22StartedAt, userTimeZone),
+            Pause22StoppedAt = ParseDateTime(m.Pause22StoppedAt, userTimeZone),
+            Pause23StartedAt = ParseDateTime(m.Pause23StartedAt, userTimeZone),
+            Pause23StoppedAt = ParseDateTime(m.Pause23StoppedAt, userTimeZone),
+            Pause24StartedAt = ParseDateTime(m.Pause24StartedAt, userTimeZone),
+            Pause24StoppedAt = ParseDateTime(m.Pause24StoppedAt, userTimeZone),
+            Pause25StartedAt = ParseDateTime(m.Pause25StartedAt, userTimeZone),
+            Pause25StoppedAt = ParseDateTime(m.Pause25StoppedAt, userTimeZone),
+            Pause26StartedAt = ParseDateTime(m.Pause26StartedAt, userTimeZone),
+            Pause26StoppedAt = ParseDateTime(m.Pause26StoppedAt, userTimeZone),
+            Pause27StartedAt = ParseDateTime(m.Pause27StartedAt, userTimeZone),
+            Pause27StoppedAt = ParseDateTime(m.Pause27StoppedAt, userTimeZone),
+            Pause28StartedAt = ParseDateTime(m.Pause28StartedAt, userTimeZone),
+            Pause28StoppedAt = ParseDateTime(m.Pause28StoppedAt, userTimeZone),
+            Pause29StartedAt = ParseDateTime(m.Pause29StartedAt, userTimeZone),
+            Pause29StoppedAt = ParseDateTime(m.Pause29StoppedAt, userTimeZone),
+            Pause200StartedAt = ParseDateTime(m.Pause200StartedAt, userTimeZone),
+            Pause200StoppedAt = ParseDateTime(m.Pause200StoppedAt, userTimeZone),
+            Pause201StartedAt = ParseDateTime(m.Pause201StartedAt, userTimeZone),
+            Pause201StoppedAt = ParseDateTime(m.Pause201StoppedAt, userTimeZone),
+            Pause202StartedAt = ParseDateTime(m.Pause202StartedAt, userTimeZone),
+            Pause202StoppedAt = ParseDateTime(m.Pause202StoppedAt, userTimeZone),
             // Netto hours override
             NettoHoursOverride = m.NettoHoursOverride,
             NettoHoursOverrideActive = m.NettoHoursOverrideActive,
         };
     }
 
-    private static DateTime? ParseDateTime(string s) =>
-        string.IsNullOrEmpty(s)
-            ? null
-            : DateTime.Parse(s, System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal);
+    /// <summary>
+    /// Parses an incoming shift timestamp string for persistence.
+    /// PlanRegistration exact-timestamp columns hold the user's LOCAL wall time
+    /// by convention (all live punch flows write local, Kind=Unspecified).
+    /// Therefore:
+    /// <list type="bullet">
+    /// <item>Strings WITHOUT a zone designator (e.g. Dart DateTime.toString(),
+    /// "2026-07-07T06:30:00" or "2026-07-07 06:30:00") are already wall time and
+    /// are parsed byte-verbatim — no conversion (Kind=Unspecified).</item>
+    /// <item>Strings WITH an explicit zone designator (Z or ±hh:mm, e.g. UTC ISO
+    /// strings sent by the app's register/edit-shift screen) denote an absolute
+    /// instant and are converted to the user's time zone wall time so the stored
+    /// digits match the convention (Kind=Unspecified).</item>
+    /// </list>
+    /// Malformed input throws <see cref="FormatException"/> (unchanged behavior).
+    /// </summary>
+    private static DateTime? ParseDateTime(string s, TimeZoneInfo userTimeZone)
+    {
+        if (string.IsNullOrEmpty(s))
+        {
+            return null;
+        }
+
+        var parsed = DateTime.Parse(s, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind);
+
+        if (parsed.Kind == DateTimeKind.Unspecified)
+        {
+            // Naive string — already user-local wall time; keep verbatim.
+            return parsed;
+        }
+
+        // Explicit zone designator: Kind is Utc ("Z") or Local (±hh:mm offset);
+        // ToUniversalTime() handles both, then convert to the user's wall time.
+        return DateTime.SpecifyKind(
+            TimeZoneInfo.ConvertTimeFromUtc(parsed.ToUniversalTime(), userTimeZone),
+            DateTimeKind.Unspecified);
+    }
 }


### PR DESCRIPTION
## Live regression

PlanRegistration exact timestamps (`Start/Stop/Pause*At`) store **local wall time** — every live punch across all tenants writes wall digits (verified against the UTC version-audit clock to within seconds). Since the **June 25 app release**, the app's register/edit shift flow sends **Z-suffixed UTC** strings, which `ParseDateTime` (`DateTimeStyles.AssumeUniversal`) stored verbatim as UTC instants. On one-minute sites those rows display ~2h wrong on web, app lists and Excel. **Live on tenants 986 and 1123 since 2026-07-03**, a few rows per day.

## Fix — parse decision table

`TimePlanningPlanningsGrpcService.ParseDateTime` now normalizes at the transport boundary; **read paths untouched**:

| Incoming gRPC timestamp | Before | After |
|---|---|---|
| Naive wall digits (`2026-07-03T14:07:00`, no zone designator) | stored byte-verbatim | stored byte-verbatim (unchanged) |
| Explicit UTC (`...Z`) | stored verbatim as UTC digits (**the bug** — displays shifted) | converted to the current user's timezone → naive wall digits stored |
| Explicit offset (`...+02:00` etc.) | normalized to UTC digits (wrong) | converted to the user's timezone → naive wall digits stored |

The user's timezone is resolved once per write request; **Europe/Copenhagen fallback** because the host's own fallback id is Windows-only and throws on Linux. Covered by `TimePlanningPlanningsGrpcServiceTimeZoneTests` (wired into dotnet CI shard h).

## Scope note

This is stage 1 extracted from PR #1637. The display-parity chain for sites flipping `UseOneMinuteIntervals` (mode-at-registration rendering) stays in #1637, pending a write-time mode-marker schema decision (option A). The app-side `toUtc()` removal ships separately with the next app release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)