### PR TITLE
fix(working-hours): mobile flex/worked from seconds recompute + exclude removed rows

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -250,7 +250,7 @@ jobs:
           - name: c
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
           - name: d
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.MobileFlexRecomputeAndCascadeTests"
           - name: e
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
           - name: f

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -239,7 +239,7 @@ jobs:
           - name: c
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanningServiceMultiShiftTests|FullyQualifiedName=TimePlanning.Pn.Test.ScheduleMessageReadTests|FullyQualifiedName=TimePlanning.Pn.Test.DeviceTokenServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.GpsCoordinateServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayDayTypeRuleServiceTests"
           - name: d
-            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests"
+            filter: "FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationVersionHistoryTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetControllerTests|FullyQualifiedName=TimePlanning.Pn.Test.PayRuleSetServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTierRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.MobileFlexRecomputeAndCascadeTests"
           - name: e
             filter: "FullyQualifiedName=TimePlanning.Pn.Test.PushNotificationIntegrationTests|FullyQualifiedName=TimePlanning.Pn.Test.WorkingHoursDisplayParityTests|FullyQualifiedName=TimePlanning.Pn.Test.PayTimeBandRuleServiceTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperComputationTests|FullyQualifiedName=TimePlanning.Pn.Test.PlanRegistrationHelperHolidayTests"
           - name: f

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/MobileFlexRecomputeAndCascadeTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/MobileFlexRecomputeAndCascadeTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Database.Entities;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers.PluginDbOptions;
+using Microting.EformAngularFrontendBase.Infrastructure.Data;
+using Microting.eForm.Infrastructure.Constants;
+using NSubstitute;
+using NUnit.Framework;
+using TimePlanning.Pn.Infrastructure.Models.Settings;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.Index;
+using TimePlanning.Pn.Infrastructure.Models.WorkingHours.UpdateCreate;
+using TimePlanning.Pn.Services.TimePlanningLocalizationService;
+using TimePlanning.Pn.Services.TimePlanningWorkingHoursService;
+using AssignedSiteEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.AssignedSite;
+using PlanRegistrationEntity = Microting.TimePlanningBase.Infrastructure.Data.Entities.PlanRegistration;
+using SdkLanguage = Microting.eForm.Infrastructure.Data.Entities.Language;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using SdkSiteWorker = Microting.eForm.Infrastructure.Data.Entities.SiteWorker;
+using SdkWorker = Microting.eForm.Infrastructure.Data.Entities.Worker;
+
+namespace TimePlanning.Pn.Test;
+
+/// <summary>
+/// Pins the mobile-vs-web flex divergence on UseOneMinuteIntervals sites.
+///
+/// Root cause: the web grid (<see cref="TimePlanningWorkingHoursService.Index"/>)
+/// recomputes the running flex balance from the second-precision columns, but the
+/// mobile period-status hero
+/// (<see cref="TimePlanningWorkingHoursService.CalculateHoursSummary"/>) used to read
+/// the <c>double</c> <c>SumFlexEnd</c> column verbatim. That double is rewritten —
+/// and left inconsistent with the <c>*InSeconds</c> source of truth — by
+/// <c>CreateUpdate</c>'s forward cascade, which recomputed only the doubles and
+/// ignored <c>NettoHoursOverrideActive</c>. So after editing an early day the
+/// mobile summary disagreed with the web grid.
+///
+/// The two tests here FAIL on the pre-fix code (documenting the bug) and PASS once
+/// (1) <c>CalculateHoursSummary</c> recomputes via the shared chain and
+/// (2) the cascade routes UseOneMinuteIntervals rows through
+/// <c>ApplyNettoFlexChainSecondPrecision</c>.
+/// </summary>
+[TestFixture]
+public class MobileFlexRecomputeAndCascadeTests : TestBaseSetup
+{
+    private const int SiteUid = 8123;
+    private const string UserEmail = "flexuser@example.com";
+
+    private TimePlanningWorkingHoursService _service = null!;
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        await base.Setup();
+
+        var core = await GetCore();
+        var sdkDb = core.DbContextHelper.GetDbContext();
+
+        // --- SDK graph: site + worker + siteworker, keyed by the user's email ---
+        var language = await sdkDb.Languages.FirstOrDefaultAsync(l => l.LanguageCode == "da");
+        if (language == null)
+        {
+            language = new SdkLanguage { LanguageCode = "da", Name = "Danish" };
+            await language.Create(sdkDb);
+        }
+
+        var site = new SdkSite { Name = $"Site {SiteUid}", MicrotingUid = SiteUid };
+        await site.Create(sdkDb);
+        var worker = new SdkWorker
+        {
+            FirstName = "Flex",
+            LastName = "User",
+            Email = UserEmail,
+            MicrotingUid = 1000 + SiteUid
+        };
+        await worker.Create(sdkDb);
+        await new SdkSiteWorker
+        {
+            SiteId = site.Id,
+            WorkerId = worker.Id,
+            MicrotingUid = 2000 + SiteUid
+        }.Create(sdkDb);
+
+        // --- Base frontend context: one EformUser matched by email ---
+        var sdkConn = sdkDb.Database.GetConnectionString()!;
+        var baseConn = sdkConn.Replace("420_SDK", "420_baseflextest");
+        var baseOptions = new DbContextOptionsBuilder<BaseDbContext>()
+            .UseMySql(baseConn, new MariaDbServerVersion(ServerVersion.AutoDetect(sdkConn)))
+            .Options;
+        var baseDbContext = new BaseDbContext(baseOptions);
+        baseDbContext.Database.EnsureDeleted();
+        baseDbContext.Database.EnsureCreated();
+        var eformUser = new EformUser
+        {
+            FirstName = "Flex",
+            LastName = "User",
+            UserName = UserEmail,
+            NormalizedUserName = UserEmail.ToUpperInvariant(),
+            Email = UserEmail,
+            NormalizedEmail = UserEmail.ToUpperInvariant(),
+            SecurityStamp = Guid.NewGuid().ToString(),
+            ConcurrencyStamp = Guid.NewGuid().ToString()
+        };
+        baseDbContext.Users.Add(eformUser);
+        await baseDbContext.SaveChangesAsync();
+
+        // --- AssignedSite: UseOneMinuteIntervals ON (the affected population) ---
+        await new AssignedSiteEntity
+        {
+            SiteId = SiteUid,
+            UseOneMinuteIntervals = true,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        }.Create(TimePlanningPnDbContext!);
+
+        // --- Service under test with real base context + mocked user service ---
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(language);
+        userService.GetCurrentUserAsync().Returns(eformUser);
+
+        var localizationService = Substitute.For<ITimePlanningLocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
+
+        var coreService = Substitute.For<IEFormCoreService>();
+        coreService.GetCore().Returns(core);
+
+        var options = Substitute.For<IPluginDbOptions<TimePlanningBaseSettings>>();
+        options.Value.Returns(new TimePlanningBaseSettings
+        {
+            AutoBreakCalculationActive = "0",
+            DayOfPayment = 20,
+            GpsEnabled = "0",
+            SnapshotEnabled = "0"
+        });
+
+        _service = new TimePlanningWorkingHoursService(
+            Substitute.For<ILogger<TimePlanningWorkingHoursService>>(),
+            TimePlanningPnDbContext!,
+            userService,
+            localizationService,
+            baseDbContext,
+            options,
+            coreService);
+    }
+
+    /// <summary>
+    /// Seeds a UseOneMinuteIntervals row whose double and *InSeconds flex columns
+    /// are given explicitly, so a test can start them in sync (or deliberately
+    /// out of sync).
+    /// </summary>
+    private async Task SeedRow(
+        DateTime date,
+        int start1Id, int stop1Id,
+        int nettoSeconds, int flexSeconds,
+        int sumFlexStartSeconds, int sumFlexEndSeconds,
+        int planHoursSeconds,
+        double doubleSumFlexEndOverride,
+        bool overrideActive = false, double nettoHoursOverride = 0)
+    {
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = SiteUid,
+            Date = date,
+            Start1Id = start1Id,
+            Stop1Id = stop1Id,
+            PlanHours = planHoursSeconds / 3600.0,
+            PlanHoursInSeconds = planHoursSeconds,
+            NettoHours = nettoSeconds / 3600.0,
+            NettoHoursInSeconds = nettoSeconds,
+            Flex = flexSeconds / 3600.0,
+            FlexInSeconds = flexSeconds,
+            SumFlexStart = sumFlexStartSeconds / 3600.0,
+            SumFlexStartInSeconds = sumFlexStartSeconds,
+            SumFlexEnd = doubleSumFlexEndOverride,
+            SumFlexEndInSeconds = sumFlexEndSeconds,
+            NettoHoursOverrideActive = overrideActive,
+            NettoHoursOverride = nettoHoursOverride,
+            RegisteredUnderOneMinuteIntervals = true,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        }.Create(TimePlanningPnDbContext!);
+    }
+
+    // ------------------------------------------------------------------
+    // (a) End-to-end: an early-day edit drives the forward cascade; the web
+    //     grid and the mobile summary must agree afterwards, and the cascade
+    //     must not leave the double SumFlexEnd inconsistent with the seconds.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EarlyEdit_Cascade_WebGridAndMobileSummaryAgree_AndDoubleMatchesSeconds()
+    {
+        var anchorDate = new DateTime(2026, 3, 2); // opening balance carrier
+        var d1 = new DateTime(2026, 3, 3);         // EARLY day to edit
+        var d2 = new DateTime(2026, 3, 4);         // later, NettoHoursOverride active
+        var d3 = new DateTime(2026, 3, 5);         // later, normal
+
+        // Opening balance = +1h (3600s), everything in sync.
+        await SeedRow(anchorDate, 98, 205, nettoSeconds: 32100, flexSeconds: 3600,
+            sumFlexStartSeconds: 0, sumFlexEndSeconds: 3600, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 3600 / 3600.0);
+        // D1: 08:05-16:00 = 28500s, plan 8h => flex -300. SumFlex 3600 -> 3300.
+        await SeedRow(d1, 98, 193, nettoSeconds: 28500, flexSeconds: -300,
+            sumFlexStartSeconds: 3600, sumFlexEndSeconds: 3300, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 3300 / 3600.0);
+        // D2: worked 28500s but NettoHoursOverride=10h => flex uses override: 36000-28800=7200.
+        await SeedRow(d2, 98, 193, nettoSeconds: 28500, flexSeconds: 7200,
+            sumFlexStartSeconds: 3300, sumFlexEndSeconds: 10500, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 10500 / 3600.0,
+            overrideActive: true, nettoHoursOverride: 10.0);
+        // D3: 28500s, plan 8h => flex -300. SumFlex 10500 -> 10200.
+        await SeedRow(d3, 98, 193, nettoSeconds: 28500, flexSeconds: -300,
+            sumFlexStartSeconds: 10500, sumFlexEndSeconds: 10200, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 10200 / 3600.0);
+
+        // Edit ONLY the early day D1: extend Stop1 to 20:00 (Id 241) => 42900s worked.
+        // This triggers CreateUpdate's forward cascade over D2 and D3.
+        var edit = new TimePlanningWorkingHoursUpdateCreateModel
+        {
+            SiteId = SiteUid,
+            Plannings = new System.Collections.Generic.List<TimePlanningWorkingHoursModel>
+            {
+                new()
+                {
+                    Date = d1,
+                    Shift1Start = 98,
+                    Shift1Stop = 241,
+                    Shift1Pause = 0,
+                    PlanHours = 8.0,
+                    NettoHours = 0,   // recomputed from shifts on a one-minute site
+                    FlexHours = 0,    // recomputed
+                    PaidOutFlex = "0",
+                    Message = 10,     // 10 => MessageId null
+                    PlanText = "",
+                    CommentOffice = "",
+                    CommentOfficeAll = "",
+                    CommentWorker = ""
+                }
+            }
+        };
+        var updateResult = await _service.CreateUpdate(edit);
+        Assert.That(updateResult.Success, Is.True, updateResult.Message);
+
+        // Web grid recompute (correct oracle).
+        var index = await _service.Index(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = SiteUid,
+            DateFrom = d1,
+            DateTo = d3
+        });
+        Assert.That(index.Success, Is.True, index.Message);
+        var webLastDayFlex = index.Model.Single(x => x.Date == d3).SumFlexEnd;
+
+        // Mobile period-status hero.
+        var summary = await _service.CalculateHoursSummary(d1, d3, null, null, null, null);
+        Assert.That(summary.Success, Is.True, summary.Message);
+        var mobileDifference = summary.Model.Difference;
+
+        // Inspect the cascaded later day's stored columns.
+        var d3Row = await TimePlanningPnDbContext!.PlanRegistrations
+            .AsNoTracking().SingleAsync(x => x.SdkSitId == SiteUid && x.Date == d3);
+
+        Assert.Multiple(() =>
+        {
+            // (1) The mobile summary must agree with the web grid. Pre-fix the mobile
+            //     read of the (override-blind, cascade-rewritten) double diverges.
+            Assert.That(mobileDifference, Is.EqualTo(webLastDayFlex).Within(1e-6),
+                "Mobile CalculateHoursSummary.Difference must match the web grid's recomputed last-day flex.");
+
+            // (2) The cascade must leave the double SumFlexEnd consistent with the
+            //     seconds source of truth. Pre-fix the override-blind double drifts.
+            Assert.That(d3Row.SumFlexEndInSeconds / 3600.0, Is.EqualTo(d3Row.SumFlexEnd).Within(1e-6),
+                "Cascaded row's double SumFlexEnd must equal SumFlexEndInSeconds/3600.");
+
+            // And the agreed value is the seconds-chain truth:
+            //   opening 3600 + D1 14100 + D2 override 7200 + D3 -300 = 24600s = 6.8333h
+            Assert.That(mobileDifference, Is.EqualTo(24600 / 3600.0).Within(1e-6));
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (b) Direct: a stale double SumFlexEnd with correct seconds columns —
+    //     CalculateHoursSummary must return the seconds-derived value.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task CalculateHoursSummary_OneMinuteSite_UsesSecondsDerivedFlex_NotStaleDouble()
+    {
+        var d1 = new DateTime(2026, 4, 1);
+        var d2 = new DateTime(2026, 4, 2);
+
+        // Seconds columns correct (each day +1h): end-of-period = 2h = 7200s.
+        // Double SumFlexEnd deliberately garbage to prove it is not read.
+        await SeedRow(d1, 98, 205, nettoSeconds: 32400, flexSeconds: 3600,
+            sumFlexStartSeconds: 0, sumFlexEndSeconds: 3600, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 99.0);
+        await SeedRow(d2, 98, 205, nettoSeconds: 32400, flexSeconds: 3600,
+            sumFlexStartSeconds: 3600, sumFlexEndSeconds: 7200, planHoursSeconds: 28800,
+            doubleSumFlexEndOverride: 88.0);
+
+        var summary = await _service.CalculateHoursSummary(d1, d2, null, null, null, null);
+        Assert.That(summary.Success, Is.True, summary.Message);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(summary.Model.Difference, Is.EqualTo(7200 / 3600.0).Within(1e-6),
+                "Difference must be the seconds-derived 2.0h, not the stale double 88.0.");
+            Assert.That(summary.Model.Difference, Is.Not.EqualTo(88.0).Within(1e-6),
+                "The stale double SumFlexEnd column must never be surfaced.");
+        });
+    }
+}

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -281,6 +281,7 @@ public class TimePlanningWorkingHoursService(
 
             var lastPlanning = dbContext.PlanRegistrations
                 .AsNoTracking()
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .Where(x => x.Date < model.DateFrom)
                 .Where(x => x.SdkSitId == model.SiteId).OrderBy(x => x.Date).LastOrDefault();
 
@@ -420,94 +421,10 @@ public class TimePlanningWorkingHoursService(
                         ?? oneMinuteTimeline.WasOneMinuteAt(timePlanning.Date));
             }
 
