### PR TITLE
feat(planning): standard text size in history modal, open to all users

### DIFF
--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/version-history-modal/version-history-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/version-history-modal/version-history-modal.component.scss
@@ -1,3 +1,8 @@
+:host {
+  // Material sizes dialog text via this token (0.875rem); use the app's standard 1rem instead.
+  --mat-dialog-supporting-text-size: 1rem;
+}
+
 .history-header {
   display: flex;
   align-items: flex-start;
@@ -17,7 +22,8 @@
 
 .history-intro {
   margin: 0;
-  font-size: 0.82rem;
+  // Sits inside mat-dialog-title, which would cascade the 21px headline size.
+  font-size: 1rem;
   font-weight: 400;
   color: var(--text-tertiary, #6c757d);
   line-height: 1.35;
@@ -25,7 +31,6 @@
 
 .history-hint {
   margin: 0 0 12px;
-  font-size: 0.8rem;
   color: var(--text-tertiary, #6c757d);
   line-height: 1.4;
 }
@@ -46,7 +51,6 @@
 
 .history-day-heading {
   margin: 0 0 10px;
-  font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
@@ -62,7 +66,7 @@
 
 .history-event {
   display: grid;
-  grid-template-columns: 3.35rem minmax(0, 1fr);
+  grid-template-columns: max-content minmax(0, 1fr);
   gap: 6px 12px;
   align-items: start;
   margin-bottom: 14px;
@@ -73,7 +77,6 @@
 }
 
 .history-time {
-  font-size: 0.82rem;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
   color: var(--text-tertiary, #6c757d);
@@ -85,7 +88,6 @@
 
 .history-action {
   margin: 0 0 4px;
-  font-size: 0.88rem;
   font-weight: 500;
   line-height: 1.4;
 }
@@ -97,7 +99,6 @@
 
 .history-actor {
   margin: 0;
-  font-size: 0.8rem;
   font-weight: 400;
   color: var(--text-tertiary, #6c757d);
 }

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.html
@@ -4,8 +4,6 @@
       {{ datePipe.transform(data.planningPrDayModels.date, 'dd.MM.yyyy') }}
       <small class="microting-uid" matTooltip="Id">({{ data.planningPrDayModels.id }})</small></div>
     <button
-      *ngIf="selectAuthIsAdmin$ | async"
-
       mat-icon-button
       (click)="openVersionHistory()"
       matTooltip="{{'View history' | translate}}">

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/workday-entity/workday-entity-dialog.component.ts
@@ -10,7 +10,7 @@ import {MtxGridColumn} from '@ng-matero/extensions/grid';
 import {TimePlanningPnPlanningsService, TimePlanningPnGpsCoordinatesService, TimePlanningPnPictureSnapshotsService} from '../../../../services';
 import {VersionHistoryModalComponent} from '../version-history-modal/version-history-modal.component';
 import {Store} from '@ngrx/store';
-import {selectAuthIsAdmin, selectCurrentUserIsFirstUser} from 'src/app/state';
+import {selectCurrentUserIsFirstUser} from 'src/app/state';
 import validator from 'validator';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {TemplateFilesService} from 'src/app/common/services';
@@ -54,7 +54,6 @@ export class WorkdayEntityDialogComponent implements OnInit, OnDestroy {
   private originalDialogHeight: string = 'auto';
 
   public selectCurrentUserIsFirstUser$ = this.store.select(selectCurrentUserIsFirstUser);
-  protected selectAuthIsAdmin$ = this.store.select(selectAuthIsAdmin);
 
   TimePlanningMessagesEnum = TimePlanningMessagesEnum;
   enumKeys: string[] = [];


### PR DESCRIPTION
## Summary
- The Aktivitetslog timeline no longer uses extra-small font sizes — all text inherits the dialog's standard size via the `--mat-dialog-supporting-text-size` token (verified live at 14px, equal to the workday dialog's own body text). The time column widened to `max-content` to fit.
- The history button is no longer admin-only — any user can open the Aktivitetslog. The backend endpoint was never admin-restricted, so this is purely removing the frontend `*ngIf` (plus its now-dead selector).

## Verification
Verified live in the browser: computed font-size 14px on every timeline element (action/time/actor/hint/day-heading/intro), matching the dialog body text; time column fits HH:mm without wrapping; the token override is scoped to this dialog's host and cannot leak to other dialogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)