### PR TITLE
fix: resolve device-token SdkSiteId server-side from the JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,5 @@ eform-client/.idea/
 
 .DS_Store
 .claude
+.worktrees/
+.superpowers/

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DeviceTokenServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DeviceTokenServiceTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Database.Entities;
 using Microting.EformAngularFrontendBase.Infrastructure.Data;
 using NSubstitute;
 using NUnit.Framework;
@@ -14,25 +15,22 @@ namespace TimePlanning.Pn.Test;
 public class DeviceTokenServiceTests : TestBaseSetup
 {
     private DeviceTokenService _service = null!;
+    private IUserService _userService = null!;
 
     [SetUp]
     public async Task SetUp()
     {
         await base.Setup();
 
-        // RegisterAsync/UnregisterAsync (exercised below) are keyed on the
-        // sdkSiteId/token parameters directly and never touch the resolver
-        // dependencies; substitutes are provided only so the constructor
-        // never NREs. The JWT-based resolver path (RegisterForCallerAsync)
-        // is covered separately (see Task 2's resolver-focused suite).
-        var userService = Substitute.For<IUserService>();
+        _userService = Substitute.For<IUserService>();
+        var baseDbContext = Substitute.For<BaseDbContext>(
+            new DbContextOptions<BaseDbContext>());
         var coreService = Substitute.For<IEFormCoreService>();
-        var baseDbContext = Substitute.For<BaseDbContext>(new DbContextOptions<BaseDbContext>());
 
         _service = new DeviceTokenService(
             TimePlanningPnDbContext!,
             Substitute.For<ILogger<DeviceTokenService>>(),
-            userService,
+            _userService,
             baseDbContext,
             coreService);
     }
@@ -82,5 +80,31 @@ public class DeviceTokenServiceTests : TestBaseSetup
         var result = await _service.UnregisterAsync("does-not-exist");
 
         Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task RegisterForCallerAsync_NoAuthenticatedUser_RejectsWithoutStoring()
+    {
+        _userService.GetCurrentUserAsync().Returns(Task.FromResult<EformUser?>(null));
+
+        var result = await _service.RegisterForCallerAsync("dead-token", "android");
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(await TimePlanningPnDbContext!.DeviceTokens.CountAsync(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task RegisterAsync_ReRegisteringDeadToken_RepairsSdkSiteId()
+    {
+        // A row stored under SdkSiteId=0 (the historical bug) is repaired by
+        // the token-keyed upsert once a real site id arrives.
+        await _service.RegisterAsync(0, "legacy-token", "android");
+
+        var result = await _service.RegisterAsync(77, "legacy-token", "android");
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(await TimePlanningPnDbContext!.DeviceTokens.CountAsync(), Is.EqualTo(1));
+        var stored = await TimePlanningPnDbContext.DeviceTokens.SingleAsync();
+        Assert.That(stored.SdkSiteId, Is.EqualTo(77));
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DeviceTokenServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DeviceTokenServiceTests.cs
@@ -2,6 +2,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.EformAngularFrontendBase.Infrastructure.Data;
 using NSubstitute;
 using NUnit.Framework;
 using TimePlanning.Pn.Services.DeviceTokenService;
@@ -18,9 +20,21 @@ public class DeviceTokenServiceTests : TestBaseSetup
     {
         await base.Setup();
 
+        // RegisterAsync/UnregisterAsync (exercised below) are keyed on the
+        // sdkSiteId/token parameters directly and never touch the resolver
+        // dependencies; substitutes are provided only so the constructor
+        // never NREs. The JWT-based resolver path (RegisterForCallerAsync)
+        // is covered separately (see Task 2's resolver-focused suite).
+        var userService = Substitute.For<IUserService>();
+        var coreService = Substitute.For<IEFormCoreService>();
+        var baseDbContext = Substitute.For<BaseDbContext>(new DbContextOptions<BaseDbContext>());
+
         _service = new DeviceTokenService(
             TimePlanningPnDbContext!,
-            Substitute.For<ILogger<DeviceTokenService>>());
+            Substitute.For<ILogger<DeviceTokenService>>(),
+            userService,
+            baseDbContext,
+            coreService);
     }
 
     [Test]

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/device_token.proto
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Protos/device_token.proto
@@ -9,6 +9,8 @@ option csharp_namespace = "TimePlanning.Pn.Grpc";
 message RegisterDeviceTokenRequest {
   string token = 1;
   string platform = 2;
+  // Ignored since 2026-07: the server resolves the caller's site id from
+  // the JWT. Field retained for wire compatibility with shipped clients.
   int32 sdk_site_id = 3;
 }
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/DeviceTokenService/DeviceTokenService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/DeviceTokenService/DeviceTokenService.cs
@@ -1,10 +1,15 @@
 namespace TimePlanning.Pn.Services.DeviceTokenService;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Infrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
 using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.EformAngularFrontendBase.Infrastructure.Data;
 using Microting.TimePlanningBase.Infrastructure.Data;
 using Microting.TimePlanningBase.Infrastructure.Data.Entities;
 
@@ -12,13 +17,67 @@ public class DeviceTokenService : IDeviceTokenService
 {
     private readonly TimePlanningPnDbContext _dbContext;
     private readonly ILogger<DeviceTokenService> _logger;
+    private readonly IUserService _userService;
+    private readonly BaseDbContext _baseDbContext;
+    private readonly IEFormCoreService _coreService;
 
     public DeviceTokenService(
         TimePlanningPnDbContext dbContext,
-        ILogger<DeviceTokenService> logger)
+        ILogger<DeviceTokenService> logger,
+        IUserService userService,
+        BaseDbContext baseDbContext,
+        IEFormCoreService coreService)
     {
         _dbContext = dbContext;
         _logger = logger;
+        _userService = userService;
+        _baseDbContext = baseDbContext;
+        _coreService = coreService;
+    }
+
+    public async Task<OperationResult> RegisterForCallerAsync(string token, string platform)
+    {
+        var sdkSiteId = await ResolveCallerSdkSiteIdAsync();
+        if (sdkSiteId == 0)
+        {
+            _logger.LogWarning(
+                "Rejecting device-token registration: caller has no active site");
+            return new OperationResult(
+                false, "Could not resolve an active site for the calling user");
+        }
+
+        return await RegisterAsync(sdkSiteId, token, platform);
+    }
+
+    /// <summary>
+    /// Resolves the authenticated caller's SDK site id (MicrotingUid) from
+    /// the JWT. Returns 0 if the user has no worker/site record. Mirrors
+    /// AbsenceRequestService.ResolveCallerSdkSiteIdAsync().
+    /// </summary>
+    private async Task<int> ResolveCallerSdkSiteIdAsync()
+    {
+        var currentUserAsync = await _userService.GetCurrentUserAsync();
+        if (currentUserAsync == null)
+        {
+            return 0;
+        }
+        var currentUser = _baseDbContext.Users
+            .Single(x => x.Id == currentUserAsync.Id);
+
+        var sdkCore = await _coreService.GetCore();
+        var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+
+        var worker = await sdkDbContext.Workers
+            .Include(x => x.SiteWorkers)
+            .ThenInclude(x => x.Site)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .FirstOrDefaultAsync(x => x.Email == currentUser.Email);
+
+        if (worker == null || worker.SiteWorkers.Count == 0)
+        {
+            return 0;
+        }
+        return worker.ResolveActiveSdkSiteId() ?? 0;
     }
 
     public async Task<OperationResult> RegisterAsync(int sdkSiteId, string token, string platform)

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/DeviceTokenService/IDeviceTokenService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/DeviceTokenService/IDeviceTokenService.cs
@@ -5,6 +5,13 @@ using Microting.eFormApi.BasePn.Infrastructure.Models.API;
 
 public interface IDeviceTokenService
 {
+    /// <summary>
+    /// Registers a device token for the authenticated caller. The SDK site id
+    /// is resolved server-side from the JWT (client-sent ids are ignored).
+    /// Fails without storing anything when no active site resolves.
+    /// </summary>
+    Task<OperationResult> RegisterForCallerAsync(string token, string platform);
+
     Task<OperationResult> RegisterAsync(int sdkSiteId, string token, string platform);
     Task<OperationResult> UnregisterAsync(string token);
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningDeviceTokenGrpcService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/GrpcServices/TimePlanningDeviceTokenGrpcService.cs
@@ -21,8 +21,10 @@ public class TimePlanningDeviceTokenGrpcService
     {
         try
         {
-            var result = await _deviceTokenService.RegisterAsync(
-                request.SdkSiteId, request.Token, request.Platform);
+            // request.SdkSiteId is deliberately ignored: the site id is
+            // resolved server-side from the JWT (see DeviceTokenService).
+            var result = await _deviceTokenService.RegisterForCallerAsync(
+                request.Token, request.Platform);
 
             return new OperationResponse
             {


### PR DESCRIPTION
Tokens were registered under the client-sent sdk_site_id, which the flutter-time app never sends, so every push lookup (SendToSiteAsync) matched nothing. The gRPC layer now ignores the wire field and resolves the caller's active site server-side (ResolveCallerSdkSiteIdAsync convention); unresolved callers are rejected without storing dead tokens. Existing SdkSiteId=0 rows self-repair on next register via the token-keyed upsert. Part of the Firebase push tenant-deployment effort (flutter-adhoc docs/superpowers/specs/2026-07-31-firebase-push-tenant-deployment-design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)