### PR TITLE
feat(pay-rule-sets): non-admin selection + pay-code columns on empty periods

### DIFF
--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/DagsoversigtWorksheetExportTests.cs
@@ -409,8 +409,308 @@ public class DagsoversigtWorksheetExportTests : TestBaseSetup
     }
 
     // ------------------------------------------------------------------
+    // 7. Empty period: the pay-code columns come from the DECLARED codes of the
+    //    site's pay-rule-set, so they are present even when the selected period
+    //    contains no registered time at all.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task SingleWorker_EmptyPeriod_DashboardCarriesDeclaredPayCodesWithZeroTotals()
+    {
+        var dateFrom = new DateTime(2026, 5, 11);
+        var dateTo = new DateTime(2026, 5, 13);
+
+        // Site has a pay-rule-set declaring three codes, but NOT ONE PlanRegistration
+        // inside [dateFrom, dateTo] — only a prior-day row outside the range.
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9711, employeeNo: "1", rangeStart: dateFrom);
+        await LinkPayRuleSetDeclaringCodes(siteUid: 9711, name: "RuleSet Empty", "NORM", "OT50", "OT100");
+
+        var result = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = 9711,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+
+        try
+        {
+            result.Model!.Position = 0;
+            using var doc = SpreadsheetDocument.Open(result.Model!, false);
+            var workbookPart = doc.WorkbookPart!;
+
+            var (header, totalsRow) = ReadHeaderAndLastRow(workbookPart, "Dashboard");
+            var dataRow = ReadFirstDataRow(workbookPart, "Dashboard");
+
+            foreach (var payCode in new[] { "NORM", "OT50", "OT100" })
+            {
+                var columnIndex = header.IndexOf(payCode);
+                Assert.That(columnIndex, Is.GreaterThanOrEqualTo(0),
+                    $"Declared pay code {payCode} must have a column even for a period with no registered time");
+
+                Assert.That(totalsRow.Count, Is.GreaterThan(columnIndex),
+                    $"Totals row must reach the {payCode} column");
+                Assert.That(double.Parse(totalsRow[columnIndex], CultureInfo.InvariantCulture),
+                    Is.EqualTo(0).Within(1e-9),
+                    $"Totals row must show 0 for the unobserved declared code {payCode}");
+
+                // The per-day data rows must emit the declared columns too, otherwise the
+                // rows would be narrower than the header and every later column would slide.
+                Assert.That(dataRow.Count, Is.GreaterThan(columnIndex),
+                    $"Data row must reach the {payCode} column — row width must match the header width");
+                Assert.That(double.Parse(dataRow[columnIndex], CultureInfo.InvariantCulture),
+                    Is.EqualTo(0).Within(1e-9),
+                    $"Data row must show 0 for the unobserved declared code {payCode}");
+            }
+        }
+        finally
+        {
+            await result.Model!.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task SingleWorker_EmptyPeriod_SiteWithoutPayRuleSet_HasNoPayCodeColumns()
+    {
+        var dateFrom = new DateTime(2026, 5, 11);
+        var dateTo = new DateTime(2026, 5, 13);
+
+        // Reference site: a rule-set declaring exactly two codes.
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9712, employeeNo: "1", rangeStart: dateFrom);
+        await LinkPayRuleSetDeclaringCodes(siteUid: 9712, name: "RuleSet Ref", "REFA", "REFB");
+
+        // Control site: identical seeding, but PayRuleSetId stays null.
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9713, employeeNo: "2", rangeStart: dateFrom);
+
+        var withRuleSet = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = 9712, DateFrom = dateFrom, DateTo = dateTo,
+        });
+        var withoutRuleSet = await _service.GenerateExcelDashboard(new TimePlanningWorkingHoursRequestModel
+        {
+            SiteId = 9713, DateFrom = dateFrom, DateTo = dateTo,
+        });
+
+        Assert.That(withRuleSet.Success, Is.True, withRuleSet.Message);
+        Assert.That(withoutRuleSet.Success, Is.True, withoutRuleSet.Message);
+
+        try
+        {
+            withRuleSet.Model!.Position = 0;
+            using var withDoc = SpreadsheetDocument.Open(withRuleSet.Model!, false);
+            var (withHeader, _) = ReadHeaderAndLastRow(withDoc.WorkbookPart!, "Dashboard");
+
+            withoutRuleSet.Model!.Position = 0;
+            using var withoutDoc = SpreadsheetDocument.Open(withoutRuleSet.Model!, false);
+            var (withoutHeader, _) = ReadHeaderAndLastRow(withoutDoc.WorkbookPart!, "Dashboard");
+
+            Assert.That(withHeader, Does.Contain("REFA"));
+            Assert.That(withHeader, Does.Contain("REFB"));
+
+            // The rule-set-less site gets the fixed columns only — exactly two fewer.
+            Assert.That(withoutHeader, Does.Not.Contain("REFA"));
+            Assert.That(withoutHeader, Does.Not.Contain("REFB"));
+            Assert.That(withoutHeader.Count, Is.EqualTo(withHeader.Count - 2),
+                "A site with no pay-rule-set must add no pay-code columns at all");
+        }
+        finally
+        {
+            await withRuleSet.Model!.DisposeAsync();
+            await withoutRuleSet.Model!.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task AllWorkers_EmptyPeriod_TotalSheetCarriesDeclaredPayCodes()
+    {
+        var dateFrom = new DateTime(2026, 5, 11);
+        var dateTo = new DateTime(2026, 5, 13);
+
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9721, employeeNo: "1", rangeStart: dateFrom);
+        await LinkPayRuleSetDeclaringCodes(siteUid: 9721, name: "RuleSet A", "EMPTYA");
+
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9722, employeeNo: "2", rangeStart: dateFrom);
+        await LinkPayRuleSetDeclaringCodes(siteUid: 9722, name: "RuleSet B", "EMPTYB");
+
+        // Site with no rule-set at all — must contribute no code.
+        await SeedSiteWithNoRegistrationsInRange(siteUid: 9723, employeeNo: "3", rangeStart: dateFrom);
+
+        var result = await _service.GenerateExcelDashboard(
+            new TimePlanningWorkingHoursReportForAllWorkersRequestModel
+            {
+                DateFrom = dateFrom,
+                DateTo = dateTo,
+            });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+
+        try
+        {
+            result.Model!.Position = 0;
+            using var doc = SpreadsheetDocument.Open(result.Model!, false);
+            var workbookPart = doc.WorkbookPart!;
+
+            var totalHeader = ReadHeaderRowText(workbookPart, "Total");
+            Assert.That(totalHeader, Does.Contain("EMPTYA"),
+                "Total sheet must carry Site A's declared code even with no registered time");
+            Assert.That(totalHeader, Does.Contain("EMPTYB"),
+                "Total sheet must carry Site B's declared code even with no registered time");
+
+            // Per-site sheets keep their own declared codes; the rule-set-less site gets none.
+            Assert.That(ReadHeaderRowText(workbookPart, "Site 9721"), Does.Contain("EMPTYA"));
+            Assert.That(ReadHeaderRowText(workbookPart, "Site 9722"), Does.Contain("EMPTYB"));
+            var siteCHeader = ReadHeaderRowText(workbookPart, "Site 9723");
+            Assert.That(siteCHeader, Does.Not.Contain("EMPTYA"));
+            Assert.That(siteCHeader, Does.Not.Contain("EMPTYB"));
+        }
+        finally
+        {
+            await result.Model!.DisposeAsync();
+        }
+    }
+
+    // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns (header row cells, last row cells) as plain text for the named sheet.
+    /// The positional sheets ("Dashboard" / "Site NNNN") emit cells without a
+    /// CellReference, so index i of the header lines up with index i of any data or
+    /// totals row. The last row of those sheets is the totals row.
+    /// </summary>
+    private static (List<string> Header, List<string> LastRow) ReadHeaderAndLastRow(
+        WorkbookPart workbookPart, string sheetName)
+    {
+        var sheet = workbookPart.Workbook.Descendants<Sheet>().First(s => s.Name == sheetName);
+        var part = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
+        var rows = part.Worksheet.Descendants<Row>()
+            .OrderBy(r => r.RowIndex!.Value)
+            .ToList();
+        var header = rows.First().Elements<Cell>().Select(c => CellText(c, workbookPart)).ToList();
+        var lastRow = rows.Last().Elements<Cell>().Select(c => CellText(c, workbookPart)).ToList();
+        return (header, lastRow);
+    }
+
+    /// <summary>
+    /// Returns the cells of the FIRST per-day DATA row (the row right after the header)
+    /// of a positional sheet, as plain text. Row 1 is the header and the last row is the
+    /// totals row, so this is the row that must stay exactly as wide as the header — the
+    /// data rows are what keep the pay-code columns aligned.
+    /// </summary>
+    private static List<string> ReadFirstDataRow(WorkbookPart workbookPart, string sheetName)
+    {
+        var sheet = workbookPart.Workbook.Descendants<Sheet>().First(s => s.Name == sheetName);
+        var part = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
+        var rows = part.Worksheet.Descendants<Row>()
+            .OrderBy(r => r.RowIndex!.Value)
+            .ToList();
+        Assert.That(rows.Count, Is.GreaterThan(2),
+            $"Sheet '{sheetName}' must hold at least one data row between the header and the totals row");
+        return rows[1].Elements<Cell>().Select(c => CellText(c, workbookPart)).ToList();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="PayRuleSet"/> declaring the given pay codes (one
+    /// <see cref="PayDayRule"/> with one <see cref="PayTierRule"/> per code) and links
+    /// it to the already-seeded site. Unlike <c>LinkPayRuleSetToSite</c> this does NOT
+    /// touch any PlanRegistration — the point is that the columns must appear with no
+    /// worked time at all.
+    /// </summary>
+    private async Task LinkPayRuleSetDeclaringCodes(int siteUid, string name, params string[] payCodes)
+    {
+        var tiers = new List<PayTierRule>();
+        for (var i = 0; i < payCodes.Length; i++)
+        {
+            tiers.Add(new PayTierRule
+            {
+                UpToSeconds = i == payCodes.Length - 1 ? null : (i + 1) * 3600,
+                PayCode = payCodes[i],
+                PayrollCode = (100 + i).ToString(CultureInfo.InvariantCulture),
+                Order = i + 1,
+            });
+        }
+
+        var payRuleSet = new PayRuleSet
+        {
+            Name = name,
+            DayRules = new List<PayDayRule>
+            {
+                new PayDayRule { DayCode = "WEEKDAY", Tiers = tiers }
+            },
+            DayTypeRules = new List<PayDayTypeRule>(),
+            WorkflowState = Constants.WorkflowStates.Created,
+        };
+        await payRuleSet.Create(TimePlanningPnDbContext!);
+
+        var assignedSite = await TimePlanningPnDbContext!.AssignedSites
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .FirstAsync(x => x.SiteId == siteUid);
+        assignedSite.PayRuleSetId = payRuleSet.Id;
+        await assignedSite.Update(TimePlanningPnDbContext!);
+    }
+
+    /// <summary>
+    /// Seeds one SDK Site/Worker/SiteWorker + an AssignedSite + a SINGLE
+    /// PlanRegistration on the day BEFORE <paramref name="rangeStart"/>. The exported
+    /// period therefore holds no registration at all: Index() carries the prior day in
+    /// as the "prePlanning" row (dropped by the export's Skip(1)) and synthesises an
+    /// empty placeholder row for every day of the requested range.
+    /// </summary>
+    private async Task SeedSiteWithNoRegistrationsInRange(int siteUid, string employeeNo, DateTime rangeStart)
+    {
+        var core = await GetCore();
+        var sdkDb = core.DbContextHelper.GetDbContext();
+
+        var site = new SdkSite { Name = $"Site {siteUid}", MicrotingUid = siteUid };
+        await site.Create(sdkDb);
+
+        var worker = new SdkWorker
+        {
+            FirstName = "Test",
+            LastName = "Worker",
+            Email = $"test{siteUid}@example.com",
+            MicrotingUid = 1000 + siteUid,
+            EmployeeNo = employeeNo,
+        };
+        await worker.Create(sdkDb);
+
+        var siteWorker = new SdkSiteWorker
+        {
+            SiteId = site.Id,
+            WorkerId = worker.Id,
+            MicrotingUid = 2000 + siteUid,
+        };
+        await siteWorker.Create(sdkDb);
+
+        await new AssignedSiteEntity
+        {
+            SiteId = siteUid,
+            UseOneMinuteIntervals = false,
+            Resigned = false,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+
+        await new PlanRegistrationEntity
+        {
+            SdkSitId = siteUid,
+            Date = rangeStart.AddDays(-1),
+            Start1Id = 0,
+            Stop1Id = 0,
+            Pause1Id = 0,
+            PlanText = "",
+            CommentOffice = "",
+            CommentOfficeAll = "",
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        }.Create(TimePlanningPnDbContext!);
+    }
 
     /// <summary>
     /// Opens the xlsx stream and returns the (Shift1Start, Shift1Stop) cell text
@@ -514,9 +814,11 @@ public class DagsoversigtWorksheetExportTests : TestBaseSetup
         await assignedSite.Update(TimePlanningPnDbContext!);
 
         // Give the in-range registration positive NettoHours so the WEEKDAY tier
-        // emits a pay line for the declared code. The per-site COLUMN header comes
-        // from the DECLARED codes (worked time irrelevant), but the Total sheet's
-        // union is built from EMITTED pay codes, so it needs non-zero worked time.
+        // emits a pay line for the declared code. Column headers no longer depend on
+        // this: both the per-site sheet and the Total sheet build their union from the
+        // DECLARED codes, so the columns appear with no worked time at all. The
+        // non-zero NettoHours is kept so the emitted values are non-zero, which is what
+        // the value-level assertions of the tests using this helper rely on.
         var registrations = await TimePlanningPnDbContext!.PlanRegistrations
             .Where(x => x.SdkSitId == siteUid
                         && x.WorkflowState != Constants.WorkflowStates.Removed

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PayRuleSetControllerTests.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn.Test/PayRuleSetControllerTests.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microting.eFormApi.BasePn.Infrastructure.Database.Entities;
 using Microting.eFormApi.BasePn.Infrastructure.Models.API;
 using Microting.TimePlanningBase.Infrastructure.Data;
 using NUnit.Framework;
+using TimePlanning.Pn.Controllers;
 using TimePlanning.Pn.Infrastructure.Models.PayRuleSet;
 using TimePlanning.Pn.Infrastructure.Models.PayTierRule;
 
@@ -187,5 +191,83 @@ public class PayRuleSetControllerTests : TestBaseSetup
         }
         
         Console.WriteLine("✅ All property casing variations deserialize correctly");
+    }
+
+    [Test]
+    public void Controller_StillRequiresAuthentication()
+    {
+        // Opening up the read endpoints must not have opened them to anonymous callers.
+        var authorizeAttributes = typeof(PayRuleSetController)
+            .GetCustomAttributes<AuthorizeAttribute>(true)
+            .ToList();
+
+        Assert.That(authorizeAttributes, Is.Not.Empty,
+            "PayRuleSetController must keep its class-level [Authorize] — anonymous access stays blocked");
+
+        var allowAnonymous = typeof(PayRuleSetController)
+            .GetCustomAttributes<AllowAnonymousAttribute>(true)
+            .ToList();
+
+        Assert.That(allowAnonymous, Is.Empty,
+            "PayRuleSetController must not be marked [AllowAnonymous]");
+
+        Console.WriteLine("✅ PayRuleSetController still requires an authenticated user");
+    }
+
+    [Test]
+    public void IndexAndRead_AreNotRoleRestricted()
+    {
+        // Listing and reading pay rule sets is open to any authenticated user: a
+        // non-admin has to be able to select a pay rule set for a site. Before this,
+        // a role-restricted GET answered 403, which the Angular HttpErrorInterceptor
+        // escalated into a forced logout.
+        foreach (var methodName in new[] { "Index", "Read" })
+        {
+            var method = typeof(PayRuleSetController).GetMethod(methodName);
+            Assert.That(method, Is.Not.Null, $"PayRuleSetController.{methodName} must exist");
+
+            var roleRestricted = method!
+                .GetCustomAttributes<AuthorizeAttribute>(true)
+                .Where(a => !string.IsNullOrWhiteSpace(a.Roles))
+                .ToList();
+
+            Assert.That(roleRestricted, Is.Empty,
+                $"{methodName} must NOT carry an AuthorizeAttribute with roles — found: " +
+                string.Join(", ", roleRestricted.Select(a => a.Roles)));
+        }
+
+        Console.WriteLine("✅ Index and Read are readable by any authenticated user");
+    }
+
+    [Test]
+    public void CreateUpdateDelete_RequireAdminRole()
+    {
+        // Authoring stays admin-only.
+        foreach (var methodName in new[] { "Create", "Update", "Delete" })
+        {
+            var method = typeof(PayRuleSetController).GetMethod(methodName);
+            Assert.That(method, Is.Not.Null, $"PayRuleSetController.{methodName} must exist");
+
+            var authorizeAttributes = method!
+                .GetCustomAttributes<AuthorizeAttribute>(true)
+                .ToList();
+
+            Assert.That(authorizeAttributes, Is.Not.Empty,
+                $"{methodName} must carry an AuthorizeAttribute");
+
+            var roles = authorizeAttributes
+                .Where(a => !string.IsNullOrWhiteSpace(a.Roles))
+                .SelectMany(a => a.Roles!.Split(','))
+                .Select(r => r.Trim())
+                .ToList();
+
+            Assert.That(
+                roles.Any(r => string.Equals(r, EformRole.Admin, StringComparison.OrdinalIgnoreCase)),
+                Is.True,
+                $"{methodName} must be restricted to the '{EformRole.Admin}' role — found: " +
+                string.Join(", ", roles));
+        }
+
+        Console.WriteLine("✅ Create, Update and Delete remain admin-only");
     }
 }

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Controllers/PayRuleSetController.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Controllers/PayRuleSetController.cs
@@ -25,16 +25,19 @@ public class PayRuleSetController : Controller
         _payRuleSetService = payRuleSetService;
     }
 
