### PR TITLE
fix: own a DI scope per fire-and-forget handover push send

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverRemovedRowTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverRemovedRowTests.cs
@@ -39,6 +39,15 @@ public class ContentHandoverRemovedRowTests : TestBaseSetup
         var localizationService = Substitute.For<ITimePlanningLocalizationService>();
         localizationService.GetString(Arg.Any<string>()).Returns(x => x[0]?.ToString());
 
+        var pushSub = Substitute.For<TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService>();
+        var scopeProvider = Substitute.For<IServiceProvider>();
+        scopeProvider.GetService(typeof(TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService))
+            .Returns(pushSub);
+        var scope = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScope>();
+        scope.ServiceProvider.Returns(scopeProvider);
+        var scopeFactory = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
         _service = new ContentHandoverService(
             Substitute.For<Microsoft.Extensions.Logging.ILogger<ContentHandoverService>>(),
             TimePlanningPnDbContext,
@@ -46,7 +55,7 @@ public class ContentHandoverRemovedRowTests : TestBaseSetup
             localizationService,
             Substitute.For<IEFormCoreService>(),
             Substitute.For<BaseDbContext>(new DbContextOptions<BaseDbContext>()),
-            Substitute.For<TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService>());
+            scopeFactory);
     }
 
     [Test]

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
@@ -21,6 +21,8 @@ public class ContentHandoverServiceTests : TestBaseSetup
     private IContentHandoverService _contentHandoverService;
     private IUserService _userService;
     private ITimePlanningLocalizationService _localizationService;
+    private TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService _pushSub;
+    private Microsoft.Extensions.DependencyInjection.IServiceScopeFactory _scopeFactory;
 
     [SetUp]
     public async Task SetUp()
@@ -36,6 +38,15 @@ public class ContentHandoverServiceTests : TestBaseSetup
         // Mirrors the pattern used in PlanRegistrationVersionHistoryTests.
         var baseDbContext = Substitute.For<BaseDbContext>(new DbContextOptions<BaseDbContext>());
 
+        _pushSub = Substitute.For<TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService>();
+        var scopeProvider = Substitute.For<IServiceProvider>();
+        scopeProvider.GetService(typeof(TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService))
+            .Returns(_pushSub);
+        var scope = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScope>();
+        scope.ServiceProvider.Returns(scopeProvider);
+        _scopeFactory = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>();
+        _scopeFactory.CreateScope().Returns(scope);
+
         _contentHandoverService = new ContentHandoverService(
             Substitute.For<Microsoft.Extensions.Logging.ILogger<ContentHandoverService>>(),
             TimePlanningPnDbContext,
@@ -43,7 +54,7 @@ public class ContentHandoverServiceTests : TestBaseSetup
             _localizationService,
             Substitute.For<Microting.eFormApi.BasePn.Abstractions.IEFormCoreService>(),
             baseDbContext,
-            Substitute.For<TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService>());
+            _scopeFactory);
     }
 
     // GetHandoverEligibleCoworkersAsync exercises the real SDK MicrotingDbContext (Workers,

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/ContentHandoverServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microting.EformAngularFrontendBase.Infrastructure.Data;
 using Microting.eFormApi.BasePn.Abstractions;
 using Microting.TimePlanningBase.Infrastructure.Data.Entities;
@@ -1211,5 +1212,128 @@ public class ContentHandoverServiceTests : TestBaseSetup
 
         Assert.That(result.Success, Is.False);
         Assert.That(result.Message, Is.EqualTo("ShiftOverlapsExistingShift"));