-            var j = 0;
-            double sumFlexEnd = 0;
-            // Phase 2: parallel running balance in seconds for flag-on chain.
-            int sumFlexEndInSeconds = 0;
-            //double SumFlexStart = 0;
-            foreach (var timePlanningWorkingHoursModel in timePlannings)
-            {
-                if (j == 0)
-                {
-                    if (useOneMinuteIntervals)
-                    {
-                        // Phase 2: chain in seconds; back-derive doubles via /3600.0.
-                        timePlanningWorkingHoursModel.SumFlexStartInSeconds =
-                            timePlanningWorkingHoursModel.SumFlexStartInSeconds;
-                        timePlanningWorkingHoursModel.SumFlexStart =
-                            timePlanningWorkingHoursModel.SumFlexStartInSeconds / 3600.0;
-                        timePlanningWorkingHoursModel.SumFlexEndInSeconds =
-                            timePlanningWorkingHoursModel.SumFlexStartInSeconds
-                            + timePlanningWorkingHoursModel.FlexInSeconds
-                            - timePlanningWorkingHoursModel.PaiedOutFlexInSeconds;
-                        timePlanningWorkingHoursModel.SumFlexEnd =
-                            timePlanningWorkingHoursModel.SumFlexEndInSeconds / 3600.0;
-                        sumFlexEndInSeconds = timePlanningWorkingHoursModel.SumFlexEndInSeconds;
-                        sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
-                    }
-                    else
-                    {
-                        timePlanningWorkingHoursModel.SumFlexStart =
-                            Math.Round(timePlanningWorkingHoursModel.SumFlexStart, 2);
-                        timePlanningWorkingHoursModel.SumFlexEnd = Math.Round(
-                            timePlanningWorkingHoursModel.SumFlexStart + timePlanningWorkingHoursModel.FlexHours -
-                            (string.IsNullOrEmpty(timePlanningWorkingHoursModel.PaidOutFlex)
-                                ? 0
-                                : double.Parse(timePlanningWorkingHoursModel.PaidOutFlex.Replace(",", "."),
-                                    CultureInfo.InvariantCulture)), 2);
-                        sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
-                    }
-                }
-                else
-                {
-                    if (useOneMinuteIntervals)
-                    {
-                        timePlanningWorkingHoursModel.SumFlexStartInSeconds = sumFlexEndInSeconds;
-                        timePlanningWorkingHoursModel.SumFlexStart = sumFlexEndInSeconds / 3600.0;
-                        try
-                        {
-                            timePlanningWorkingHoursModel.SumFlexEndInSeconds =
-                                timePlanningWorkingHoursModel.SumFlexStartInSeconds
-                                + timePlanningWorkingHoursModel.FlexInSeconds
-                                - timePlanningWorkingHoursModel.PaiedOutFlexInSeconds;
-                            timePlanningWorkingHoursModel.SumFlexEnd =
-                                timePlanningWorkingHoursModel.SumFlexEndInSeconds / 3600.0;
-                        }
-                        catch (Exception e)
-                        {
-                            SentrySdk.CaptureException(e);
-                            logger.LogError(e.Message);
-                            logger.LogTrace(e.StackTrace);
-                        }
-
-                        sumFlexEndInSeconds = timePlanningWorkingHoursModel.SumFlexEndInSeconds;
-                        sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
-                    }
-                    else
-                    {
-                        timePlanningWorkingHoursModel.SumFlexStart = sumFlexEnd;
-                        try
-                        {
-                            timePlanningWorkingHoursModel.SumFlexEnd = Math.Round(
-                                timePlanningWorkingHoursModel.SumFlexStart + timePlanningWorkingHoursModel.FlexHours -
-                                (string.IsNullOrEmpty(timePlanningWorkingHoursModel.PaidOutFlex)
-                                    ? 0
-                                    : double.Parse(timePlanningWorkingHoursModel.PaidOutFlex.Replace(",", "."),
-                                        CultureInfo.InvariantCulture)), 2);
-                        }
-                        catch (Exception e)
-                        {
-                            SentrySdk.CaptureException(e);
-                            logger.LogError(e.Message);
-                            logger.LogTrace(e.StackTrace);
-                        }
-
-                        sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
-                    }
-                }
-
-                j++;
-            }
+            // Single source of truth for the running flex balance rendered by
+            // both this web grid AND the mobile period-status hero
+            // (CalculateHoursSummary) — see ApplyRunningFlexChain.
+            ApplyRunningFlexChain(timePlannings, useOneMinuteIntervals);
 
             return new OperationDataResult<List<TimePlanningWorkingHoursModel>>(
                 true,
@@ -532,6 +449,12 @@ public class TimePlanningWorkingHoursService(
                 .Where(x => x.SdkSitId == model.SiteId)
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .ToListAsync();
+            // Site-level one-minute flag drives the forward-cascade recompute below
+            // so the double AND *InSeconds SumFlex columns are written consistently.
+            var assignedSite = await dbContext.AssignedSites
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .FirstOrDefaultAsync(x => x.SiteId == model.SiteId);
+            var useOneMinuteIntervals = assignedSite?.UseOneMinuteIntervals ?? false;
             var first = true;
             foreach (var planning in model.Plannings)
             {
@@ -574,20 +497,43 @@ public class TimePlanningWorkingHoursService(
                             .OrderByDescending(x => x.Date)
                             .FirstOrDefaultAsync();
 
-                    if (preTimePlanning != null)
+                    // Re-chain the running flex balance for this later day off the
+                    // preceding row. On UseOneMinuteIntervals sites route through the
+                    // seconds-precision helper so BOTH the *InSeconds source of truth
+                    // AND the back-derived double columns stay consistent — previously
+                    // this rewrote only the doubles (and ignored NettoHoursOverride),
+                    // so the double SumFlexEnd drifted from the seconds chain and the
+                    // mobile summary (which read the double) disagreed with the web
+                    // grid (which recomputes from seconds).
+                    if (useOneMinuteIntervals)
                     {
-                        planRegistration.SumFlexStart = preTimePlanning.SumFlexEnd;
-                        planRegistration.SumFlexEnd = preTimePlanning.SumFlexEnd + planRegistration.NettoHours -
-                                                      planRegistration.PlanHours -
-                                                      planRegistration.PaiedOutFlex;
-                        planRegistration.Flex = planRegistration.NettoHours - planRegistration.PlanHours;
+                        PlanRegistrationHelper.ApplyNettoFlexChainSecondPrecision(
+                            planRegistration,
+                            preTimePlanning?.SumFlexEndInSeconds ?? 0,
+                            preTimePlanning != null);
                     }
                     else
                     {
-                        planRegistration.SumFlexEnd = planRegistration.NettoHours - planRegistration.PlanHours -
-                                                      planRegistration.PaiedOutFlex;
-                        planRegistration.SumFlexStart = 0;
-                        planRegistration.Flex = planRegistration.NettoHours - planRegistration.PlanHours;
+                        // Flag-off path keeps the legacy double formula but now honours
+                        // NettoHoursOverrideActive, matching UpdatePlanRegistration.
+                        var effectiveNettoHours = planRegistration.NettoHoursOverrideActive
+                            ? planRegistration.NettoHoursOverride
+                            : planRegistration.NettoHours;
+                        if (preTimePlanning != null)
+                        {
+                            planRegistration.SumFlexStart = preTimePlanning.SumFlexEnd;
+                            planRegistration.SumFlexEnd = preTimePlanning.SumFlexEnd + effectiveNettoHours -
+                                                          planRegistration.PlanHours -
+                                                          planRegistration.PaiedOutFlex;
+                        }
+                        else
+                        {
+                            planRegistration.SumFlexStart = 0;
+                            planRegistration.SumFlexEnd = effectiveNettoHours - planRegistration.PlanHours -
+                                                          planRegistration.PaiedOutFlex;
+                        }
+
+                        planRegistration.Flex = effectiveNettoHours - planRegistration.PlanHours;
                     }
 
                     await planRegistration.Update(dbContext);
@@ -652,7 +598,9 @@ public class TimePlanningWorkingHoursService(
                 planRegistration.RegisteredUnderOneMinuteIntervals = assignedSite?.UseOneMinuteIntervals;
 
                 var preTimePlanning =
-                    await dbContext.PlanRegistrations.AsNoTracking().Where(x => x.Date < planRegistration.Date
+                    await dbContext.PlanRegistrations.AsNoTracking()
+                        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                        .Where(x => x.Date < planRegistration.Date
                             && x.SdkSitId == planRegistration.SdkSitId).OrderByDescending(x => x.Date)
                         .FirstOrDefaultAsync();
                 if (preTimePlanning != null)
@@ -918,14 +866,67 @@ public class TimePlanningWorkingHoursService(
             var totalPlanHours = planRegistrations.Sum(x => x.PlanHours);
             var totalNettoHours = planRegistrations.Sum(x => x.NettoHours);
             var totalPaidOutFlex = planRegistrations.Sum(x => x.PaiedOutFlex);
-            // The flex balance shown on the period status hero card is a point-in-time
-            // read of the last day's stored SumFlexEnd, not a recomputation of
-            // sum(NettoHours) - sum(PlanHours). The latter ignores opening balance
-            // and mid-period payouts.
-            var lastDay = planRegistrations
-                .OrderByDescending(x => x.Date)
-                .FirstOrDefault();
-            var endOfPeriodFlex = lastDay?.SumFlexEnd ?? 0;
+
+            // The flex balance shown on the period-status hero must agree with the
+            // web grid (Index). Recompute the running balance through the SAME chain
+            // (ApplyRunningFlexChain) instead of reading the stored SumFlexEnd double
+            // column verbatim: on UseOneMinuteIntervals sites the forward cascade
+            // rewrites that double but not the *InSeconds source of truth, so a raw
+            // read drifts. Build the chain rows exactly like Index — the anchor row
+            // (last planning strictly before the period) carries the opening balance
+            // — then take the last in-range day's recomputed SumFlexEnd.
+            var assignedSite = await dbContext.AssignedSites
+                .AsNoTracking()
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .FirstOrDefaultAsync(x => x.SiteId == sdkSite.MicrotingUid);
+            var useOneMinuteIntervals = assignedSite?.UseOneMinuteIntervals ?? false;
+
+            // Anchor = last non-removed planning strictly before the period; carries
+            // the opening balance into the chain. Matches Index's prePlanning anchor
+            // (which also excludes soft-removed rows) so mobile == web.
+            var anchor = await dbContext.PlanRegistrations
+                .AsNoTracking()
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => x.Date < startDate)
+                .Where(x => x.SdkSitId == sdkSite.MicrotingUid)
+                .OrderBy(x => x.Date)
+                .LastOrDefaultAsync();
+
+            // Mirror Index's per-row projection for the flex-relevant fields only.
+            static TimePlanningWorkingHoursModel ToFlexRow(PlanRegistration x) => new()
+            {
+                Date = x.Date,
+                NettoHours = Math.Round(x.NettoHours, 2),
+                FlexHours = Math.Round(x.Flex, 2),
+                SumFlexStart = Math.Round(x.SumFlexStart, 2),
+                PaidOutFlex = x.PaiedOutFlex.ToString().Replace(",", "."),
+                NettoHoursInSeconds = x.NettoHoursInSeconds,
+                FlexInSeconds = x.FlexInSeconds,
+                SumFlexStartInSeconds = x.SumFlexStartInSeconds,
+                SumFlexEndInSeconds = x.SumFlexEndInSeconds,
+                PaiedOutFlexInSeconds = x.PaiedOutFlexInSeconds
+            };
+
+            var inRangeRows = planRegistrations
+                .OrderBy(x => x.Date)
+                .Select(ToFlexRow)
+                .ToList();
+
+            var chainRows = new List<TimePlanningWorkingHoursModel>();
+            if (anchor != null)
+            {
+                chainRows.Add(ToFlexRow(anchor));
+            }
+            chainRows.AddRange(inRangeRows);
+
+            ApplyRunningFlexChain(chainRows, useOneMinuteIntervals);
+
+            // Difference = the last in-range day's recomputed SumFlexEnd (seconds
+            // chain), NOT a raw column read. When the period itself has no rows,
+            // fall back to the anchor's carried-forward balance.
+            var endOfPeriodFlex = inRangeRows.Count > 0
+                ? inRangeRows[^1].SumFlexEnd
+                : (anchor != null ? chainRows[^1].SumFlexEnd : 0);
 
             var summary = new TimePlanningHoursSummaryModel
             {
@@ -956,6 +957,111 @@ public class TimePlanningWorkingHoursService(
         }
     }
 
+
+    /// <summary>
+    /// Applies the running flex-balance chain over an ordered-by-date list of
+    /// working-hours rows. Single source of truth for the flex balance rendered
+    /// by both <see cref="Index"/> (web grid) and <see cref="CalculateHoursSummary"/>
+    /// (mobile period-status hero) so the two never disagree.
+    ///
+    /// For UseOneMinuteIntervals sites the chain runs in the integer
+    /// <c>*InSeconds</c> columns (the source of truth) and back-derives the legacy
+    /// <c>double</c> SumFlex* fields via <c>/3600.0</c>; otherwise it runs in the
+    /// legacy rounded doubles. Behaviour is byte-identical to the loop previously
+    /// inlined in <see cref="Index"/>.
+    /// </summary>
+    private void ApplyRunningFlexChain(
+        List<TimePlanningWorkingHoursModel> timePlannings, bool useOneMinuteIntervals)
+    {
+        var j = 0;
+        double sumFlexEnd = 0;
+        // Phase 2: parallel running balance in seconds for flag-on chain.
+        int sumFlexEndInSeconds = 0;
+        //double SumFlexStart = 0;
+        foreach (var timePlanningWorkingHoursModel in timePlannings)
+        {
+            if (j == 0)
+            {
+                if (useOneMinuteIntervals)
+                {
+                    // Phase 2: chain in seconds; back-derive doubles via /3600.0.
+                    timePlanningWorkingHoursModel.SumFlexStartInSeconds =
+                        timePlanningWorkingHoursModel.SumFlexStartInSeconds;
+                    timePlanningWorkingHoursModel.SumFlexStart =
+                        timePlanningWorkingHoursModel.SumFlexStartInSeconds / 3600.0;
+                    timePlanningWorkingHoursModel.SumFlexEndInSeconds =
+                        timePlanningWorkingHoursModel.SumFlexStartInSeconds
+                        + timePlanningWorkingHoursModel.FlexInSeconds
+                        - timePlanningWorkingHoursModel.PaiedOutFlexInSeconds;
+                    timePlanningWorkingHoursModel.SumFlexEnd =
+                        timePlanningWorkingHoursModel.SumFlexEndInSeconds / 3600.0;
+                    sumFlexEndInSeconds = timePlanningWorkingHoursModel.SumFlexEndInSeconds;
+                    sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
+                }
+                else
+                {
+                    timePlanningWorkingHoursModel.SumFlexStart =
+                        Math.Round(timePlanningWorkingHoursModel.SumFlexStart, 2);
+                    timePlanningWorkingHoursModel.SumFlexEnd = Math.Round(
+                        timePlanningWorkingHoursModel.SumFlexStart + timePlanningWorkingHoursModel.FlexHours -
+                        (string.IsNullOrEmpty(timePlanningWorkingHoursModel.PaidOutFlex)
+                            ? 0
+                            : double.Parse(timePlanningWorkingHoursModel.PaidOutFlex.Replace(",", "."),
+                                CultureInfo.InvariantCulture)), 2);
+                    sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
+                }
+            }
+            else
+            {
+                if (useOneMinuteIntervals)
+                {
+                    timePlanningWorkingHoursModel.SumFlexStartInSeconds = sumFlexEndInSeconds;
+                    timePlanningWorkingHoursModel.SumFlexStart = sumFlexEndInSeconds / 3600.0;
+                    try
+                    {
+                        timePlanningWorkingHoursModel.SumFlexEndInSeconds =
+                            timePlanningWorkingHoursModel.SumFlexStartInSeconds
+                            + timePlanningWorkingHoursModel.FlexInSeconds
+                            - timePlanningWorkingHoursModel.PaiedOutFlexInSeconds;
+                        timePlanningWorkingHoursModel.SumFlexEnd =
+                            timePlanningWorkingHoursModel.SumFlexEndInSeconds / 3600.0;
+                    }
+                    catch (Exception e)
+                    {
+                        SentrySdk.CaptureException(e);
+                        logger.LogError(e.Message);
+                        logger.LogTrace(e.StackTrace);
+                    }
+
+                    sumFlexEndInSeconds = timePlanningWorkingHoursModel.SumFlexEndInSeconds;
+                    sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
+                }
+                else
+                {
+                    timePlanningWorkingHoursModel.SumFlexStart = sumFlexEnd;
+                    try
+                    {
+                        timePlanningWorkingHoursModel.SumFlexEnd = Math.Round(
+                            timePlanningWorkingHoursModel.SumFlexStart + timePlanningWorkingHoursModel.FlexHours -
+                            (string.IsNullOrEmpty(timePlanningWorkingHoursModel.PaidOutFlex)
+                                ? 0
+                                : double.Parse(timePlanningWorkingHoursModel.PaidOutFlex.Replace(",", "."),
+                                    CultureInfo.InvariantCulture)), 2);
+                    }
+                    catch (Exception e)
+                    {
+                        SentrySdk.CaptureException(e);
+                        logger.LogError(e.Message);
+                        logger.LogTrace(e.StackTrace);
+                    }
+
+                    sumFlexEnd = timePlanningWorkingHoursModel.SumFlexEnd;
+                }
+            }
+
+            j++;
+        }
+    }
 
     private static double RoundToTwoDecimalPlaces(double value)
     {


### PR DESCRIPTION
## Root cause

On `UseOneMinuteIntervals` sites, the mobile period-status hero (`CalculateHoursSummary`) read the stored **double** `SumFlexEnd` column verbatim and summed stored `NettoHours`. The web grid (`Index`) instead **recomputes** the running flex balance from the second-precision columns (`FlexInSeconds`/`SumFlex*InSeconds`). When the double columns drift from the seconds columns, mobile shows a wrong flex balance and worked total (e.g. **+34:08 mobile vs +20:14 web**) while the web grid stays correct.

The double columns drift because `CreateUpdate`'s forward-cascade (rewriting every later day after an edit) recomputed **only** the doubles with an ad-hoc formula — it never wrote the `*InSeconds` source of truth, never branched on `UseOneMinuteIntervals`, and ignored `NettoHoursOverrideActive`. So on one-minute sites the double `SumFlexEnd` permanently diverges from the seconds-derived value.

## Fix

**Single source of truth (Part 1).** Extract `Index()`'s running-flex chain into a shared private helper `ApplyRunningFlexChain(rows, useOneMinuteIntervals)` (behavior-preserving — the loop is moved verbatim, `Index` just calls it). `CalculateHoursSummary` now builds the same anchor + in-range rows and runs the **same** chain, deriving `Difference` from the last in-range day's recomputed `SumFlexEnd` instead of a raw column read. `TotalPlanHours`/`TotalNettoHours`/`TotalPaidOutFlex` are unchanged (same in-range rows, same precision).

**Cascade fix (Part 2).** `CreateUpdate`'s forward-cascade now routes one-minute rows through `PlanRegistrationHelper.ApplyNettoFlexChainSecondPrecision` (writing **both** the `*InSeconds` source of truth and the back-derived doubles, honoring `NettoHoursOverrideActive`). The non-one-minute leg keeps the legacy double formula but now also honors `NettoHoursOverrideActive`, matching `UpdatePlanRegistration`. The +180-day window and per-row ordering are preserved.

**Removed-rows filter (Part 2b).** Added the missing `WorkflowState != Removed` filter to two anchor/pre-planning lookups that seed the flex balance:
- `Index()`'s prePlanning anchor (the opening-balance row) — a soft-removed row could previously seed the web chain.
- `CreatePlanning`'s `preTimePlanning` lookup.

All other anchor/pre-planning lookups in `TimePlanningWorkingHoursService` and `PlanRegistrationHelper` already excluded Removed and were left as-is.

## Tests

New `MobileFlexRecomputeAndCascadeTests` (Testcontainers + a real `BaseDbContext`), wired into CI shard **d** in both workflow files:
- **`EarlyEdit_Cascade_WebGridAndMobileSummaryAgree_AndDoubleMatchesSeconds`** — seeds a one-minute site (opening balance + a `NettoHoursOverride` day), edits an early day to trigger the cascade, and asserts (1) mobile `Difference == web` last-day flex and (2) `SumFlexEndInSeconds/3600 == SumFlexEnd` on the cascaded row. Both fail on the pre-fix code (override-blind double drift) and pass after.
- **`CalculateHoursSummary_OneMinuteSite_UsesSecondsDerivedFlex_NotStaleDouble`** — deliberately stale double column with correct seconds; asserts the seconds-derived value is returned.

## Note

A broader `WorkflowState != Removed` audit surfaced additional unrelated sites (payroll export, import, absence, content handover, mobile self-edit, `SiteWorkers`) that also omit the filter; those are being fixed in **separate follow-up PRs** to keep this one scoped to the mobile flex divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)