### PR TITLE
fix(assigned-site): gate admin-only pay-rule-sets fetch on isAdmin

### DIFF
--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.spec.ts
@@ -102,6 +102,38 @@ describe('AssignedSiteDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('Pay rule sets admin gating', () => {
+    it('should fetch pay rule sets for an admin', () => {
+      component.ngOnInit();
+
+      expect(mockPayRuleSetsService.getPayRuleSets).toHaveBeenCalledWith({ offset: 0, pageSize: 1000 });
+    });
+
+    it('should NOT fetch pay rule sets for a non-admin (admin-only endpoint 403s and forces logout)', () => {
+      mockStore.select.mockReturnValue(of(false));
+      // Re-create so the selectCurrentUserIsAdmin$ class field picks up the
+      // non-admin stream (it is captured at construction time).
+      fixture = TestBed.createComponent(AssignedSiteDialogComponent);
+      component = fixture.componentInstance;
+
+      component.ngOnInit();
+
+      expect(mockPayRuleSetsService.getPayRuleSets).not.toHaveBeenCalled();
+    });
+
+    it('should still initialize payRuleSetId from dialog data for a non-admin', () => {
+      mockStore.select.mockReturnValue(of(false));
+      fixture = TestBed.createComponent(AssignedSiteDialogComponent);
+      component = fixture.componentInstance;
+
+      component.ngOnInit();
+
+      expect(component.assignedSiteForm.get('payRuleSetId')).toBeDefined();
+      expect(component.assignedSiteForm.get('payRuleSetId')?.value)
+        .toBe((mockAssignedSiteData as any).payRuleSetId ?? null);
+    });
+  });
+
   describe('Time Conversion Utilities', () => {
     describe('padZero', () => {
       it('should pad single digit numbers with zero', () => {

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
@@ -9,6 +9,7 @@ import {AssignedSiteModel, CommonTagModel, GlobalAutoBreakSettingsModel, PayRule
 import {PayRuleSetsViewModalComponent} from '../../../../modules/pay-rule-sets/components/pay-rule-sets-view-modal/pay-rule-sets-view-modal.component';
 import {selectCurrentUserIsAdmin, selectCurrentUserIsFirstUser} from 'src/app/state';
 import {Store} from '@ngrx/store';
+import {filter, first, switchMap} from 'rxjs/operators';
 import {TimePlanningPnSettingsService, TimePlanningPnPayRuleSetsService} from 'src/app/plugins/modules/time-planning-pn/services';
 import {
   AbstractControl,
@@ -672,7 +673,19 @@ export class AssignedSiteDialogComponent implements DoCheck, OnInit {
   }
 
   loadPayRuleSets(): void {
-    this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}).subscribe({
+    // GET api/time-planning-pn/pay-rule-sets is admin-only
+    // ([Authorize(Roles = Admin)] on PayRuleSetController.Index). Calling it as
+    // a non-admin returns 403, which the global HttpErrorInterceptor escalates
+    // into a forced logout (refresh token → retry → still 403 → logout) — the
+    // local error callback below never runs. The template already hides the
+    // whole payroll-rules block behind selectCurrentUserIsAdmin$, so for
+    // non-admins we skip the fetch entirely; an admin-assigned payRuleSetId is
+    // still preserved on save because the hidden form control keeps its value.
+    this.selectCurrentUserIsAdmin$.pipe(
+      first(),
+      filter((isAdmin) => isAdmin),
+      switchMap(() => this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}))
+    ).subscribe({
       next: (result) => {
         if (result && result.success) {
           this.availablePayRuleSets = result.model?.payRuleSets || [];


### PR DESCRIPTION
## What
Port of microting/eform-backendconfiguration-plugin#1041 (non-admin forced-logout regression) to the timeplanning assigned-site dialog.

`loadPayRuleSets()` in `assigned-site-dialog.component.ts` unconditionally called `GET api/time-planning-pn/pay-rule-sets`, which is `[Authorize(Roles = Admin)]` (PayRuleSetController.Index). For a non-admin, the 403 drives the global `HttpErrorInterceptor`'s 403 branch (refresh token → retry → still 403 → `logout()`) — a forced logout, with the dialog's local `error` callback never running. The template already hides the payroll-rules block behind `selectCurrentUserIsAdmin$`; only the fetch was unguarded.

## Fix
Gate the fetch on `selectCurrentUserIsAdmin$` with `first()` + `filter()` + `switchMap` — identical to the reviewed and e2e-verified BC fix. `first()` before `filter()` is deliberate: the store selector never completes, so the reverse order would leave a dangling unstored subscription for non-admins (this component has no AutoUnsubscribe). An admin-assigned `payRuleSetId` still round-trips for non-admins: the form control is initialized from `MAT_DIALOG_DATA` independent of the fetch, and hidden reactive-form controls keep their value.

## Reachability note (from code review)
Today the dialog is only opened from an isAdmin-gated caller (`time-plannings-table.component.ts` `onFirstColumnClick`), so no non-admin currently hits this path — the change is defense-in-depth so a future loosening of that outer gate cannot reintroduce the forced-logout bug, and it keeps both plugins on the same pattern.

## Tests
New unit tests in `assigned-site-dialog.component.spec.ts`: admin → fetch happens with `{offset: 0, pageSize: 1000}`; non-admin → no fetch, and `payRuleSetId` still initializes from dialog data. Full suite: 48/48 pass locally. Code-reviewed: ship, no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)