+    }
+
+    // ---------------------------------------------------------------
+    // Scope-owning push send contract.
+    // Fire-and-forget handover pushes must resolve IPushNotificationService
+    // from a scope the send itself creates and disposes (never from the
+    // caller's/request's DI scope, which may already be disposed by the
+    // time a Task.Run-backed send executes). Hand-rolled recording fakes are
+    // used because NSubstitute cannot observe IDisposable.Dispose ordering
+    // cleanly.
+    // ---------------------------------------------------------------
+
+    private sealed class RecordingScope : IServiceScope
+    {
+        private readonly IServiceProvider _provider;
+        public bool Disposed;
+        public RecordingScope(IServiceProvider provider) => _provider = provider;
+        public IServiceProvider ServiceProvider => _provider;
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class RecordingScopeFactory : IServiceScopeFactory
+    {
+        private readonly IServiceProvider _provider;
+        public readonly List<RecordingScope> CreatedScopes = new();
+        public RecordingScopeFactory(IServiceProvider provider) => _provider = provider;
+        public IServiceScope CreateScope()
+        {
+            var scope = new RecordingScope(_provider);
+            CreatedScopes.Add(scope);
+            return scope;
+        }
+    }
+
+    private (ContentHandoverService service, RecordingScopeFactory factory,
+        TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService push)
+        BuildScopeRecordingService()
+    {
+        var push = Substitute.For<TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(TimePlanning.Pn.Services.PushNotificationService.IPushNotificationService))
+            .Returns(push);
+        var factory = new RecordingScopeFactory(provider);
+        var service = new ContentHandoverService(
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<ContentHandoverService>>(),
+            TimePlanningPnDbContext,
+            _userService,
+            _localizationService,
+            Substitute.For<Microting.eFormApi.BasePn.Abstractions.IEFormCoreService>(),
+            Substitute.For<BaseDbContext>(new DbContextOptions<BaseDbContext>()),
+            factory);
+        return (service, factory, push);
+    }
+
+    [Test]
+    public async Task SendCreatePushAsync_ResolvesPushServiceFromOwnScope_AndDisposesIt()
+    {
+        var (service, factory, push) = BuildScopeRecordingService();
+
+        await service.SendCreatePushAsync(17495, new List<int> { 7, 8 }, 2, new DateTime(2026, 8, 2));
+
+        Assert.That(factory.CreatedScopes, Has.Count.EqualTo(1));
+        Assert.That(factory.CreatedScopes[0].Disposed, Is.True,
+            "the send must dispose the scope it created");
+        await push.Received(1).SendToSiteAsync(
+            17495,
+            "New handover request",
+            Arg.Any<string>(),
+            Arg.Is<Dictionary<string, string>>(d =>
+                d["type"] == "handover_created" &&
+                d["handoverRequestId"] == "7" &&
+                d["handoverRequestIds"] == "7,8" &&
+                d["shiftCount"] == "2"));
+    }
+
+    [Test]
+    public async Task SendAcceptPushAsync_SendsDecidedPayload_ToRequester()
+    {
+        var (service, factory, push) = BuildScopeRecordingService();
+
+        await service.SendAcceptPushAsync(22505, 48);
+
+        Assert.That(factory.CreatedScopes.Single().Disposed, Is.True);
+        await push.Received(1).SendToSiteAsync(
+            22505,
+            "Handover accepted",
+            Arg.Any<string>(),
+            Arg.Is<Dictionary<string, string>>(d =>
+                d["type"] == "handover_decided" &&
+                d["action"] == "accepted" &&
+                d["handoverRequestId"] == "48"));
+    }
+
+    [Test]
+    public async Task SendRejectPushAsync_SendsDecidedPayload_ToRequester()
+    {
+        var (service, factory, push) = BuildScopeRecordingService();
+
+        await service.SendRejectPushAsync(22505, 48);
+
+        Assert.That(factory.CreatedScopes.Single().Disposed, Is.True);
+        await push.Received(1).SendToSiteAsync(
+            22505,
+            "Handover rejected",
+            Arg.Any<string>(),
+            Arg.Is<Dictionary<string, string>>(d =>
+                d["type"] == "handover_decided" &&
+                d["action"] == "rejected" &&
+                d["handoverRequestId"] == "48"));
+    }
+
+    [Test]
+    public async Task SendCreatePushAsync_PushFailure_IsSwallowedAndScopeStillDisposed()
+    {
+        var (service, factory, push) = BuildScopeRecordingService();
+        push.SendToSiteAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<Dictionary<string, string>>())
+            .Returns<Task>(_ => throw new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrowAsync(() =>
+            service.SendCreatePushAsync(1, new List<int> { 1 }, 1, DateTime.UtcNow));
+        Assert.That(factory.CreatedScopes.Single().Disposed, Is.True,
+            "using-scope must dispose even when the send throws");
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PushNotificationIntegrationTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PushNotificationIntegrationTests.cs
@@ -67,6 +67,13 @@ public class PushNotificationIntegrationTests : TestBaseSetup
             baseDbContext,
             _pushService);
 
+        var handoverScopeProvider = Substitute.For<IServiceProvider>();
+        handoverScopeProvider.GetService(typeof(IPushNotificationService)).Returns(_pushService);
+        var handoverScope = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScope>();
+        handoverScope.ServiceProvider.Returns(handoverScopeProvider);
+        var handoverScopeFactory = Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>();
+        handoverScopeFactory.CreateScope().Returns(handoverScope);
+
         _contentHandoverService = new ContentHandoverService(
             Substitute.For<Microsoft.Extensions.Logging.ILogger<ContentHandoverService>>(),
             TimePlanningPnDbContext!,
@@ -74,7 +81,7 @@ public class PushNotificationIntegrationTests : TestBaseSetup
             localization,
             Substitute.For<IEFormCoreService>(),
             baseDbContext,
-            _pushService);
+            handoverScopeFactory);
     }
 
     [TearDown]

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/ContentHandoverService/ContentHandoverService.cs
@@ -33,6 +33,7 @@ using System.Threading.Tasks;
 using Infrastructure.Helpers;
 using Infrastructure.Models.ContentHandover;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.EformAngularFrontendBase.Infrastructure.Data;
