### PR TITLE
chore: bump Microting.TimePlanningBase to 10.0.57 (praktikant tier migration)

### DIFF
--- a/docs/superpowers/specs/overenskomst-research-findings.md
+++ b/docs/superpowers/specs/overenskomst-research-findings.md
@@ -510,7 +510,7 @@ preference.
 
 | Family | Presets | Status |
 |---|---|---|
-| **Udenlandske praktikanter** (Stald, Andet) | 2 | ✅ **Corrected 2026-08-07.** Tiers, Saturday, Sunday and the § 29 Grundlovsdag noon split all match. Open: per-day vs per-hour supplement unit; pay codes shared with adult Dyrehold whose amounts differ |
+| **Udenlandske praktikanter** (Stald, Andet) | 2 | ✅ **Corrected 2026-08-07.** Tiers, Saturday, Sunday and the § 29 Grundlovsdag noon split all match. **Data migration shipped 2026-08-07** (eform-timeplanning-base `CorrectPraktikantSection50Tiers`, v10.0.57): existing customer rule sets under either validity-period name are rewritten to the corrected tiers idempotently, so pre-correction rows now take the split path and earn overtime like freshly created ones. Open: per-day vs per-hour supplement unit; pay codes shared with adult Dyrehold whose amounts differ |
 | Jordbrug Standard / Dyrehold | 2 | ❌ fabricated Saturday supplement; Dyrehold band errors; flat Grundlovsdag |
 | Jordbrug Elev u18 / o18 / u18 Dyrehold | 3 | ❌ wrong first tier (o18), missing top tier (u18), fabricated u18/o18 split |
 | Gartneri Standard / Elev ×2 | 3 | ❌ Sunday not tiered; Saturday code; 1. maj missing; Elev tiers |
@@ -585,10 +585,13 @@ The 8 h/day cap has no basis in any text.
 - **Weekday bands shadow the tiers** on the 8 "Standard" presets, so several tier
   errors above are currently invisible rather than harmless.
 - **Presets are copy-at-create-time snapshots.** Correcting a preset does **not**
-  change rule sets already created, and no migration exists. Any future correction
-  needs a migration story *before* it ships — see the 2026-08-07 regression where a
-  name-gated engine change met stale rows and moved up to 6 h/Saturday onto an
-  afternoon supplement (fixed by additionally requiring the corrected tier shape).
+  change rule sets already created. Any future correction needs a migration story
+  *before* it ships — see the 2026-08-07 regression where a name-gated engine
+  change met stale rows and moved up to 6 h/Saturday onto an afternoon supplement
+  (fixed by additionally requiring the corrected tier shape). The praktikant
+  correction's migration shipped 2026-08-07 (`CorrectPraktikantSection50Tiers`,
+  eform-timeplanning-base v10.0.57); the other 37 presets still have **no**
+  migration, and their 18 recorded defects remain undecided.
 - **Pay lines are never persisted**, so re-exporting an already-paid period reflects
   today's rules, not the rules it was paid under. There is no snapshot to reconcile.
 

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PayRuleSetLock.cs
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/Infrastructure/Helpers/PayRuleSetLock.cs
@@ -221,7 +221,10 @@ internal static class PayRuleSetLock
     ///
     /// This is a guard, not the cure. The durable fix is a DATA MIGRATION that rewrites
     /// the stale praktikant day rules to the corrected tiers; once every customer row has
-    /// been migrated this predicate becomes a no-op and can be retired.
+    /// been migrated this predicate becomes a no-op and can be retired. That migration
+    /// shipped 2026-08-07 as CorrectPraktikantSection50Tiers in eform-timeplanning-base
+    /// v10.0.57 — it runs when a customer backend upgrades past that version, so the
+    /// guard stays until no pre-migration database remains.
     /// </summary>
     internal static bool HasNormalTimeBoundaryShape(IReadOnlyList<PayTierRule>? orderedTiers)
     {

--- a/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
+++ b/eFormAPI/Plugins/TimePlanning.Pn/TimePlanning.Pn/TimePlanning.Pn.csproj
@@ -33,7 +33,7 @@
       <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.36" />
       <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.31" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.56" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="10.0.57" />
       <PackageReference Include="Sentry" Version="6.8.0" />
       <PackageReference Include="FirebaseAdmin" Version="3.6.0" />
       <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />


### PR DESCRIPTION
## Summary

Bumps Microting.TimePlanningBase 10.0.56 → 10.0.57, which ships **CorrectPraktikantSection50Tiers** (microting/eform-timeplanning-base#899): the data migration that rewrites pre-2026-08-07 **Udenlandske praktikanter Landbrug** (Staldarbejde / Andet arbejde) rule-set snapshots to the corrected § 50 tiers.

Existing customers created their rule sets from the pre-correction catalogue, and since presets are copy-at-create-time snapshots, the 2026-08-07 correction (#1676) never reached them — the shape gate from #1678 kept them safely on the historical path, still earning zero overtime minutes on long Saturdays, Sundays and holidays. After this upgrade the migration runs on the customer backend, the migrated rows match `HasNormalTimeBoundaryShape`, and the normal-time/overtime split applies to them exactly as it does to freshly created rule sets — no plugin code change needed.

Also records the shipped migration in the overenskomst implementation-status audit and in the shape-gate's comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)