+    // Readable by any authenticated user: a non-admin needs the list to pick a
+    // pay rule set for a site they are assigned to. Authoring stays admin-only
+    // (see Create/Update/Delete below).
     [HttpGet]
-    [Authorize(Roles = EformRole.Admin)]
     public async Task<OperationDataResult<PayRuleSetsListModel>> Index(
         [FromQuery] PayRuleSetsRequestModel requestModel)
     {
         return await _payRuleSetService.Index(requestModel);
     }
 
+    // Readable by any authenticated user — same reasoning as Index: viewing a
+    // pay rule set is needed to select one, changing it is not.
     [HttpGet("{id}")]
-    [Authorize(Roles = EformRole.Admin)]
     public async Task<OperationDataResult<PayRuleSetModel>> Read(int id)
     {
         return await _payRuleSetService.Read(id);

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -2627,10 +2627,10 @@ public class TimePlanningWorkingHoursService(
             if (assignedSite.PayRuleSetId.HasValue)
             {
                 payRuleSet = await dbContext.PayRuleSets
-                    .Include(p => p.DayRules)
-                    .ThenInclude(d => d.Tiers)
-                    .Include(p => p.DayTypeRules)
-                    .ThenInclude(d => d.TimeBandRules)
+                    .Include(p => p.DayRules.Where(d => d.WorkflowState != Constants.WorkflowStates.Removed))
+                    .ThenInclude(d => d.Tiers.Where(t => t.WorkflowState != Constants.WorkflowStates.Removed))
+                    .Include(p => p.DayTypeRules.Where(d => d.WorkflowState != Constants.WorkflowStates.Removed))
+                    .ThenInclude(d => d.TimeBandRules.Where(b => b.WorkflowState != Constants.WorkflowStates.Removed))
                     .FirstOrDefaultAsync(p => p.Id == assignedSite.PayRuleSetId.Value);
             }
 
@@ -2648,9 +2648,12 @@ public class TimePlanningWorkingHoursService(
             // remove the first entry from the content.Model
             var timePlannings = content.Model.Skip(1).ToList();
 
-            // Pre-compute pay lines for each day and collect unique pay codes
+            // Pre-compute pay lines for each day and collect unique pay codes.
+            // Seed from the codes DECLARED by the site's pay-rule-set so the columns exist
+            // even when the selected period contains no registered time at all
+            // (GetDeclaredPayCodes returns an empty list when payRuleSet is null).
             var payLinesByDate = new Dictionary<DateTime, List<PlanRegistrationPayLine>>();
-            var allPayCodes = new List<string>();
+            var allPayCodes = GetDeclaredPayCodes(payRuleSet);
 
             if (payRuleSet != null)
             {
@@ -2670,6 +2673,7 @@ public class TimePlanningWorkingHoursService(
 
                     payLinesByDate[planning.Date] = payLines;
 
+                    // Defensive fallback: union in any code produced outside the declaration.
                     foreach (var pl in payLines)
                     {
                         if (!allPayCodes.Contains(pl.PayCode))
@@ -3256,11 +3260,22 @@ public class TimePlanningWorkingHoursService(
                 if (assignedSiteForCache.PayRuleSetId.HasValue)
                 {
                     payRuleSetForCache = await dbContext.PayRuleSets
-                        .Include(p => p.DayRules)
-                        .ThenInclude(d => d.Tiers)
-                        .Include(p => p.DayTypeRules)
-                        .ThenInclude(d => d.TimeBandRules)
+                        .Include(p => p.DayRules.Where(d => d.WorkflowState != Constants.WorkflowStates.Removed))
+                        .ThenInclude(d => d.Tiers.Where(t => t.WorkflowState != Constants.WorkflowStates.Removed))
+                        .Include(p => p.DayTypeRules.Where(d => d.WorkflowState != Constants.WorkflowStates.Removed))
+                        .ThenInclude(d => d.TimeBandRules.Where(b => b.WorkflowState != Constants.WorkflowStates.Removed))
                         .FirstOrDefaultAsync(p => p.Id == assignedSiteForCache.PayRuleSetId.Value);
+                }
+
+                // Union this site's DECLARED codes into the global list so the Total sheet
+                // carries every declared column even for a period with no registered time.
+                // (GetDeclaredPayCodes returns an empty list when the site has no rule-set.)
+                foreach (var declaredPayCode in GetDeclaredPayCodes(payRuleSetForCache))
+                {
+                    if (!allPayCodes.Contains(declaredPayCode))
+                    {
+                        allPayCodes.Add(declaredPayCode);
+                    }
                 }
 
                 var dataResult = await Index(new TimePlanningWorkingHoursRequestModel
@@ -3762,7 +3777,7 @@ public class TimePlanningWorkingHoursService(
                     // Append per-pay-code total for this worker (matches the dynamic columns added to the headers)
                     foreach (var payCode in allPayCodes)
                     {
-                        totalRow.Append(CreateNumericCell(siteTotalsByPayCode[payCode]));
+                        totalRow.Append(CreateNumericCell(siteTotalsByPayCode.GetValueOrDefault(payCode, 0)));
                     }
 
                     // Add netto hours sum for each seed message

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Services/TimePlanningWorkingHoursService/TimePlanningWorkingHoursService.cs
@@ -2638,7 +2638,10 @@ public class TimePlanningWorkingHoursService(
             var culture = new CultureInfo(language.LanguageCode);
             Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "results"));
 
-            var timeStamp = $"{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+            // The suffix must be unique: the timestamp only has second precision, so two
+            // exports started within the same second would target the same file — and the
+            // first one's returned stream still holds it open, failing the second.
+            var timeStamp = $"{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid():N}";
             var filePath = Path.Combine(Path.GetTempPath(), "results", $"{timeStamp}_.xlsx");
 
             // Fetch data early so we can pre-compute pay lines for header discovery
@@ -3231,7 +3234,9 @@ public class TimePlanningWorkingHoursService(
             // one lookup per export, shared by all sheet writers below.
             var tagNamesBySiteUid = await GetSiteTagNames(sdkContext, siteIds);
             Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "results"));
-            var timeStamp = $"{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+            // Unique suffix for the same reason as the single-worker export above: a
+            // second-precision timestamp alone collides when two exports start together.
+            var timeStamp = $"{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid():N}";
             var resultDocument = Path.Combine(Path.GetTempPath(), "results", $"{timeStamp}_.xlsx");
 
             // Set CurrentUICulture so Translations.X resolves in the user's language for all

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.html
@@ -7,9 +7,9 @@
     <mat-tab label="{{'General' | translate }}" >
 
       <!-- ========= Payroll rules (hidden when no pay rule sets exist) ========= -->
-      <h3 class="section-header" *ngIf="!data.resigned && availablePayRuleSets.length > 0 && selectCurrentUserIsAdmin$ | async">{{ 'Payroll rules' | translate }}</h3>
+      <h3 class="section-header" *ngIf="!data.resigned && availablePayRuleSets.length > 0">{{ 'Payroll rules' | translate }}</h3>
 
-      <div class="d-flex flex-row align-items-center pay-rule-set-row" *ngIf="!data.resigned && availablePayRuleSets.length > 0 && selectCurrentUserIsAdmin$ | async">
+      <div class="d-flex flex-row align-items-center pay-rule-set-row" *ngIf="!data.resigned && availablePayRuleSets.length > 0">
         <mat-form-field class="p-1 flex-grow-1">
           <mat-label>{{ 'Pay Rule Set' | translate }}</mat-label>
           <mtx-select

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.spec.ts
@@ -102,14 +102,19 @@ describe('AssignedSiteDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Pay rule sets admin gating', () => {
+  describe('Pay rule sets availability', () => {
     it('should fetch pay rule sets for an admin', () => {
       component.ngOnInit();
 
       expect(mockPayRuleSetsService.getPayRuleSets).toHaveBeenCalledWith({ offset: 0, pageSize: 1000 });
     });
 
-    it('should NOT fetch pay rule sets for a non-admin (admin-only endpoint 403s and forces logout)', () => {
+    it('should ALSO fetch pay rule sets for a non-admin (listing is no longer admin-only)', () => {
+      // GET api/time-planning-pn/pay-rule-sets used to be [Authorize(Roles =
+      // Admin)], so a non-admin's 403 was escalated into a forced logout and
+      // the fetch had to be skipped. Listing and reading a rule set are now
+      // open to any authenticated user so non-admins can pick one for an
+      // assigned site; only creating/editing/deleting stays admin-only.
       mockStore.select.mockReturnValue(of(false));
       // Re-create so the selectCurrentUserIsAdmin$ class field picks up the
       // non-admin stream (it is captured at construction time).
@@ -118,7 +123,7 @@ describe('AssignedSiteDialogComponent', () => {
 
       component.ngOnInit();
 
-      expect(mockPayRuleSetsService.getPayRuleSets).not.toHaveBeenCalled();
+      expect(mockPayRuleSetsService.getPayRuleSets).toHaveBeenCalledWith({ offset: 0, pageSize: 1000 });
     });
 
     it('should still initialize payRuleSetId from dialog data for a non-admin', () => {

--- a/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/components/plannings/time-planning-actions/assigned-site/assigned-site-dialog.component.ts
@@ -9,7 +9,6 @@ import {AssignedSiteModel, CommonTagModel, GlobalAutoBreakSettingsModel, PayRule
 import {PayRuleSetsViewModalComponent} from '../../../../modules/pay-rule-sets/components/pay-rule-sets-view-modal/pay-rule-sets-view-modal.component';
 import {selectCurrentUserIsAdmin, selectCurrentUserIsFirstUser} from 'src/app/state';
 import {Store} from '@ngrx/store';
-import {filter, first, switchMap} from 'rxjs/operators';
 import {TimePlanningPnSettingsService, TimePlanningPnPayRuleSetsService} from 'src/app/plugins/modules/time-planning-pn/services';
 import {
   AbstractControl,
@@ -674,19 +673,9 @@ export class AssignedSiteDialogComponent implements DoCheck, OnInit {
   }
 
   loadPayRuleSets(): void {
-    // GET api/time-planning-pn/pay-rule-sets is admin-only
-    // ([Authorize(Roles = Admin)] on PayRuleSetController.Index). Calling it as
-    // a non-admin returns 403, which the global HttpErrorInterceptor escalates
-    // into a forced logout (refresh token → retry → still 403 → logout) — the
-    // local error callback below never runs. The template already hides the
-    // whole payroll-rules block behind selectCurrentUserIsAdmin$, so for
-    // non-admins we skip the fetch entirely; an admin-assigned payRuleSetId is
-    // still preserved on save because the hidden form control keeps its value.
-    this.selectCurrentUserIsAdmin$.pipe(
-      first(),
-      filter((isAdmin) => isAdmin),
-      switchMap(() => this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}))
-    ).subscribe({
+    // GET api/time-planning-pn/pay-rule-sets is readable by any authenticated
+    // user, so non-admins can pick a pay rule set for an assigned site too.
+    this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}).subscribe({
       next: (result) => {
         if (result && result.success) {
           this.availablePayRuleSets = result.model?.payRuleSets || [];

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/pay-rule-sets/components/pay-rule-sets-table/pay-rule-sets-table.component.html
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/pay-rule-sets/components/pay-rule-sets-table/pay-rule-sets-table.component.html
@@ -1,4 +1,4 @@
-<div class="table-actions">
+<div class="table-actions" *ngIf="selectCurrentUserIsAdmin$ | async">
   <button
     id="openCreatePayRuleSetBtn"
     class="btn-primary btn-primary--icon-left"
@@ -39,6 +39,7 @@
       <button
         mat-menu-item
         id="editPayRuleSetBtn-{{i}}"
+        *ngIf="selectCurrentUserIsAdmin$ | async"
         [disabled]="isLockedPreset(row)"
         [matTooltip]="isLockedPreset(row) ? ('Cannot edit locked preset' | translate) : ''"
         (click)="openEditModal(row)"
@@ -50,6 +51,7 @@
         mat-menu-item
         id="deletePayRuleSetBtn-{{i}}"
         class="btn-delete-menu"
+        *ngIf="selectCurrentUserIsAdmin$ | async"
         [disabled]="isLockedPreset(row)"
         [matTooltip]="isLockedPreset(row) ? ('Cannot delete locked preset' | translate) : ''"
         (click)="openDeleteModal(row)"

--- a/eform-client/src/app/plugins/modules/time-planning-pn/modules/pay-rule-sets/components/pay-rule-sets-table/pay-rule-sets-table.component.ts
+++ b/eform-client/src/app/plugins/modules/time-planning-pn/modules/pay-rule-sets/components/pay-rule-sets-table/pay-rule-sets-table.component.ts
@@ -2,6 +2,8 @@ import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular
 import { MatDialog } from '@angular/material/dialog';
 import { MtxGridColumn } from '@ng-matero/extensions/grid';
 import { TranslateService } from '@ngx-translate/core';
+import { Store } from '@ngrx/store';
+import { selectCurrentUserIsAdmin } from 'src/app/state';
 import { PayRuleSetSimpleModel } from '../../../../models';
 import { isLockedPresetName } from '../../pay-rule-lock.util';
 
@@ -14,6 +16,13 @@ import { isLockedPresetName } from '../../pay-rule-lock.util';
 export class PayRuleSetsTableComponent implements OnInit {
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private store = inject(Store);
+
+  // The list endpoint is open to any authenticated user, but create/update/delete
+  // are still admin-only on the server and a 403 is escalated into a forced
+  // logout by the global HttpErrorInterceptor. Hide the mutating actions rather
+  // than let a non-admin trigger them.
+  public selectCurrentUserIsAdmin$ = this.store.select(selectCurrentUserIsAdmin);
 
   @Input() payRuleSets: PayRuleSetSimpleModel[] = [];
   @Input() loading = false;


### PR DESCRIPTION
Two independent changes, both requested by @rene.

## 1. Non-admins can select a pay rule set

Setting a pay rule set on an assigned site required the Admin role. `GET api/time-planning-pn/pay-rule-sets` was `[Authorize(Roles = Admin)]`, and its 403 is escalated by the global `HttpErrorInterceptor` into a **forced logout**, which is why the UI hid the selector rather than letting it 403.

- **Backend**: `Index` and `Read` drop the role requirement (class-level `[Authorize]` retained — anonymous still blocked). `Create`/`Update`/`Delete` **stay admin-only**.
- **Frontend**: selector ungated in the assigned-site dialog; the Pay Rule Sets page now hides create/edit/delete for non-admins, since opening `Index` makes that page reachable for them and its mutations would otherwise 403 → logout.

Worth knowing: the **write** path was never gated — the assigned-site PUT already wrote `PayRuleSetId` for anyone with `time_planning_working_hours_get`. This closes a read/write asymmetry rather than widening what can be changed.

⚠️ `Read` returns the full tier/time-band structure of the agreement (no monetary rates) to any authenticated user. Accepted deliberately; say the word if you'd rather keep `Read` admin-only and hide the eye button.

## 2. Pay-code columns survive an empty period

Both exports built their column list from pay lines *observed* in the period, so no registered time meant no pay-code columns. They now seed from the codes **declared** by the site's rule set (the all-workers per-site sheets already did this), with observed codes unioned in as a fallback.

⚠️ **Column order changes for existing non-empty exports** — declared structural order instead of first-observed. Any payroll import reading by column *position* rather than header name needs checking.

## Bonus fix found in review

Pay rules are **soft**-deleted, but neither the export eager-loads nor `PayLineGenerator` filtered `WorkflowState`. A tier an admin had already deleted still produced columns **and still took part in pay calculation**. Both loads now filter removed rows.

## Tests

Reflection tests pinning the authorization split (shard d), three empty-period export tests (shard g), and an updated Jest spec that previously asserted the old non-admin behaviour.

## Verified locally

Full-solution build clean. Against the running backend with a real non-admin user: **200** on list and read, **403** still on create and delete. An export for a period with zero registrations now carries all ten declared pay codes (`NORMAL`, `OVERTIME_30`, `OVERTIME_80`, `SAT_NORMAL`, `SAT_ANIMAL_AFTERNOON`, `ANIMAL_SUN_HOLIDAY`, `GRUNDLOVSDAG`, `ANIMAL_NIGHT`, `SHIFTED_MORNING`, `SHIFTED_EVENING`) where it previously carried none.

## Merge order

**This PR must merge before** the matching backend-configuration PR. BC's CI checks out this repo at `ref: stable` and builds it into the test container, so the BC change is red — and would regress production to the forced-logout bug — until this is on `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)