@@ -52,7 +53,7 @@ public class ContentHandoverService : IContentHandoverService
     private readonly ITimePlanningLocalizationService _localizationService;
     private readonly IEFormCoreService _core;
     private readonly BaseDbContext _baseDbContext;
-    private readonly IPushNotificationService _pushNotificationService;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
 
     public ContentHandoverService(
         ILogger<ContentHandoverService> logger,
@@ -61,7 +62,7 @@ public class ContentHandoverService : IContentHandoverService
         ITimePlanningLocalizationService localizationService,
         IEFormCoreService core,
         BaseDbContext baseDbContext,
-        IPushNotificationService pushNotificationService)
+        IServiceScopeFactory serviceScopeFactory)
     {
         _logger = logger;
         _dbContext = dbContext;
@@ -69,7 +70,7 @@ public class ContentHandoverService : IContentHandoverService
         _localizationService = localizationService;
         _core = core;
         _baseDbContext = baseDbContext;
-        _pushNotificationService = pushNotificationService;
+        _serviceScopeFactory = serviceScopeFactory;
     }
 
     // Danish-locale, case-insensitive comparer used to sort the handover-eligible
@@ -463,37 +464,101 @@ public class ContentHandoverService : IContentHandoverService
 
     private void FireCreatePush(int toSdkSitId, List<int> requestIds, int shiftCount, DateTime date)
     {
-        _ = Task.Run(async () =>
+        _ = Task.Run(() => SendCreatePushAsync(toSdkSitId, requestIds, shiftCount, date));
+    }
+
+    // Owns a short-lived DI scope per send: the fire-and-forget wrappers outlive
+    // the gRPC request scope, so we must not capture request-scoped services.
+    private async Task SendToSiteInOwnScopeAsync(
+        int targetSdkSitId, string title, string body, Dictionary<string, string> data)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var pushService = scope.ServiceProvider.GetRequiredService<IPushNotificationService>();
+        await pushService.SendToSiteAsync(targetSdkSitId, title, body, data);
+    }
+
+    /// <summary>
+    /// Scope-owning push send for handover creation. The fire-and-forget wrapper
+    /// above outlives the gRPC request's DI scope, so this method creates and
+    /// disposes its own scope instead of capturing request-scoped services
+    /// (the previous capture crashed with ObjectDisposedException once the
+    /// request scope was disposed before the background task ran).
+    /// Internal (not private) so tests can await it deterministically.
+    /// </summary>
+    internal async Task SendCreatePushAsync(int toSdkSitId, List<int> requestIds, int shiftCount, DateTime date)
+    {
+        try
         {
-            try
-            {
-                var title = "New handover request";
-                var body = shiftCount > 1
-                    ? $"A coworker wants to hand over {shiftCount} shifts on {date:yyyy-MM-dd}"
-                    : "A coworker wants to hand over content to you";
-                // Dual-key scheme: Accept/Reject pushes use the singular
-                // "handoverRequestId" and Flutter's FCM handler keys off that
-                // name. Old handlers will open the first request in the batch
-                // (better than nothing); new handlers can read the comma-joined
-                // "handoverRequestIds" for the full batch.
-                var primaryId = requestIds.Count > 0 ? requestIds[0].ToString() : "";
-                await _pushNotificationService.SendToSiteAsync(
-                    toSdkSitId,
-                    title,
-                    body,
-                    new Dictionary<string, string>
-                    {
-                        { "type", "handover_created" },
-                        { "handoverRequestId", primaryId },
-                        { "handoverRequestIds", string.Join(",", requestIds) },
-                        { "shiftCount", shiftCount.ToString() }
-                    });
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error sending push notification for handover creation");
-            }
-        });
+            var title = "New handover request";
+            var body = shiftCount > 1
+                ? $"A coworker wants to hand over {shiftCount} shifts on {date:yyyy-MM-dd}"
+                : "A coworker wants to hand over content to you";
+            // Dual-key scheme: Accept/Reject pushes use the singular
+            // "handoverRequestId" and Flutter's FCM handler keys off that
+            // name. Old handlers will open the first request in the batch
+            // (better than nothing); new handlers can read the comma-joined
+            // "handoverRequestIds" for the full batch.
+            var primaryId = requestIds.Count > 0 ? requestIds[0].ToString() : "";
+            await SendToSiteInOwnScopeAsync(
+                toSdkSitId,
+                title,
+                body,
+                new Dictionary<string, string>
+                {
+                    { "type", "handover_created" },
+                    { "handoverRequestId", primaryId },
+                    { "handoverRequestIds", string.Join(",", requestIds) },
+                    { "shiftCount", shiftCount.ToString() }
+                });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending push notification for handover creation");
+        }
+    }
+
+    /// <summary>Scope-owning push send for handover acceptance (see SendCreatePushAsync).</summary>
+    internal async Task SendAcceptPushAsync(int fromSdkSitId, int requestId)
+    {
+        try
+        {
+            await SendToSiteInOwnScopeAsync(
+                fromSdkSitId,
+                "Handover accepted",
+                "Your content handover request has been accepted",
+                new Dictionary<string, string>
+                {
+                    { "type", "handover_decided" },
+                    { "action", "accepted" },
+                    { "handoverRequestId", requestId.ToString() }
+                });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending push notification for handover acceptance");
+        }
+    }
+
+    /// <summary>Scope-owning push send for handover rejection (see SendCreatePushAsync).</summary>
+    internal async Task SendRejectPushAsync(int fromSdkSitId, int requestId)
+    {
+        try
+        {
+            await SendToSiteInOwnScopeAsync(
+                fromSdkSitId,
+                "Handover rejected",
+                "Your content handover request has been rejected",
+                new Dictionary<string, string>
+                {
+                    { "type", "handover_decided" },
+                    { "action", "rejected" },
+                    { "handoverRequestId", requestId.ToString() }
+                });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending push notification for handover rejection");
+        }
     }
 
     private static int GetPlannedEndOfShift(PlanRegistration pr, int n)
@@ -851,26 +916,7 @@ public class ContentHandoverService : IContentHandoverService
 
             // 8. Fire-and-forget push to sender.
             var fromSdkSitId = request.FromSdkSitId;
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await _pushNotificationService.SendToSiteAsync(
-                        fromSdkSitId,
-                        "Handover accepted",
-                        "Your content handover request has been accepted",
-                        new Dictionary<string, string>
-                        {
-                            { "type", "handover_decided" },
-                            { "action", "accepted" },
-                            { "handoverRequestId", requestId.ToString() }
-                        });
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error sending push notification for handover acceptance");
-                }
-            });
+            _ = Task.Run(() => SendAcceptPushAsync(fromSdkSitId, requestId));
 
             return new OperationResult(true);
         }
@@ -914,26 +960,7 @@ public class ContentHandoverService : IContentHandoverService
 
             // Fire-and-forget push to sender
             var fromSdkSitId = request.FromSdkSitId;
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await _pushNotificationService.SendToSiteAsync(
-                        fromSdkSitId,
-                        "Handover rejected",
-                        "Your content handover request has been rejected",
-                        new Dictionary<string, string>
-                        {
-                            { "type", "handover_decided" },
-                            { "action", "rejected" },
-                            { "handoverRequestId", requestId.ToString() }
-                        });
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error sending push notification for handover rejection");
-                }
-            });
+            _ = Task.Run(() => SendRejectPushAsync(fromSdkSitId, requestId));
 
             return new OperationResult(true);
         }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/PushNotificationService/PushNotificationService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/PushNotificationService/PushNotificationService.cs
@@ -65,7 +65,7 @@ public class PushNotificationService : IPushNotificationService
     {
         if (!_isEnabled)
         {
-            _logger.LogDebug(
+            _logger.LogInformation(
                 "Push notification skipped (Firebase not configured): SdkSiteId={SdkSiteId}, Title={Title}",
                 targetSdkSiteId, title);
             return;
@@ -79,7 +79,7 @@ public class PushNotificationService : IPushNotificationService
 
             if (tokens.Count == 0)
             {
-                _logger.LogDebug("No device tokens found for SdkSiteId {SdkSiteId}", targetSdkSiteId);
+                _logger.LogInformation("No device tokens found for SdkSiteId {SdkSiteId}", targetSdkSiteId);
                 return;
             }
 


### PR DESCRIPTION
Fixes the live ObjectDisposedException on tenant 855: the three fire-and-forget handover push sends captured the request-scoped IPushNotificationService/DbContext, which was disposed when the gRPC request completed. Each send now creates and owns its scope via IServiceScopeFactory; the two silent-skip log lines are elevated to Information; four regression tests pin the contract.

Spec: flutter-adhoc/docs/superpowers/specs/2026-08-02-flutter-time-push-fixes-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)